### PR TITLE
feat(db): phase 3 schema — clicks + user_id + source_metrics_30d (#25)

### DIFF
--- a/daily_news.py
+++ b/daily_news.py
@@ -260,6 +260,7 @@ def main():
                 "title": item["title"],
                 "url": item["url"],
                 "summary": summary,
+                "category": item.get("category"),
             }
         )
 

--- a/db.py
+++ b/db.py
@@ -44,17 +44,19 @@ def save_article(article: dict) -> None:
             - title: str
             - url: str
             - summary: str | None
+            - category: str | None  (optional; source_metrics_30d の GROUP BY に使う)
     """
+    params = {**article, "category": article.get("category")}
     with get_conn() as conn:
         conn.execute(
             """
             insert into articles
-              (source_type, source_name, content_id, title, url, summary, sent_at)
+              (source_type, source_name, content_id, title, url, summary, category, sent_at)
             values
               (%(source_type)s, %(source_name)s, %(content_id)s,
-               %(title)s, %(url)s, %(summary)s, now())
+               %(title)s, %(url)s, %(summary)s, %(category)s, now())
             on conflict (content_id) do nothing
             """,
-            article,
+            params,
         )
         conn.commit()

--- a/migrations/002_phase3_schema.sql
+++ b/migrations/002_phase3_schema.sql
@@ -1,0 +1,58 @@
+-- ================================================================
+-- Phase 3 schema additions
+--   * articles.user_id  (multi-tenant 化への布石)
+--   * articles.category (source_metrics_30d で GROUP BY するため)
+--   * clicks            (メールリンクのクリック記録)
+--   * source_metrics_30d VIEW (sources.yaml のメンテ判断用)
+--
+-- 2 回流しても壊れないよう、全部 idempotent に書く。
+-- ================================================================
+
+-- 1. articles への列追加 ------------------------------------------------
+
+-- multi-tenant 化の布石。当面は kazuki 固定の UUID を default に。
+ALTER TABLE articles
+    ADD COLUMN IF NOT EXISTS user_id uuid NOT NULL
+    DEFAULT '00000000-0000-0000-0000-000000000001';
+
+-- fetcher は既に unified item に `category` を入れているが、DB には落ちていなかった。
+-- VIEW で GROUP BY するために永続化する。nullable（既存行は NULL）。
+ALTER TABLE articles
+    ADD COLUMN IF NOT EXISTS category text;
+
+CREATE INDEX IF NOT EXISTS articles_user_id_idx ON articles (user_id);
+
+
+-- 2. clicks テーブル ----------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS clicks (
+    id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    article_id  uuid NOT NULL REFERENCES articles (id) ON DELETE CASCADE,
+    user_id     uuid NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001',
+    clicked_at  timestamptz NOT NULL DEFAULT NOW(),
+    user_agent  text,
+    ip_hash     text   -- SHA-256(ip || daily_salt) を想定。salt は D で扱う。
+);
+
+CREATE INDEX IF NOT EXISTS clicks_article_id_idx     ON clicks (article_id);
+CREATE INDEX IF NOT EXISTS clicks_user_clicked_idx   ON clicks (user_id, clicked_at DESC);
+
+
+-- 3. source_metrics_30d VIEW -------------------------------------------
+
+-- sources.yaml メンテ用。直近30日での配信件数・平均要約長・最終配信日時を
+-- ソース別 / カテゴリ別で見られる。`psql -c "select * from source_metrics_30d"`
+-- で mute 判断や品質劣化の検知に使う。
+CREATE OR REPLACE VIEW source_metrics_30d AS
+SELECT
+    source_type,
+    source_name,
+    category,
+    COUNT(*)                  AS delivered,
+    AVG(LENGTH(summary))::int AS avg_summary_len,
+    MIN(created_at)           AS first_delivered,
+    MAX(created_at)           AS last_delivered
+FROM articles
+WHERE created_at > NOW() - INTERVAL '30 days'
+GROUP BY source_type, source_name, category
+ORDER BY delivered DESC;

--- a/scripts/smoke_phase3_schema.py
+++ b/scripts/smoke_phase3_schema.py
@@ -1,0 +1,103 @@
+"""migrations/002_phase3_schema.sql の適用結果を確認する smoke test。
+
+DATABASE_URL に接続し、
+  - articles.user_id / articles.category 列の存在
+  - clicks テーブル + FK
+  - source_metrics_30d VIEW のクエリ可能性
+を確認する。本番パイプラインからは呼ばれない。
+
+使い方:
+    python scripts/smoke_phase3_schema.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import psycopg
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DATABASE_URL = os.environ.get("DATABASE_URL")
+if not DATABASE_URL:
+    print("ERROR: DATABASE_URL is not set in .env", file=sys.stderr)
+    sys.exit(1)
+
+
+CHECKS: list[tuple[str, str]] = [
+    (
+        "articles.user_id exists and is NOT NULL",
+        """
+        select is_nullable
+        from information_schema.columns
+        where table_name = 'articles' and column_name = 'user_id'
+        """,
+    ),
+    (
+        "articles.category column exists",
+        """
+        select 1
+        from information_schema.columns
+        where table_name = 'articles' and column_name = 'category'
+        """,
+    ),
+    (
+        "clicks table exists",
+        """
+        select 1 from information_schema.tables where table_name = 'clicks'
+        """,
+    ),
+    (
+        "clicks.article_id FK references articles(id)",
+        """
+        select 1
+        from information_schema.referential_constraints rc
+        join information_schema.key_column_usage kcu
+          on rc.constraint_name = kcu.constraint_name
+        where kcu.table_name  = 'clicks'
+          and kcu.column_name = 'article_id'
+        """,
+    ),
+    (
+        "source_metrics_30d view is queryable",
+        "select count(*) from source_metrics_30d",
+    ),
+]
+
+
+def main() -> int:
+    failures: list[str] = []
+    try:
+        with psycopg.connect(DATABASE_URL) as conn, conn.cursor() as cur:
+            for label, sql in CHECKS:
+                cur.execute(sql)
+                row = cur.fetchone()
+                if row is None:
+                    failures.append(label)
+                    print(f"❌ {label}")
+                    continue
+
+                if label.startswith("articles.user_id"):
+                    # is_nullable が 'NO' であること
+                    if row[0] != "NO":
+                        failures.append(label)
+                        print(f"❌ {label} — is_nullable={row[0]!r}")
+                        continue
+
+                print(f"✅ {label}")
+    except Exception as e:
+        print(f"❌ connection or query failed: {e}", file=sys.stderr)
+        return 1
+
+    if failures:
+        print(f"\n❌ {len(failures)} check(s) failed", file=sys.stderr)
+        return 1
+
+    print("\n✅ Phase 3 schema smoke test passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #25.

## Summary
- `migrations/002_phase3_schema.sql` — one idempotent migration that lays the Phase 3 foundation:
  - `articles.user_id uuid NOT NULL DEFAULT '…0001'` + index (multi-tenant布石; existing rows get the default via `ADD COLUMN DEFAULT`).
  - `articles.category text` (nullable) — already produced by the fetchers in the unified item shape but previously dropped at save-time; persisting it unblocks `source_metrics_30d`.
  - `clicks` table with FK to `articles(id) ON DELETE CASCADE`, plus `(article_id)` and `(user_id, clicked_at DESC)` indexes for the two click-analytics access patterns.
  - `source_metrics_30d` view — per-source delivered count / avg summary length / first+last delivery timestamp over a 30-day window, for `sources.yaml` maintenance.
  - All idempotent: `ADD COLUMN IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`, `CREATE TABLE IF NOT EXISTS`, `CREATE OR REPLACE VIEW`.
- `db.save_article` + `daily_news.py` now persist `category` (fetchers already emit it; it was being silently dropped).
- `scripts/smoke_phase3_schema.py` — post-migration smoke test that verifies the columns, FK, and view.

## Note on adding `category`
The issue sample's `source_metrics_30d` view GROUPs BY `category`, but `articles` had no such column — the value lived only in-memory inside the fetchers. I added it as a nullable column in the same migration (existing rows → NULL, which is fine for the view). Also wired `category` through `db.save_article` so new rows populate it. Left `category` nullable because back-filling historical rows from `source_name` would be guesswork and isn't needed for the view to work.

## Execution
The migration is **not run by CI** — it needs to be applied manually against Neon:

```bash
psql "$DATABASE_URL" -f migrations/002_phase3_schema.sql
python scripts/smoke_phase3_schema.py
psql "$DATABASE_URL" -c "select * from source_metrics_30d limit 5;"
```

Re-running is safe (idempotent).

## Test plan
- [ ] Apply migration against Neon.
- [ ] `python scripts/smoke_phase3_schema.py` reports all ✅.
- [ ] `select user_id, count(*) from articles group by 1` shows existing rows backfilled to the default UUID.
- [ ] `select * from source_metrics_30d order by delivered desc limit 10` returns per-source stats.
- [ ] Next `daily_news.py` run — new rows land with `category` populated for entries whose `sources.yaml` entry has a `category:` key.
- [ ] Re-run the migration a second time; no errors.

## Intentionally out of scope (per issue)
- `embedding vector(1536)` — Phase 3 E.
- `source_mutes` table — separate issue.
- RLS — defer until multi-tenant actually happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)