### PR TITLE
feat: Phase 2 pipeline refactor (14d window + 3-stage sampling)

### DIFF
--- a/daily_news.py
+++ b/daily_news.py
@@ -8,7 +8,7 @@ import os
 import base64
 import sys
 from email.mime.text import MIMEText
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import yaml
 from googleapiclient.discovery import build
@@ -23,6 +23,8 @@ from db import is_already_sent, save_article
 # CONFIG
 # ============================================================
 VIDEOS_PER_CHANNEL = 3
+FETCH_CANDIDATES_PER_CHANNEL = 30  # 重複分の穴埋め用にプールを広げる
+MAX_LOOKBACK_DAYS = 14  # 2週間より古い動画は配信対象外
 CLAUDE_MODEL = "claude-sonnet-4-6"
 TRANSCRIPT_CHAR_LIMIT = 15000  # コスト制御
 
@@ -44,6 +46,12 @@ def _check_env() -> None:
     if missing:
         print(f"❌ Missing env vars: {', '.join(missing)}")
         sys.exit(1)
+
+
+def _is_within_lookback(published_at_iso: str) -> bool:
+    ts = datetime.fromisoformat(published_at_iso.replace("Z", "+00:00"))
+    cutoff = datetime.now(timezone.utc) - timedelta(days=MAX_LOOKBACK_DAYS)
+    return ts >= cutoff
 
 
 def _load_channels(path: str = "channels.yaml") -> list[tuple[str, str]]:
@@ -205,10 +213,15 @@ def main():
     sections = []
     for channel_name, channel_id in channels:
         print(f"\n📺 {channel_name}")
-        videos = fetch_recent_videos(youtube, channel_id, VIDEOS_PER_CHANNEL)
+        candidates = fetch_recent_videos(
+            youtube, channel_id, FETCH_CANDIDATES_PER_CHANNEL
+        )
+        candidates = [v for v in candidates if _is_within_lookback(v["published_at"])]
 
         processed = []
-        for v in videos:
+        for v in candidates:
+            if len(processed) >= VIDEOS_PER_CHANNEL:
+                break
             print(f"  • {v['title'][:70]}")
 
             if is_already_sent(v["video_id"]):

--- a/daily_news.py
+++ b/daily_news.py
@@ -6,6 +6,7 @@ Fetches recent YouTube videos → summarizes with Claude → sends Gmail.
 import html as html_lib
 import os
 import base64
+import random
 import sys
 from email.mime.text import MIMEText
 from datetime import datetime, timedelta, timezone
@@ -22,9 +23,9 @@ from db import is_already_sent, save_article
 # ============================================================
 # CONFIG
 # ============================================================
-VIDEOS_PER_CHANNEL = 3
-FETCH_CANDIDATES_PER_CHANNEL = 30  # 重複分の穴埋め用にプールを広げる
+METADATA_PER_CHANNEL = 15  # Stage A で取得するメタデータ件数
 MAX_LOOKBACK_DAYS = 14  # 2週間より古い動画は配信対象外
+MAX_VIDEOS_PER_RUN = 10  # ランダム抽出後、実際に要約・送信する最大本数
 CLAUDE_MODEL = "claude-sonnet-4-6"
 TRANSCRIPT_CHAR_LIMIT = 15000  # コスト制御
 
@@ -210,61 +211,71 @@ def main():
         )
     )
 
-    sections = []
+    # Stage A: 全チャンネルからメタデータのみ取得（transcript/要約なし）
+    print("🔎 Gathering candidates (metadata only)...")
+    candidates = []
     for channel_name, channel_id in channels:
