### PR TITLE
feat: RSS source support via unified fetchers (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 # Personal AI Newspaper
 
-毎朝 YouTube の技術チャンネルから最新動画を取得し、Claude が日本語で要約して Gmail に配信するパーソナルニュースレター。
+毎朝 YouTube の技術チャンネルと RSS フィードから最新コンテンツを取得し、Claude が日本語で要約して Gmail に配信するパーソナルニュースレター。
 
 ## フロー
 
 ```
 GitHub Actions（毎朝 UTC 13:00 = Vancouver 6:00 AM PDT）
   └─ daily_news.py
-       ├─ YouTube Data API v3（playlistItems.list）
-       │    └─ 対象3チャンネル × 最新3本 = 最大9動画
-       ├─ youtube-transcript-api（字幕取得・無料）
-       ├─ Claude Sonnet 4.6（日本語3行要約）
-       └─ Gmail API（OAuth2）→ 受信トレイへ配信
+       ├─ sources.yaml で定義した全ソースから並列にメタデータを取得
+       │    ├─ YouTube: YouTube Data API v3 → playlistItems.list（2 units/channel）
+       │    └─ RSS: feedparser
+       ├─ 候補をシャッフル → 先頭 MAX_ATTEMPTS 本を試行プール化
+       ├─ 本文取得
+       │    ├─ YouTube: youtube-transcript-api（WebShare proxy 経由）
+       │    └─ RSS: trafilatura（本文抽出 + robots.txt 尊重）
+       ├─ Claude Sonnet 4.6（日本語3行要約、要約不能時は空文字返却）
+       └─ Gmail API（OAuth2）→ 受信トレイへ配信（目標 5 本）
 ```
 
-## 対象チャンネル
+## ソース設定
 
-| チャンネル | ID |
-|---|---|
-| Theo - t3.gg | UCbRP3c757lWg9M-U7TyEkXA |
-| AI Explained | UCNJ1Ymd5yFuUPtn21xtRbbw |
-| Fireship | UCsBjURrPoezykLs9EqgamOA |
+`sources.yaml` でソースを追加・削除できます。`type: youtube` と `type: rss` の 2 種類をサポート。
 
 ## セットアップ
 

--- a/daily_news.py
+++ b/daily_news.py
@@ -1,6 +1,6 @@
 """
-Personal AI Newspaper — Phase 1 Minimum Viable Version
-Fetches recent YouTube videos → summarizes with Claude → sends Gmail.
+Personal AI Newspaper — Phase 2 multi-source edition.
+Fetches YouTube uploads + RSS articles → summarizes with Claude → sends Gmail.
 """
 
 import html as html_lib
@@ -19,18 +19,20 @@ from youtube_transcript_api.proxies import WebshareProxyConfig
 from anthropic import Anthropic
 
 from db import is_already_sent, save_article
+from fetchers import rss as rss_fetcher
+from fetchers import youtube as youtube_fetcher
 
 # ============================================================
 # CONFIG
 # ============================================================
-METADATA_PER_CHANNEL = 15  # Stage A で取得するメタデータ件数
-MAX_LOOKBACK_DAYS = 14  # 2週間より古い動画は配信対象外
+METADATA_PER_SOURCE = 15  # Stage A で各ソースから取得するメタデータ件数
+MAX_LOOKBACK_DAYS = 14  # 2週間より古いアイテムは配信対象外
 MAX_VIDEOS_PER_RUN = 5  # 1回の配信で要約・送信する最大本数（目標値）
 MAX_ATTEMPTS = 30  # 1回の実行で試行する最大候補数（無限試行防止）
-MIN_TRANSCRIPT_CHARS = 500  # これ未満は transcript 失敗扱い
+MIN_CONTENT_CHARS = 500  # transcript/記事本文がこれ未満なら失敗扱い
 MIN_SUMMARY_CHARS = 10  # Claude が防御プロンプトに従って空を返したケースを弾く閾値
 CLAUDE_MODEL = "claude-sonnet-4-6"
-TRANSCRIPT_CHAR_LIMIT = 15000  # コスト制御
+CONTENT_CHAR_LIMIT = 15000  # Claude に渡す本文の上限（コスト制御）
 
 REQUIRED_ENV_VARS = [
     "WEBSHARE_USERNAME",
@@ -58,78 +60,49 @@ def _is_within_lookback(published_at_iso: str) -> bool:
     return ts >= cutoff
 
 
-def _load_channels(path: str = "channels.yaml") -> list[tuple[str, str]]:
+def _load_sources(path: str = "sources.yaml") -> list[dict]:
     with open(path) as f:
         config = yaml.safe_load(f)
-    return [
-        (c["name"], c["channel_id"])
-        for c in config["channels"]
-        if c.get("enabled", True)
-    ]
+    return [s for s in config["sources"] if s.get("enabled", True)]
 
 
-# ============================================================
-# 1. YouTube fetch (uses 2 units per channel, not 100)
-# ============================================================
-def fetch_recent_videos(youtube, channel_id: str, max_results: int = 3):
-    """Get recent videos via uploads playlist. Costs 2 units/channel."""
-    ch = youtube.channels().list(part="contentDetails", id=channel_id).execute()
-    if not ch.get("items"):
-        print(f"  ⚠️  Channel not found: {channel_id}")
-        return []
-
-    uploads_playlist = ch["items"][0]["contentDetails"]["relatedPlaylists"]["uploads"]
-    pl = (
-        youtube.playlistItems()
-        .list(
-            part="snippet,contentDetails",
-            playlistId=uploads_playlist,
-            maxResults=max_results,
+def _fetch_items(
+    source: dict, youtube_client, max_results: int
+) -> list[dict]:
+    stype = source["type"]
+    if stype == "youtube":
+        return youtube_fetcher.fetch_recent_items(
+            youtube_client, source, max_results
         )
-        .execute()
-    )
-
-    videos = []
-    for item in pl.get("items", []):
-        videos.append(
-            {
-                "video_id": item["contentDetails"]["videoId"],
-                "title": item["snippet"]["title"],
-                "published_at": item["contentDetails"]["videoPublishedAt"],
-                "description": item["snippet"].get("description", ""),
-            }
-        )
-    return videos
+    if stype == "rss":
+        return rss_fetcher.fetch_recent_items(source, max_results)
+    print(f"  ⚠️  Unknown source type '{stype}' ({source['name']}), skipping")
+    return []
 
 
-# ============================================================
-# 2. Transcript fetch (free, via scraping)
-# ============================================================
-def get_transcript(ytt_api: YouTubeTranscriptApi, video_id: str) -> str | None:
-    """Returns None if transcript unavailable."""
-    try:
-        fetched = ytt_api.fetch(video_id, languages=["en", "ja"])
-        # fetched は FetchedTranscript オブジェクト。snippets 属性に各行
-        return " ".join(snippet.text for snippet in fetched.snippets)
-    except Exception as e:
-        print(f"    [skip] transcript unavailable: {type(e).__name__}: {e}")
-        return None
+def _fetch_content(item: dict, ytt_api: YouTubeTranscriptApi) -> str | None:
+    stype = item["source_type"]
+    if stype == "youtube":
+        return youtube_fetcher.get_content_text(ytt_api, item)
+    if stype == "rss":
+        return rss_fetcher.get_content_text(item)
+    return None
 
 
 # ============================================================
-# 3. Claude summarize
+# Claude summarize
 # ============================================================
-def summarize(client: Anthropic, title: str, transcript: str) -> str:
-    prompt = f"""以下のYouTube動画を日本語で3行に要約してください。
+def summarize(client: Anthropic, title: str, content: str) -> str:
+    prompt = f"""以下の記事/動画を日本語で3行に要約してください。
 技術的な要点、実装のヒント、開発者にとっての示唆を優先してください。
 各行は1文で、「・」で始めてください。
 
-重要: 字幕が断片的・不十分・要約困難な場合でも、謝罪文・「情報が不足」等の注釈・推測による補完は絶対に禁止。その場合は何も出力せず空文字列のみ返してください。
+重要: 本文が断片的・不十分・要約困難な場合でも、謝罪文・「情報が不足」等の注釈・推測による補完は絶対に禁止。その場合は何も出力せず空文字列のみ返してください。
 
 タイトル: {title}
 
-字幕:
-{transcript[:TRANSCRIPT_CHAR_LIMIT]}
+本文:
+{content[:CONTENT_CHAR_LIMIT]}
 
 出力形式:
 ・(1行目)
@@ -145,7 +118,7 @@ def summarize(client: Anthropic, title: str, transcript: str) -> str:
 
 
 # ============================================================
-# 4. Build HTML email
+# Build HTML email
 # ============================================================
 def build_email_html(sections: list[dict]) -> str:
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
@@ -154,12 +127,12 @@ def build_email_html(sections: list[dict]) -> str:
 <p style="color:#888;margin:0 0 24px 0;">{today}</p>
 """
     for section in sections:
-        channel = html_lib.escape(section["channel"])
-        html += f'<h2 style="border-bottom:2px solid #333;padding-bottom:4px;margin-top:32px;">{channel}</h2>'
-        for v in section["videos"]:
-            title = html_lib.escape(v["title"])
-            url = html_lib.escape(v["url"])
-            summary_html = html_lib.escape(v["summary"]).replace("\n", "<br>")
+        source_name = html_lib.escape(section["source_name"])
+        html += f'<h2 style="border-bottom:2px solid #333;padding-bottom:4px;margin-top:32px;">{source_name}</h2>'
+        for item in section["items"]:
+            title = html_lib.escape(item["title"])
+            url = html_lib.escape(item["url"])
+            summary_html = html_lib.escape(item["summary"]).replace("\n", "<br>")
             html += f"""
 <div style="margin:16px 0;padding:12px 16px;background:#f7f7f7;border-radius:8px;">
   <h3 style="margin:0 0 8px 0;font-size:16px;">
@@ -173,7 +146,7 @@ def build_email_html(sections: list[dict]) -> str:
 
 
 # ============================================================
-# 5. Gmail send
+# Gmail send
 # ============================================================
 def send_email(subject: str, html_body: str, to: str):
     creds = Credentials(
@@ -201,29 +174,30 @@ def send_email(subject: str, html_body: str, to: str):
 def main():
     _check_env()
 
-    channels = _load_channels()
+    sources = _load_sources()
     recipient = os.environ["RECIPIENT_EMAIL"]
 
-    youtube = build("youtube", "v3", developerKey=os.environ["YOUTUBE_API_KEY"])
+    youtube_client = build(
+        "youtube", "v3", developerKey=os.environ["YOUTUBE_API_KEY"]
+    )
     claude = Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
     ytt_api = YouTubeTranscriptApi(
         proxy_config=WebshareProxyConfig(
-            proxy_username=os.environ["WEBSHARE_USERNAME"],  # WebShare のユーザー名
-            proxy_password=os.environ["WEBSHARE_PASSWORD"],  # WebShare のパスワード
+            proxy_username=os.environ["WEBSHARE_USERNAME"],
+            proxy_password=os.environ["WEBSHARE_PASSWORD"],
         )
     )
 
-    # Stage A: 全チャンネルからメタデータのみ取得（transcript/要約なし）
+    # Stage A: 全ソースからメタデータのみ取得（本文/要約なし）
     print("🔎 Gathering candidates (metadata only)...")
-    candidates = []
-    for channel_name, channel_id in channels:
-        videos = fetch_recent_videos(youtube, channel_id, METADATA_PER_CHANNEL)
-        fresh = [v for v in videos if _is_within_lookback(v["published_at"])]
-        unsent = [v for v in fresh if not is_already_sent(v["video_id"])]
-        for v in unsent:
-            candidates.append({**v, "channel_name": channel_name})
+    candidates: list[dict] = []
+    for source in sources:
+        items = _fetch_items(source, youtube_client, METADATA_PER_SOURCE)
+        fresh = [i for i in items if _is_within_lookback(i["published_at"])]
+        unsent = [i for i in fresh if not is_already_sent(i["content_id"])]
+        candidates.extend(unsent)
         print(
-            f"  📺 {channel_name}: {len(videos)} fetched, "
+            f"  📡 [{source['type']}] {source['name']}: {len(items)} fetched, "
             f"{len(fresh)} within {MAX_LOOKBACK_DAYS}d, {len(unsent)} unsent"
         )
 
@@ -233,7 +207,7 @@ def main():
     random.shuffle(candidates)
     attempt_pool = candidates[:MAX_ATTEMPTS]
     print(
-        f"🎲 Attempt pool: {len(attempt_pool)} videos "
+        f"🎲 Attempt pool: {len(attempt_pool)} items "
         f"(target: {MAX_VIDEOS_PER_RUN} summaries, cap: {MAX_ATTEMPTS} attempts)"
     )
 
@@ -242,44 +216,49 @@ def main():
         return
 
     # Stage C: 試行プールを順に処理。MAX_VIDEOS_PER_RUN 本揃ったら break
-    processed_by_channel: dict[str, list[dict]] = {}
+    processed_by_source: dict[str, list[dict]] = {}
     summarized_count = 0
     skipped_count = 0
 
-    for idx, v in enumerate(attempt_pool, 1):
-        print(f"\n[{idx}/{len(attempt_pool)}] [{v['channel_name']}] {v['title'][:70]}")
+    for idx, item in enumerate(attempt_pool, 1):
+        print(
+            f"\n[{idx}/{len(attempt_pool)}] "
+            f"[{item['source_type']}:{item['source_name']}] "
+            f"{item['title'][:70]}"
+        )
 
-        transcript = get_transcript(ytt_api, v["video_id"])
-        if not transcript or len(transcript) < MIN_TRANSCRIPT_CHARS:
-            char_count = len(transcript) if transcript else 0
+        content = _fetch_content(item, ytt_api)
+        if not content or len(content) < MIN_CONTENT_CHARS:
+            char_count = len(content) if content else 0
             print(
-                f"  → skip (transcript unavailable or too short: {char_count} chars)"
+                f"  → skip (content unavailable or too short: {char_count} chars)"
             )
             skipped_count += 1
             continue
 
-        summary = summarize(claude, v["title"], transcript)
+        summary = summarize(claude, item["title"], content)
         if not summary or len(summary) < MIN_SUMMARY_CHARS:
-            print("  → skip (summary empty: Claude defended against insufficient transcript)")
+            print(
+                "  → skip (summary empty: Claude defended against insufficient content)"
+            )
             skipped_count += 1
             continue
 
         summarized_count += 1
         print(f"  ✅ summarized ({summarized_count}/{MAX_VIDEOS_PER_RUN})")
 
-        url = f"https://www.youtube.com/watch?v={v['video_id']}"
-        processed_by_channel.setdefault(v["channel_name"], []).append(
-            {"title": v["title"], "summary": summary, "url": url}
+        processed_by_source.setdefault(item["source_name"], []).append(
+            {"title": item["title"], "summary": summary, "url": item["url"]}
         )
 
         # 送信失敗時に再送できるよう、保存は送信前に行う
         save_article(
             {
-                "source_type": "youtube",
-                "source_name": v["channel_name"],
-                "content_id": v["video_id"],
-                "title": v["title"],
-                "url": url,
+                "source_type": item["source_type"],
+                "source_name": item["source_name"],
+                "content_id": item["content_id"],
+                "title": item["title"],
+                "url": item["url"],
                 "summary": summary,
             }
         )
@@ -291,14 +270,14 @@ def main():
     if summarized_count < MAX_VIDEOS_PER_RUN:
         print(
             f"⚠️  Target was {MAX_VIDEOS_PER_RUN}, got {summarized_count}. "
-            "Likely cause: transcript blocking or low candidate pool."
+            "Likely cause: content blocking or low candidate pool."
         )
 
-    # channels.yaml の順序で section を組み立てる
+    # sources.yaml の順序で section を組み立てる
     sections = [
-        {"channel": name, "videos": processed_by_channel[name]}
-        for name, _ in channels
-        if name in processed_by_channel
+        {"source_name": s["name"], "items": processed_by_source[s["name"]]}
+        for s in sources
+        if s["name"] in processed_by_source
     ]
 
     if not sections:

--- a/fetchers/__init__.py
+++ b/fetchers/__init__.py
@@ -1,0 +1,25 @@
+"""Source-specific fetchers for the Personal AI Newspaper pipeline.
+
+Every fetcher exposes the same two functions:
+
+- ``fetch_recent_items(source, max_results)`` — returns a list of items.
+- ``get_content_text(item, ...)`` — returns the body text used for summarization,
+  or ``None`` if the content is unavailable.
+
+Unified item shape:
+
+    {
+        "source_type":  "youtube" | "rss",
+        "source_name":  str,
+        "category":     str | None,
+        "content_id":   str,   # video_id for YT, canonical URL for RSS
+        "title":        str,
+        "url":          str,
+        "published_at": str,   # ISO 8601 (UTC)
+        "description":  str,
+    }
+"""
+
+from fetchers import rss, youtube
+
+__all__ = ["rss", "youtube"]

--- a/fetchers/rss.py
+++ b/fetchers/rss.py
@@ -1,0 +1,105 @@
+"""RSS fetcher — feedparser for metadata, trafilatura for article body.
+
+Respects robots.txt per-origin (cached for the duration of the run).
+"""
+
+from datetime import datetime, timezone
+from time import mktime, struct_time
+from urllib.parse import urlparse
+from urllib.robotparser import RobotFileParser
+
+import feedparser
+import trafilatura
+
+
+USER_AGENT = (
+    "PersonalDailyNewsBot/1.0 "
+    "(+https://github.com/kazuki-0418/Personal-Daily-News)"
+)
+
+_robots_cache: dict[str, RobotFileParser | None] = {}
+
+
+def _iso_from_struct_time(t: struct_time | None) -> str:
+    if t is None:
+        return datetime.now(timezone.utc).isoformat()
+    return datetime.fromtimestamp(mktime(t), tz=timezone.utc).isoformat()
+
+
+def fetch_recent_items(source: dict, max_results: int) -> list[dict]:
+    """Return the latest entries for an RSS source."""
+    feed = feedparser.parse(source["feed_url"])
+    if feed.bozo and not feed.entries:
+        reason = getattr(feed, "bozo_exception", "unknown")
+        print(f"  ⚠️  Failed to parse feed {source['feed_url']}: {reason}")
+        return []
+
+    items = []
+    for entry in feed.entries[:max_results]:
+        url = entry.get("link", "").strip()
+        if not url:
+            continue
+        items.append(
+            {
+                "source_type": "rss",
+                "source_name": source["name"],
+                "category": source.get("category"),
+                "content_id": url,
+                "title": entry.get("title", ""),
+                "url": url,
+                "published_at": _iso_from_struct_time(
+                    entry.get("published_parsed")
+                    or entry.get("updated_parsed")
+                ),
+                "description": entry.get("summary", ""),
+            }
+        )
+    return items
+
+
+def _robots_allows(url: str) -> bool:
+    """Check robots.txt for ``url``. Fails open on fetch errors."""
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.netloc:
+        return False
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+
+    if origin not in _robots_cache:
+        rp = RobotFileParser()
+        rp.set_url(f"{origin}/robots.txt")
+        try:
+            rp.read()
+            _robots_cache[origin] = rp
+        except Exception:
+            # robots.txt unreachable — fail open so a single broken robots
+            # endpoint doesn't silently drop every article.
+            _robots_cache[origin] = None
+
+    rp = _robots_cache[origin]
+    if rp is None:
+        return True
+    return rp.can_fetch(USER_AGENT, url)
+
+
+def get_content_text(item: dict) -> str | None:
+    """Fetch and extract the article body text. ``None`` if unavailable."""
+    url = item["url"]
+    if not _robots_allows(url):
+        print(f"    [skip] robots.txt disallows: {url}")
+        return None
+
+    downloaded = trafilatura.fetch_url(url)
+    if not downloaded:
+        print(f"    [skip] download failed: {url}")
+        return None
+
+    text = trafilatura.extract(
+        downloaded,
+        include_comments=False,
+        include_tables=False,
+        no_fallback=False,
+    )
+    if not text:
+        print(f"    [skip] extraction yielded no text: {url}")
+        return None
+    return text

--- a/fetchers/youtube.py
+++ b/fetchers/youtube.py
@@ -1,0 +1,58 @@
+"""YouTube fetcher — uploads playlist metadata + transcript via WebShare proxy."""
+
+from youtube_transcript_api import YouTubeTranscriptApi
+
+
+def fetch_recent_items(
+    youtube_client, source: dict, max_results: int
+) -> list[dict]:
+    """Return the latest uploads for a YouTube source. 2 units/channel."""
+    channel_id = source["channel_id"]
+    ch = (
+        youtube_client.channels()
+        .list(part="contentDetails", id=channel_id)
+        .execute()
+    )
+    if not ch.get("items"):
+        print(f"  ⚠️  Channel not found: {channel_id}")
+        return []
+
+    uploads_playlist = ch["items"][0]["contentDetails"]["relatedPlaylists"]["uploads"]
+    pl = (
+        youtube_client.playlistItems()
+        .list(
+            part="snippet,contentDetails",
+            playlistId=uploads_playlist,
+            maxResults=max_results,
+        )
+        .execute()
+    )
+
+    items = []
+    for entry in pl.get("items", []):
+        video_id = entry["contentDetails"]["videoId"]
+        items.append(
+            {
+                "source_type": "youtube",
+                "source_name": source["name"],
+                "category": source.get("category"),
+                "content_id": video_id,
+                "title": entry["snippet"]["title"],
+                "url": f"https://www.youtube.com/watch?v={video_id}",
+                "published_at": entry["contentDetails"]["videoPublishedAt"],
+                "description": entry["snippet"].get("description", ""),
+            }
+        )
+    return items
+
+
+def get_content_text(
+    ytt_api: YouTubeTranscriptApi, item: dict
+) -> str | None:
+    """Return transcript text, or ``None`` if unavailable."""
+    try:
+        fetched = ytt_api.fetch(item["content_id"], languages=["en", "ja"])
+        return " ".join(snippet.text for snippet in fetched.snippets)
+    except Exception as e:
+        print(f"    [skip] transcript unavailable: {type(e).__name__}: {e}")
+        return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ google-auth-oauthlib>=1.1.0
 youtube-transcript-api>=0.6.2
 pyyaml>=6.0
 psycopg[binary]>=3.2
+feedparser>=6.0.10
+trafilatura>=1.12.0

--- a/sources.yaml
+++ b/sources.yaml
@@ -1,5 +1,6 @@
-channels:
+sources:
   - name: NetworkChuck
+    type: youtube
     channel_id: UC9x0AN7BWHpCDHSm9NiJFJQ
     enabled: true
     category: tech
@@ -10,6 +11,7 @@ channels:
     url: https://www.youtube.com/channel/UC9x0AN7BWHpCDHSm9NiJFJQ
 
   - name: Web Dev Simplified
+    type: youtube
     channel_id: UCFbNIlppjAuEX4znoulh0Cw
     enabled: true
     category: tech
@@ -20,6 +22,7 @@ channels:
     url: https://www.youtube.com/channel/UCFbNIlppjAuEX4znoulh0Cw
 
   - name: Y Combinator
+    type: youtube
     channel_id: UCcefcZRL2oaA_uBNeo5UOWg
     enabled: true
     category: startup
@@ -30,6 +33,7 @@ channels:
     url: https://www.youtube.com/channel/UCcefcZRL2oaA_uBNeo5UOWg
 
   - name: This Week in Startups
+    type: youtube
     channel_id: UCkkhmBWfS7pILYIk0izkc3A
     enabled: true
     category: startup
@@ -40,6 +44,7 @@ channels:
     url: https://www.youtube.com/channel/UCkkhmBWfS7pILYIk0izkc3A
 
   - name: Jack Herrington
+    type: youtube
     channel_id: UC6vRUjYqDuoUsYsku86Lrsw
     enabled: true
     category: dev-for-startup
@@ -50,6 +55,7 @@ channels:
     url: https://www.youtube.com/channel/UC6vRUjYqDuoUsYsku86Lrsw
 
   - name: Hussein Nasser
+    type: youtube
     channel_id: UC_ML5xP23TOWKUcc-oAE_Eg
     enabled: true
     category: dev-for-startup
@@ -60,6 +66,7 @@ channels:
     url: https://www.youtube.com/channel/UC_ML5xP23TOWKUcc-oAE_Eg
 
   - name: Ahrefs
+    type: youtube
     channel_id: UCWquNQV8Y0_defMKnGKrFOQ
     enabled: true
     category: marketing
@@ -70,6 +77,7 @@ channels:
     url: https://www.youtube.com/channel/UCWquNQV8Y0_defMKnGKrFOQ
 
   - name: Mayuko
+    type: youtube
     channel_id: UCEDkO7wshcDZ7UZo17rPkzQ
     enabled: true
     category: career
@@ -80,6 +88,7 @@ channels:
     url: https://www.youtube.com/channel/UCEDkO7wshcDZ7UZo17rPkzQ
 
   - name: Engineering with Utsav
+    type: youtube
     channel_id: UC4HiUdMwzyZhBUoNKXenO-A
     enabled: true
     category: career
@@ -91,6 +100,7 @@ channels:
 
   # 旧名 "Continuous Delivery"。現在は "Modern Software Engineering" に改名
   - name: Modern Software Engineering
+    type: youtube
     channel_id: UCCfqyGl3nq_V0bo64CjZh8g
     enabled: true
     category: senior-engineer
@@ -101,6 +111,7 @@ channels:
     url: https://www.youtube.com/channel/UCCfqyGl3nq_V0bo64CjZh8g
 
   - name: ArjanCodes
+    type: youtube
     channel_id: UCVhQ2NnY5Rskt6UjCUkJ_DA
     enabled: true
     category: senior-engineer
@@ -111,6 +122,7 @@ channels:
     url: https://www.youtube.com/channel/UCVhQ2NnY5Rskt6UjCUkJ_DA
 
   - name: Dave2D
+    type: youtube
     channel_id: UCVYamHliCI9rw1tHR1xbkfw
     enabled: true
     category: gadget
@@ -121,6 +133,7 @@ channels:
     url: https://www.youtube.com/channel/UCVYamHliCI9rw1tHR1xbkfw
 
   - name: ShortCircuit
+    type: youtube
     channel_id: UCdBK94H6oZT2Q7l0-b0xmMg
     enabled: true
     category: gadget
@@ -132,6 +145,7 @@ channels:
 
   # 登録者数は少ないが、B2B SaaS 領域での一次情報源として保持
   - name: MicroConf
+    type: youtube
     channel_id: UCroeMSea_O-xfgDvgbJGVQA
     enabled: true
     category: indie-hacker
@@ -142,6 +156,7 @@ channels:
     url: https://www.youtube.com/channel/UCroeMSea_O-xfgDvgbJGVQA
 
   - name: Rob Walling
+    type: youtube
     channel_id: UCHoBKQDRkJcOY2BO47q5Ruw
     enabled: true
     category: indie-hacker
@@ -152,6 +167,7 @@ channels:
     url: https://www.youtube.com/channel/UCHoBKQDRkJcOY2BO47q5Ruw
 
   - name: Marc Lou
+    type: youtube
     channel_id: UC12JO2IPlEViR-o6SLXKx1A
     enabled: true
     category: indie-hacker
@@ -162,6 +178,7 @@ channels:
     url: https://www.youtube.com/channel/UC12JO2IPlEViR-o6SLXKx1A
 
   - name: Ali Abdaal
+    type: youtube
     channel_id: UCoOae5nYA7VqaXzerajD0lg
     enabled: true
     category: productivity
@@ -172,6 +189,7 @@ channels:
     url: https://www.youtube.com/channel/UCoOae5nYA7VqaXzerajD0lg
 
   - name: Thomas Frank
+    type: youtube
     channel_id: UCG-KntY7aVnIGXYEBQvmBAQ
     enabled: true
     category: productivity
@@ -182,6 +200,7 @@ channels:
     url: https://www.youtube.com/channel/UCG-KntY7aVnIGXYEBQvmBAQ
 
   - name: Lex Fridman
+    type: youtube
     channel_id: UCSHZKyawb77ixDdsGog4iWA
     enabled: true
     category: podcast
@@ -192,6 +211,7 @@ channels:
     url: https://www.youtube.com/channel/UCSHZKyawb77ixDdsGog4iWA
 
   - name: Lenny's Podcast
+    type: youtube
     channel_id: UC6t1O76G0jYXOAoYCm153dA
     enabled: true
     category: podcast
@@ -200,3 +220,22 @@ channels:
     recent_activity: 8
     why: プロダクトグロース、組織設計、リーダーシップの世界的定番番組。
     url: https://www.youtube.com/channel/UC6t1O76G0jYXOAoYCm153dA
+
+  # ============================================================
+  # RSS sources
+  # ============================================================
+  - name: EFF
+    type: rss
+    enabled: true
+    category: tech-news
+    feed_url: https://www.eff.org/rss/updates.xml
+    why: プライバシー・デジタル権利に関する一次情報源。
+    url: https://www.eff.org
+
+  - name: Hacker News (Front Page)
+    type: rss
+    enabled: true
+    category: tech-news
+    feed_url: https://hnrss.org/frontpage
+    why: テック業界のリアルタイム話題集約。
+    url: https://news.ycombinator.com


### PR DESCRIPTION
Closes #6

## Summary
- `sources.yaml` を新設し YouTube と RSS を同一スキーマで管理。既存 20 チャンネルに `type: youtube` を付けて移行、RSS エントリ 2 件（EFF / Hacker News）を追加。
- `fetchers/` パッケージを導入。`fetch_recent_items()` と `get_content_text()` の 2 関数で統一 item shape を返す。YouTube ロジックは `daily_news.py` から `fetchers/youtube.py` に移動、RSS は `fetchers/rss.py`（feedparser + trafilatura + 原点単位 robots.txt キャッシュ）。
- `daily_news.py` は薄い orchestrator に。Stage A のメタデータ取得も Stage C の本文取得も `item[\"source_type\"]` で dispatch。コマンド内の命名も `channel/videos` → `source_name/items` に寄せて RSS を一級市民化。

## Unified item shape
\`\`\`
{
    \"source_type\":  \"youtube\" | \"rss\",
    \"source_name\":  str,
    \"category\":     str | None,
    \"content_id\":   str,   # video_id for YT, canonical URL for RSS
    \"title\":        str,
    \"url\":          str,
    \"published_at\": str,   # ISO 8601 (UTC)
    \"description\":  str,
}
\`\`\`

## Files
- NEW `sources.yaml`（`channels.yaml` からリネーム + RSS 追加）
- NEW `fetchers/__init__.py`, `fetchers/youtube.py`, `fetchers/rss.py`
- MOD `daily_news.py`（source-agnostic に書き換え）
- MOD `requirements.txt`（`feedparser>=6.0.10`, `trafilatura>=1.12.0`）
- MOD `README.md`（フロー図を multi-source に更新）
- DEL `channels.yaml`

## Acceptance criteria
- [x] \`sources.yaml\` でソースを追加・削除できる
- [x] RSS フィードから最新 N 件の記事を取得できる（EFF で確認）
- [x] 記事本文を取得して Claude に渡せる（trafilatura で EFF 記事から 1,224 chars 抽出確認）
- [x] YouTube と RSS が同じパイプラインに流れる
- [x] ローカルで Python モジュールが import できる（コンパイル + import smoke test pass）
- [ ] ローカル/Actions で \`python daily_news.py\` エンドツーエンド実行確認 → **手動検証予定**

## Robots.txt
RSS の本文取得時に原点単位で \`robots.txt\` を取得・キャッシュし、\`User-Agent: PersonalDailyNewsBot/1.0\` で \`can_fetch\` を確認。取得失敗時は fail-open（1 件の障害で全記事が落ちないように）。

## Notes / Follow-ups
- 既存の \`sources/\`（hackernews.py, reddit.py, rss.py）は別系統のスキャフォールドで本 PR では触っていない。整理は別 Issue 化推奨。
- #7（要約フォーマット改修: 概要/学べること/実践的な応用 + ★表示）は本 PR 取り込み後に着手。

## Test plan
- [x] \`pip install -r requirements.txt\` が通ること
- [x] ローカルで \`python daily_news.py\` を走らせ、YouTube と RSS 両方から候補が集まりログに両方出ること
- [ ] Actions 手動実行で 1 回完走し、RSS 記事の要約が配信メールに含まれることを確認
- [x] Neon \`articles\` テーブルに \`source_type = 'rss'\` の行が保存されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)