-        print(f"\n📺 {channel_name}")
-        candidates = fetch_recent_videos(
-            youtube, channel_id, FETCH_CANDIDATES_PER_CHANNEL
+        videos = fetch_recent_videos(youtube, channel_id, METADATA_PER_CHANNEL)
+        fresh = [v for v in videos if _is_within_lookback(v["published_at"])]
+        unsent = [v for v in fresh if not is_already_sent(v["video_id"])]
+        for v in unsent:
+            candidates.append({**v, "channel_name": channel_name})
+        print(
+            f"  📺 {channel_name}: {len(videos)} fetched, "
+            f"{len(fresh)} within {MAX_LOOKBACK_DAYS}d, {len(unsent)} unsent"
         )
-        candidates = [v for v in candidates if _is_within_lookback(v["published_at"])]
 
-        processed = []
-        for v in candidates:
-            if len(processed) >= VIDEOS_PER_CHANNEL:
-                break
-            print(f"  • {v['title'][:70]}")
+    print(f"\n📊 Total unsent candidates: {len(candidates)}")
 
-            if is_already_sent(v["video_id"]):
-                print(f"    ⏭️  skip (already sent)")
-                continue
+    # Stage B: ランダム抽出（最大 MAX_VIDEOS_PER_RUN 本）
+    sample = random.sample(candidates, min(MAX_VIDEOS_PER_RUN, len(candidates)))
+    print(f"🎲 Sampled {len(sample)} videos for this run")
 
-            transcript = get_transcript(ytt_api, v["video_id"])
+    if not sample:
+        print("\n⚠️  No content to send today.")
+        return
 
-            if transcript:
-                content, is_description = transcript, False
-            elif v.get("description", "").strip():
-                print(f"    → transcript blocked, falling back to description")
-                content, is_description = v["description"], True
-            else:
-                print(f"    → no transcript or description, skipping")
-                continue
+    # Stage C: サンプル分だけ transcript + Claude 要約 + Neon 保存
+    processed_by_channel: dict[str, list[dict]] = {}
+    for v in sample:
+        print(f"\n  • [{v['channel_name']}] {v['title'][:70]}")
+        transcript = get_transcript(ytt_api, v["video_id"])
 
-            summary = summarize(
-                claude, v["title"], content, is_description=is_description
-            )
-            url = f"https://www.youtube.com/watch?v={v['video_id']}"
-            processed.append(
-                {
-                    "title": v["title"],
-                    "summary": summary,
-                    "url": url,
-                }
-            )
+        if transcript:
+            content, is_description = transcript, False
+        elif v.get("description", "").strip():
+            print(f"    → transcript blocked, falling back to description")
+            content, is_description = v["description"], True
+        else:
+            print(f"    → no transcript or description, skipping")
+            continue
 
-            # 送信失敗時に再送できるよう、保存は送信前に行う
-            save_article(
-                {
-                    "source_type": "youtube",
-                    "source_name": channel_name,
-                    "content_id": v["video_id"],
-                    "title": v["title"],
-                    "url": url,
-                    "summary": summary,
-                }
-            )
+        summary = summarize(
+            claude, v["title"], content, is_description=is_description
+        )
+        url = f"https://www.youtube.com/watch?v={v['video_id']}"
+        processed_by_channel.setdefault(v["channel_name"], []).append(
+            {"title": v["title"], "summary": summary, "url": url}
+        )
 
-        if processed:
-            sections.append({"channel": channel_name, "videos": processed})
+        # 送信失敗時に再送できるよう、保存は送信前に行う
+        save_article(
+            {
+                "source_type": "youtube",
+                "source_name": v["channel_name"],
+                "content_id": v["video_id"],
+                "title": v["title"],
+                "url": url,
+                "summary": summary,
+            }
+        )
+
+    # channels.yaml の順序で section を組み立てる
+    sections = [
+        {"channel": name, "videos": processed_by_channel[name]}
+        for name, _ in channels
+        if name in processed_by_channel
+    ]
 
     if not sections:
         print("\n⚠️  No content to send today.")


### PR DESCRIPTION
## 背景
PR #14 は Neon dedup の最初のコミットだけが merge された。重複排除を実用段階にするための以下 2 コミットが main に入っていないため、この PR で入れ直す。

## 変更点
### 1. `bb08b28` 14日ルックバック窓
- `VIDEOS_PER_CHANNEL=3` のままだと「最新 3 本が全部既送信なら空メール」になる問題を解消
- 候補プールを拡張し、過去 14 日以内の動画から未送信を選ぶ

### 2. `b6dd521` 3-stage パイプライン(Issue #8 コメント仕様)
- **Stage A**: 全 ch から 15 件メタデータ取得(transcript/要約なし)
- **Filter**: `published_at >= 14d` AND `articles` に未登録
- **Stage B**: `random.sample` で最大 10 本抽出
- **Stage C**: 抽出した 10 本だけ transcript + Claude 要約 + Neon 保存

### 定数変更
- ❌ `VIDEOS_PER_CHANNEL` (3)
- ❌ `FETCH_CANDIDATES_PER_CHANNEL` (30)
- ✅ `METADATA_PER_CHANNEL` (15)
- ✅ `MAX_VIDEOS_PER_RUN` (10)

## ランタイム試算(20 ch)
- Stage A: 20 ch × ~1s = 20s
- Stage C: 10 本 × 15-45s = 2.5-7.5 分
- 合計 **約 3-8 分** → workflow timeout 10 分に収まる

## Test plan
- [x] 3 チャンネル(refactor 当時)で end-to-end 成功、メール送信確認
- [ ] 20 チャンネル(merge 後)で Actions 手動実行して通ることを確認
- [ ] 翌日以降、重複なしで配信されることを確認

## 補足
並行処理は YAGNI で Phase 2.1+ に保留(Issue #8 コメント参照)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)