### PR TITLE
feat: Manager Agent state-machine orchestrator

### DIFF
--- a/.claude/rules/manager-agent.md
+++ b/.claude/rules/manager-agent.md
@@ -1,0 +1,29 @@
+# Manager Agent Rules
+
+Manager Agent (`manager/` パッケージ) の改修・テスト時に適用するルール。
+対象: `manager/**/*.py`
+
+## Rules
+
+- Manager は **コード駆動の state machine**。LLM にステート遷移を判断させない
+- 状態遷移は `manager/states.py` の `LEGAL_TRANSITIONS` に必ず登録する。`is_legal()` を通らない遷移を runner で発生させない
+- リトライ上限・コスト上限・タイムアウトは `manager/limits.py` に定数で持つ。env / 引数で動的変更しない
+- Manager は既存の 7 スラッシュコマンド (`/triage-issue` `/make-execution-packet` `/spec-architect` `/run-dev-loop` `/implementation-reviewer` `/test-qa` `/pr-creation`) を **無改修** で呼ぶ。コマンド側の Output Format に依存する
+- subagent 出力のパーサ追加・変更時は `manager/tests/fixtures/*.md` にゴールデン入力を追加し、parser テストでカバーする
+- `Subagent` / `GitOps` / `Escalator` の Protocol を破らない。Real 実装と Dummy 実装は同 Protocol を満たす
+- `subprocess.run` 系は必ず `timeout=SUBAGENT_TIMEOUT_SECONDS` を渡し、`TimeoutExpired` をハンドルする
+- `claude -p` 起動時は `--bare`, `--no-session-persistence`, `--max-budget-usd`, `--session-id`, `--add-dir <repo_root>`, `--output-format json`, `--dangerously-skip-permissions` を必ず付ける
+  - `--bare` の理由: CLAUDE.md auto-discovery / hooks / MCP / `.env` の意図せぬ読み込みを完全停止する。`.env` に `ANTHROPIC_API_KEY` が残っていた場合、`--bare` 無しだと `claude -p` が auto-discovery で API key を拾い、**Claude Max plan ではなく API ($) 課金にサイレントに切り替わる**。Phase 3 live 1 回目で実際に発生した
+  - skip-permissions の理由: 非対話 `-p` モードで Edit/Write/Bash の許可ダイアログが起きると subagent が deadlock する。Manager 自身が kill-switch / cost limit / diff limit / NEEDS_HUMAN escalation で安全網を担っているため、内側の subagent は trusted モードで動かす
+- subprocess.run は env を `sanitized_env()` で明示渡し、`ANTHROPIC_*` を **除去** する。env 経由で API key が再混入することを物理的に防ぐ
+- 既知の Phase 4 まで残る制約: `/pr-creation` が `--base main` ハードコードのため子 PR は一旦 main に向く。`_handle_verify_pr` が `gh pr edit <url> --base <epic-branch>` で retarget する (soft-fail: retarget 失敗してもログのみ、PR 自体は残る)
+- `resume` / 失敗子 retry: `python -m manager run <epic#>` で既存 state を resume、`--retry <child#> ...` で失敗子をリセットしてキュー先頭に戻す
+- SIGINT / SIGTERM: 子境界で flag をチェックし、現在の subagent 完了を待ってから state を save し HALTED 終了。Ctrl-C で state corruption しない
+- `python -m manager status <epic#>` で epic + 子 state のスナップショットを表示 (実行なし)
+- state JSON 書き込みは `_atomic_write` を経由し、`.bak` を残す
+- `epic_lock` は `flock(2)` 経由。lock 取得失敗時は `EXIT_LOCK_TAKEN=4` で即終了
+- kill-switch (`.claude/STOP` / `.claude/STOP_NOW`) は **全 transition 直前** で評価する
+- 型ヒント必須。`Any` / `# type: ignore` で逃げない
+- async / 並行処理を導入しない (1 Manager = 1 epic = 1 プロセス)
+- 既存 `/orchestrate` (LLM 駆動ルータ) を Manager 内で呼ばない。両者は併存
+- Phase 4 まで multi-epic 並列・Web UI・既存エージェント改修は **Non-goals**

--- a/.claude/state/.gitignore
+++ b/.claude/state/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ token.json
 articles.json
 enriched_articles.json
 summaries.json
+.claude/STOP
+.claude/STOP_NOW
+

--- a/manager/__init__.py
+++ b/manager/__init__.py
@@ -1,0 +1,4 @@
+"""Manager Agent: state-machine orchestrator over the existing slash commands.
+
+See `architecture/manager-design.md` (Phase 1 design) and `.claude/rules/manager-agent.md`.
+"""

--- a/manager/__main__.py
+++ b/manager/__main__.py
@@ -1,0 +1,118 @@
+"""Entry point for the Manager Agent.
+
+Default mode is `--dry-run` (Dummy* implementations) for safety. Pass `--live`
+to shell out to real `claude -p` and `gh` commands.
+
+Subcommands:
+
+    python -m manager run <epic#>     start (or resume) an epic
+    python -m manager resume <epic#>  alias for `run` (loads existing state)
+    python -m manager status <epic#>  print epic + per-child summary, no exec
+
+The `--retry` flag (with `run`/`resume`) puts the named failed children back at
+the head of the queue and resets their state to INIT before re-attempting.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .escalate import DummyEscalator, Escalator, RealEscalator
+from .git_ops import DummyGitOps, GitOps, RealGitOps
+from .limits import EXIT_LOCK_TAKEN
+from .runner import Runner
+from .state_store import LockTaken, StateStore
+from .subagent import DummySubagent, RealSubagent, Subagent
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+STATE_ROOT = REPO_ROOT / ".claude" / "state"
+
+
+def _build_dummy(epic_issue: int, children: list[int]) -> tuple[Subagent, GitOps, Escalator]:
+    return (
+        DummySubagent(scripted={}),
+        DummyGitOps(child_listing={epic_issue: children}),
+        DummyEscalator(),
+    )
+
+
+def _build_live() -> tuple[Subagent, GitOps, Escalator]:
+    return (
+        RealSubagent(repo_root=REPO_ROOT),
+        RealGitOps(repo_root=REPO_ROOT),
+        RealEscalator(repo_root=REPO_ROOT),
+    )
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    if args.live:
+        subagent, git_ops, escalator = _build_live()
+    else:
+        subagent, git_ops, escalator = _build_dummy(args.epic_issue, args.children)
+    runner = Runner(
+        state_store=StateStore(STATE_ROOT),
+        subagent=subagent,
+        git_ops=git_ops,
+        escalator=escalator,
+        repo_root=REPO_ROOT,
+    )
+    try:
+        return runner.run_epic(
+            args.epic_issue,
+            slug=args.slug,
+            retry_failed=args.retry or [],
+        )
+    except LockTaken as exc:
+        print(f"manager: {exc}", file=sys.stderr)
+        return EXIT_LOCK_TAKEN
+
+
+def _cmd_status(args: argparse.Namespace) -> int:
+    store = StateStore(STATE_ROOT)
+    epic_path = store.epic_path(args.epic_issue)
+    if not epic_path.exists():
+        print(f"no state for epic #{args.epic_issue}", file=sys.stderr)
+        return 1
+    epic = json.loads(epic_path.read_text(encoding="utf-8"))
+    print(json.dumps(epic, indent=2, sort_keys=True))
+    children_dir = store.epic_dir(args.epic_issue) / "children"
+    if children_dir.exists():
+        for sub in sorted(children_dir.iterdir()):
+            state_file = sub / "state.json"
+            if state_file.exists():
+                child = json.loads(state_file.read_text(encoding="utf-8"))
+                print(
+                    f"  child #{child['issue_number']}: {child['status']} "
+                    f"(cost ${child.get('cost_usd', 0):.4f})"
+                )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="manager")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    for name in ("run", "resume"):
+        p = sub.add_parser(name, help="start or resume an epic")
+        p.add_argument("epic_issue", type=int)
+        p.add_argument("--slug", default="epic", help="branch slug suffix")
+        p.add_argument("--live", action="store_true", help="use claude -p / gh / git")
+        p.add_argument("--children", type=int, nargs="*", default=[],
+                       help="dry-run only: explicit child issue numbers")
+        p.add_argument("--retry", type=int, nargs="*", default=[],
+                       help="failed child issue numbers to reset and re-attempt")
+        p.set_defaults(func=_cmd_run)
+
+    p = sub.add_parser("status", help="print epic + per-child summary")
+    p.add_argument("epic_issue", type=int)
+    p.set_defaults(func=_cmd_status)
+
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/manager/_subprocess.py
+++ b/manager/_subprocess.py
@@ -1,0 +1,86 @@
+"""Subprocess helpers shared by Real* implementations.
+
+Centralized so timeout / retry / error wrapping rules apply uniformly to every
+external command Manager runs.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import Sequence
+
+from .limits import NETWORK_BACKOFF_SECONDS, SUBAGENT_TIMEOUT_SECONDS
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    exit_code: int
+    stdout: str
+    stderr: str
+    elapsed_seconds: float
+
+
+class CommandTimeout(Exception):
+    pass
+
+
+def run(
+    argv: Sequence[str],
+    *,
+    stdin: str | None = None,
+    timeout: int = SUBAGENT_TIMEOUT_SECONDS,
+    cwd: str | None = None,
+    env: dict[str, str] | None = None,
+) -> CommandResult:
+    """Run a command synchronously. Never raises on non-zero exit; raises on timeout.
+
+    `env=None` inherits the parent env. Pass an explicit dict to scrub specific
+    variables (used by RealSubagent to keep ANTHROPIC_* out of `claude -p`).
+    """
+    started = time.monotonic()
+    try:
+        proc = subprocess.run(
+            list(argv),
+            input=stdin,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=cwd,
+            env=env,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise CommandTimeout(f"timeout after {timeout}s: {' '.join(argv[:3])}...") from exc
+    return CommandResult(
+        exit_code=proc.returncode,
+        stdout=proc.stdout or "",
+        stderr=proc.stderr or "",
+        elapsed_seconds=time.monotonic() - started,
+    )
+
+
+def run_with_backoff(
+    argv: Sequence[str],
+    *,
+    stdin: str | None = None,
+    timeout: int = SUBAGENT_TIMEOUT_SECONDS,
+    cwd: str | None = None,
+    retry_on_exit_codes: frozenset[int] = frozenset(),
+) -> CommandResult:
+    """Run with exponential backoff for transient failures.
+
+    Retries when exit_code is in `retry_on_exit_codes`. If still failing after
+    NETWORK_BACKOFF_SECONDS attempts, returns the last result (caller decides).
+    """
+    last: CommandResult | None = None
+    for attempt, delay in enumerate(NETWORK_BACKOFF_SECONDS):
+        result = run(argv, stdin=stdin, timeout=timeout, cwd=cwd)
+        if result.exit_code == 0 or result.exit_code not in retry_on_exit_codes:
+            return result
+        last = result
+        if attempt < len(NETWORK_BACKOFF_SECONDS) - 1:
+            time.sleep(delay)
+    assert last is not None
+    return last

--- a/manager/checkpoints.py
+++ b/manager/checkpoints.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .limits import EPIC_BUDGET_USD, MAX_DIFF_LINES_PER_CHILD
+
+
+@dataclass(frozen=True)
+class Checkpoint:
+    """A precondition checked at every state transition.
+
+    `tripped == True` means: stop the state machine. `reason` is the human-readable
+    explanation written to the log + Issue comment.
+    """
+
+    tripped: bool
+    reason: str
+    fatal: bool  # if True -> HALTED (immediate); if False -> NEEDS_HUMAN at child boundary
+
+
+def kill_switch(stop_root: Path) -> Checkpoint:
+    if (stop_root / ".claude" / "STOP_NOW").exists():
+        return Checkpoint(tripped=True, reason="STOP_NOW marker present", fatal=True)
+    if (stop_root / ".claude" / "STOP").exists():
+        return Checkpoint(tripped=True, reason="STOP marker present", fatal=True)
+    return Checkpoint(tripped=False, reason="", fatal=False)
+
+
+def cost_check(epic_cost_usd: float) -> Checkpoint:
+    if epic_cost_usd >= EPIC_BUDGET_USD:
+        return Checkpoint(
+            tripped=True,
+            reason=f"epic cost {epic_cost_usd:.2f} USD reached EPIC_BUDGET_USD={EPIC_BUDGET_USD}",
+            fatal=False,
+        )
+    return Checkpoint(tripped=False, reason="", fatal=False)
+
+
+def diff_check(child_diff_lines: int) -> Checkpoint:
+    if child_diff_lines >= MAX_DIFF_LINES_PER_CHILD:
+        return Checkpoint(
+            tripped=True,
+            reason=(
+                f"child diff {child_diff_lines} lines >= MAX_DIFF_LINES_PER_CHILD="
+                f"{MAX_DIFF_LINES_PER_CHILD}"
+            ),
+            fatal=False,
+        )
+    return Checkpoint(tripped=False, reason="", fatal=False)
+
+
+def deps_check(requirements_changed: bool) -> Checkpoint:
+    if requirements_changed:
+        return Checkpoint(
+            tripped=True,
+            reason="requirements.txt changed — new dependency requires human review",
+            fatal=False,
+        )
+    return Checkpoint(tripped=False, reason="", fatal=False)

--- a/manager/escalate.py
+++ b/manager/escalate.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+from ._subprocess import run
+from .git_ops import GitOpsError
+
+
+class Escalator(Protocol):
+    def comment(self, issue: int, body: str) -> None: ...
+
+
+@dataclass
+class DummyEscalator:
+    """Records every comment that would have been posted."""
+
+    posted: list[tuple[int, str]] = field(default_factory=list)
+
+    def comment(self, issue: int, body: str) -> None:
+        self.posted.append((issue, body))
+
+
+@dataclass
+class RealEscalator:
+    """Phase 3 implementation. Posts via `gh issue comment`."""
+
+    repo_root: Path
+    gh_bin: str = "gh"
+
+    def comment(self, issue: int, body: str) -> None:
+        # Pass body via stdin (`-F -`) to avoid shell quoting issues with
+        # multi-line markdown content.
+        result = run(
+            [self.gh_bin, "issue", "comment", str(issue), "-F", "-"],
+            stdin=body,
+            cwd=str(self.repo_root),
+        )
+        if result.exit_code != 0:
+            raise GitOpsError(
+                f"gh issue comment {issue} failed (exit={result.exit_code}): "
+                f"{result.stderr.strip()}"
+            )
+
+
+# ============================================================
+# Body renderers (shared by Dummy and Real)
+# ============================================================
+
+
+def render_needs_human(
+    epic_issue: int,
+    child_issue: int,
+    state_path: str,
+    failed_state: str,
+    last_verdict: str | None,
+    detail: str,
+) -> str:
+    return (
+        f"Manager halted on child #{child_issue}\n"
+        f"\n"
+        f"- epic: #{epic_issue}\n"
+        f"- failed_state: {failed_state}\n"
+        f"- last_verdict: {last_verdict or 'n/a'}\n"
+        f"- state_file: `{state_path}`\n"
+        f"\n"
+        f"## Detail\n"
+        f"{detail.strip()}\n"
+        f"\n"
+        f"Resume with `python -m manager resume {epic_issue}` after fixing.\n"
+    )
+
+
+def render_epic_done(epic_issue: int, done: list[int], skipped: list[int]) -> str:
+    parts = [f"Manager finished epic #{epic_issue}.", ""]
+    parts.append(f"- done: {done or 'none'}")
+    parts.append(f"- skipped: {skipped or 'none'}")
+    return "\n".join(parts) + "\n"
+
+
+def render_halted(epic_issue: int, reason: str) -> str:
+    return f"Manager halted epic #{epic_issue}: {reason}\n"

--- a/manager/git_ops.py
+++ b/manager/git_ops.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+from ._subprocess import run
+
+
+class GitOpsError(Exception):
+    """Wraps a failed git/gh command. Manager treats this as NEEDS_HUMAN."""
+
+
+class GitOps(Protocol):
+    def create_epic_branch(self, epic_issue: int, slug: str) -> str: ...
+    def create_child_branch(self, epic_branch: str, child_issue: int) -> str: ...
+    def diff_lines(self, base_branch: str) -> int: ...
+    def find_pr_url(self, head_branch: str, base_branch: str) -> str | None: ...
+    def retarget_pr(self, pr_url: str, new_base: str) -> bool: ...
+    def fetch_issue_body(self, issue: int) -> str: ...
+    def list_child_issues(self, epic_issue: int) -> list[int]: ...
+
+
+# ============================================================
+# Dummy
+# ============================================================
+
+
+@dataclass
+class DummyGitOps:
+    """Records calls; returns canned values. Used by tests and `--dry-run`."""
+
+    epic_branches: dict[int, str] = field(default_factory=dict)
+    child_branches: dict[int, str] = field(default_factory=dict)
+    diff_lines_value: int = 0
+    pr_urls: dict[str, str] = field(default_factory=dict)
+    issue_bodies: dict[int, str] = field(default_factory=dict)
+    child_listing: dict[int, list[int]] = field(default_factory=dict)
+    retargeted: dict[str, str] = field(default_factory=dict)
+    failures: dict[str, GitOpsError] = field(default_factory=dict)
+
+    def create_epic_branch(self, epic_issue: int, slug: str) -> str:
+        self._maybe_fail("create_epic_branch")
+        branch = f"epic/{epic_issue}-{slug}"
+        self.epic_branches[epic_issue] = branch
+        return branch
+
+    def create_child_branch(self, epic_branch: str, child_issue: int) -> str:
+        self._maybe_fail("create_child_branch")
+        branch = child_branch_name(epic_branch, child_issue)
+        self.child_branches[child_issue] = branch
+        return branch
+
+    def diff_lines(self, base_branch: str) -> int:
+        return self.diff_lines_value
+
+    def find_pr_url(self, head_branch: str, base_branch: str) -> str | None:
+        return self.pr_urls.get(head_branch)
+
+    def retarget_pr(self, pr_url: str, new_base: str) -> bool:
+        self._maybe_fail("retarget_pr")
+        self.retargeted[pr_url] = new_base
+        return True
+
+    def fetch_issue_body(self, issue: int) -> str:
+        return self.issue_bodies.get(issue, "")
+
+    def list_child_issues(self, epic_issue: int) -> list[int]:
+        return list(self.child_listing.get(epic_issue, []))
+
+    def _maybe_fail(self, op: str) -> None:
+        if op in self.failures:
+            raise self.failures[op]
+
+
+# ============================================================
+# Real
+# ============================================================
+
+
+_CHILDREN_HEADER_RE = re.compile(
+    r"^##\s*(?:Children|子\s*Issue|子\s*issue|子課題|サブIssue)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+_NEXT_HEADER_RE = re.compile(r"^##\s+\S", re.MULTILINE)
+_CHILD_REF_RE = re.compile(r"#(\d+)")
+
+
+def child_branch_name(epic_branch: str, child_issue: int) -> str:
+    """Compose a child branch that won't collide with the epic branch's git ref.
+
+    git refuses `refs/heads/X` and `refs/heads/X/Y` to coexist. So we must NOT
+    reuse the epic branch as a path prefix for child branches. Append `-child-N`
+    instead of `/child-N`.
+    """
+    return f"{epic_branch}-child-{child_issue}"
+
+
+def parse_children_from_body(body: str) -> list[int]:
+    """Extract child issue numbers from the `## Children` section of an epic body.
+
+    Body format (convention):
+
+        ## Children
+        - #11 add fetcher A
+        - #12 add fetcher B
+        - #13 update mailer
+
+    Returns issue numbers in the order they appear, deduplicated.
+    """
+    m = _CHILDREN_HEADER_RE.search(body)
+    if not m:
+        return []
+    section_start = m.end()
+    next_section = _NEXT_HEADER_RE.search(body, pos=section_start)
+    section = body[section_start: next_section.start() if next_section else len(body)]
+    seen: list[int] = []
+    for ref in _CHILD_REF_RE.finditer(section):
+        n = int(ref.group(1))
+        if n not in seen:
+            seen.append(n)
+    return seen
+
+
+@dataclass
+class RealGitOps:
+    """Phase 3 implementation. Calls `git` and `gh` via subprocess."""
+
+    repo_root: Path
+    base_branch: str = "main"
+    git_bin: str = "git"
+    gh_bin: str = "gh"
+
+    def create_epic_branch(self, epic_issue: int, slug: str) -> str:
+        branch = f"epic/{epic_issue}-{slug}"
+        self._git("fetch", "origin", self.base_branch)
+        # Idempotent: if the branch already exists, just check it out.
+        existing = self._git("rev-parse", "--verify", "--quiet", branch, allow_fail=True)
+        if existing.exit_code == 0:
+            self._git("checkout", branch)
+        else:
+            self._git("checkout", "-b", branch, f"origin/{self.base_branch}")
+        return branch
+
+    def create_child_branch(self, epic_branch: str, child_issue: int) -> str:
+        branch = child_branch_name(epic_branch, child_issue)
+        existing = self._git("rev-parse", "--verify", "--quiet", branch, allow_fail=True)
+        if existing.exit_code == 0:
+            self._git("checkout", branch)
+        else:
+            self._git("checkout", epic_branch)
+            self._git("checkout", "-b", branch)
+        return branch
+
+    def diff_lines(self, base_branch: str) -> int:
+        result = self._git(
+            "diff", "--numstat", f"{base_branch}...HEAD", allow_fail=True
+        )
+        if result.exit_code != 0:
+            return 0
+        total = 0
+        for line in result.stdout.splitlines():
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            for raw in parts[:2]:
+                if raw.isdigit():
+                    total += int(raw)
+        return total
+
+    def find_pr_url(self, head_branch: str, base_branch: str) -> str | None:
+        # Phase 3 limitation: existing /pr-creation hard-codes `--base main`, so
+        # child PRs land on main rather than the epic branch. Until Phase 4
+        # introduces a base-rewrite step, accept any base for the head branch.
+        result = self._gh(
+            "pr", "list",
+            "--head", head_branch,
+            "--state", "open",
+            "--json", "url",
+            "--jq", ".[0].url // empty",
+            allow_fail=True,
+        )
+        if result.exit_code != 0:
+            return None
+        url = result.stdout.strip()
+        return url or None
+
+    def retarget_pr(self, pr_url: str, new_base: str) -> bool:
+        """Move a PR to a different base branch via `gh pr edit <url> --base <branch>`.
+
+        Returns True on success, False on failure (Manager treats False as a soft
+        warning — the PR still exists on the original base, just not where we
+        wanted). Does NOT raise so a transient failure doesn't escalate the
+        whole child to NEEDS_HUMAN.
+        """
+        result = self._gh(
+            "pr", "edit", pr_url, "--base", new_base, allow_fail=True,
+        )
+        return result.exit_code == 0
+
+    def fetch_issue_body(self, issue: int) -> str:
+        result = self._gh(
+            "issue", "view", str(issue),
+            "--json", "body",
+            "--jq", ".body",
+        )
+        return result.stdout
+
+    def list_child_issues(self, epic_issue: int) -> list[int]:
+        body = self.fetch_issue_body(epic_issue)
+        return parse_children_from_body(body)
+
+    # --------------------------------------------------------- internals
+
+    def _git(self, *args: str, allow_fail: bool = False):
+        result = run([self.git_bin, *args], cwd=str(self.repo_root))
+        if result.exit_code != 0 and not allow_fail:
+            raise GitOpsError(
+                f"git {' '.join(args)} failed (exit={result.exit_code}): {result.stderr.strip()}"
+            )
+        return result
+
+    def _gh(self, *args: str, allow_fail: bool = False):
+        result = run([self.gh_bin, *args], cwd=str(self.repo_root))
+        if result.exit_code != 0 and not allow_fail:
+            raise GitOpsError(
+                f"gh {' '.join(args)} failed (exit={result.exit_code}): {result.stderr.strip()}"
+            )
+        return result

--- a/manager/limits.py
+++ b/manager/limits.py
@@ -1,0 +1,29 @@
+"""Hard-coded operational limits for the Manager Agent.
+
+These are intentionally constants (not env vars) so that loosening a guardrail
+requires a code change + review.
+"""
+
+from __future__ import annotations
+
+PLAN_MAX_ATTEMPTS: int = 2
+IMPLEMENT_MAX_ATTEMPTS: int = 3
+TRIAGE_MAX_ATTEMPTS: int = 1
+PACKETIZE_MAX_ATTEMPTS: int = 1
+VERIFY_PR_MAX_ATTEMPTS: int = 3
+
+SUBAGENT_TIMEOUT_SECONDS: int = 900
+
+EPIC_BUDGET_USD: float = 5.0
+PER_STAGE_BUDGET_USD: float = 1.0
+
+MAX_DIFF_LINES_PER_CHILD: int = 1500
+
+NETWORK_BACKOFF_SECONDS: tuple[int, ...] = (5, 15, 45)
+
+SCHEMA_VERSION: int = 1
+
+EXIT_OK: int = 0
+EXIT_NEEDS_HUMAN: int = 2
+EXIT_HALTED: int = 3
+EXIT_LOCK_TAKEN: int = 4

--- a/manager/parsers/__init__.py
+++ b/manager/parsers/__init__.py
@@ -1,0 +1,2 @@
+class ParseError(Exception):
+    """Raised when a subagent's stdout cannot be parsed into the expected shape."""

--- a/manager/parsers/dev_loop.py
+++ b/manager/parsers/dev_loop.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from . import ParseError
+from ..types import ReviewVerdict
+
+_VERDICT_RE = re.compile(
+    r"#\s*Review Verdict\s*\n+\s*-?\s*(safe to merge|fix before merge|confirm before merge)\b",
+    re.IGNORECASE,
+)
+_PYTEST_RE = re.compile(
+    r"##\s*Pytest Status\s*\n+\s*-?\s*(Pytest (?:Passed|Failed|Not Run))",
+    re.IGNORECASE,
+)
+_DRYRUN_RE = re.compile(
+    r"##\s*Dry-run Status\s*\n+\s*-?\s*(Dry-run (?:Passed|Failed|Not Run))",
+    re.IGNORECASE,
+)
+_MIGR_RE = re.compile(
+    r"##\s*Migration Apply Status\s*\n+\s*-?\s*(Migration (?:Applied|Pending|N/A))",
+    re.IGNORECASE,
+)
+_BLOCKED_RE = re.compile(r"^#\s*Blocked\s*$", re.IGNORECASE | re.MULTILINE)
+_PR_TITLE_RE = re.compile(r"##\s*Title\s*\n+\s*-?\s*(.+)$", re.IGNORECASE | re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class DevLoopOutcome:
+    verdict: ReviewVerdict
+    pytest_status: str | None
+    dryrun_status: str | None
+    migration_status: str | None
+    pr_title: str | None
+    blocked: bool
+
+
+def parse_dev_loop(raw: str) -> DevLoopOutcome:
+    if _BLOCKED_RE.search(raw):
+        return DevLoopOutcome(
+            verdict="confirm before merge",
+            pytest_status=None,
+            dryrun_status=None,
+            migration_status=None,
+            pr_title=None,
+            blocked=True,
+        )
+    m = _VERDICT_RE.search(raw)
+    if not m:
+        raise ParseError("Review Verdict 行が見つからない")
+    raw_verdict = m.group(1).lower()
+    verdict: ReviewVerdict
+    if raw_verdict == "safe to merge":
+        verdict = "safe to merge"
+    elif raw_verdict == "fix before merge":
+        verdict = "fix before merge"
+    else:
+        verdict = "confirm before merge"
+
+    return DevLoopOutcome(
+        verdict=verdict,
+        pytest_status=_first(_PYTEST_RE, raw),
+        dryrun_status=_first(_DRYRUN_RE, raw),
+        migration_status=_first(_MIGR_RE, raw),
+        pr_title=_first(_PR_TITLE_RE, raw),
+        blocked=False,
+    )
+
+
+def _first(pattern: re.Pattern[str], raw: str) -> str | None:
+    m = pattern.search(raw)
+    return m.group(1).strip() if m else None

--- a/manager/parsers/packet.py
+++ b/manager/parsers/packet.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import yaml
+
+from . import ParseError
+
+_REQUIRED_KEYS: tuple[str, ...] = (
+    "issue_id",
+    "title",
+    "classification",
+    "scope",
+    "goal",
+    "acceptance_criteria",
+    "constraints",
+    "impacted_areas",
+    "target_tests",
+    "stop_conditions",
+    "out_of_scope",
+)
+
+_FENCE_RE = re.compile(r"```(?:yaml|yml)?\s*\n(.*?)```", re.DOTALL | re.IGNORECASE)
+
+
+def _extract_yaml_block(raw: str) -> str:
+    m = _FENCE_RE.search(raw)
+    if m:
+        return m.group(1)
+    return raw
+
+
+def parse_packet(raw: str) -> dict[str, Any]:
+    text = _extract_yaml_block(raw)
+    try:
+        loaded = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ParseError(f"YAML 解析失敗: {exc}") from exc
+    if not isinstance(loaded, dict):
+        raise ParseError("packet が dict ではない")
+    missing = [k for k in _REQUIRED_KEYS if k not in loaded]
+    if missing:
+        raise ParseError(f"必須フィールド欠落: {missing}")
+    return loaded

--- a/manager/parsers/plan.py
+++ b/manager/parsers/plan.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import re
+
+from . import ParseError
+from ..types import PlanRecommendation
+
+_REC_RE = re.compile(
+    r"#\s*Recommendation\s*\n+\s*-?\s*(proceed with caution|confirm first|proceed)\b",
+    re.IGNORECASE,
+)
+
+
+def parse_plan(raw: str) -> PlanRecommendation:
+    m = _REC_RE.search(raw)
+    if not m:
+        raise ParseError("Recommendation 行が見つからない")
+    value = m.group(1).lower()
+    if value == "proceed":
+        return "proceed"
+    if value == "proceed with caution":
+        return "proceed with caution"
+    return "confirm first"

--- a/manager/parsers/triage.py
+++ b/manager/parsers/triage.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import re
+
+from . import ParseError
+from ..types import TriageReadiness
+
+_READINESS_RE = re.compile(
+    r"#\s*Execution\s+Readiness\s*\n+\s*-\s*(ready|needs-confirmation|do-not-run)\b",
+    re.IGNORECASE,
+)
+_CLASSIFICATION_RE = re.compile(
+    r"#\s*Classification\s*\n+\s*-\s*(auto-fixable|confirm-first|blocked)\b",
+    re.IGNORECASE,
+)
+
+
+def parse_triage(raw: str) -> TriageReadiness:
+    m = _READINESS_RE.search(raw)
+    if not m:
+        raise ParseError("Execution Readiness 行が見つからない")
+    value = m.group(1).lower()
+    if value == "ready":
+        return "ready"
+    if value == "needs-confirmation":
+        return "needs-confirmation"
+    return "do-not-run"
+
+
+def parse_classification(raw: str) -> str | None:
+    m = _CLASSIFICATION_RE.search(raw)
+    return m.group(1).lower() if m else None

--- a/manager/runner.py
+++ b/manager/runner.py
@@ -1,0 +1,523 @@
+"""Manager runner: drives one epic through its state machine.
+
+Synchronous. Side effects only via injected `subagent`, `git_ops`, `escalator`,
+and `state_store` — that's what makes the state machine fully testable with the
+Dummy* implementations.
+"""
+
+from __future__ import annotations
+
+import signal
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterator
+
+from .checkpoints import cost_check, diff_check, kill_switch
+from .escalate import (
+    Escalator,
+    render_epic_done,
+    render_halted,
+    render_needs_human,
+)
+from .git_ops import GitOps, GitOpsError
+from .limits import (
+    EXIT_HALTED,
+    EXIT_NEEDS_HUMAN,
+    EXIT_OK,
+    IMPLEMENT_MAX_ATTEMPTS,
+    PACKETIZE_MAX_ATTEMPTS,
+    PER_STAGE_BUDGET_USD,
+    PLAN_MAX_ATTEMPTS,
+    TRIAGE_MAX_ATTEMPTS,
+    VERIFY_PR_MAX_ATTEMPTS,
+)
+from .parsers import ParseError
+from .parsers.dev_loop import parse_dev_loop
+from .parsers.packet import parse_packet
+from .parsers.plan import parse_plan
+from .parsers.triage import parse_triage
+from .state_store import StateStore
+from .states import is_legal
+from .subagent import Subagent, SubagentResult
+from .types import (
+    ChildState,
+    ChildStatus,
+    EpicState,
+    RetryKey,
+    get_retry,
+    set_retry,
+)
+
+
+class _StopEpic(Exception):
+    """Internal control-flow: bail out of the per-child loop into HALTED."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+Handler = Callable[["Runner", EpicState, ChildState], None]
+
+
+@dataclass
+class Runner:
+    state_store: StateStore
+    subagent: Subagent
+    git_ops: GitOps
+    escalator: Escalator
+    repo_root: Path
+    install_signal_handlers: bool = True
+    _signal_received: bool = field(default=False, init=False, repr=False)
+
+    # ----------------------------------------------------------------- entry
+
+    def run_epic(
+        self,
+        epic_issue: int,
+        slug: str,
+        *,
+        retry_failed: list[int] | None = None,
+    ) -> int:
+        """Run (or resume) one epic. If `retry_failed` is non-empty, those child
+        issue numbers are reset to INIT and put back at the head of the queue.
+        """
+        retry_failed = retry_failed or []
+        with self.state_store.epic_lock(epic_issue):
+            with self._signal_guard():
+                try:
+                    epic = self._init_or_load_epic(epic_issue, slug)
+                except _StopEpic as stop:
+                    return self._finish_halted(_placeholder_epic(epic_issue), stop.reason)
+
+                self._apply_retry_failed(epic, retry_failed)
+                if epic["status"] == "HALTED":
+                    epic["status"] = "RUNNING"
+                    self.state_store.save_epic(epic)
+                    self._log(epic_issue, {"event": "resumed", "queue": epic["children_queue"]})
+                else:
+                    self._log(epic_issue, {"event": "epic_start", "queue": epic["children_queue"]})
+
+                try:
+                    while epic["children_queue"]:
+                        if self._signal_received:
+                            raise _StopEpic("received SIGINT/SIGTERM")
+                        child_issue = epic["children_queue"][0]
+                        epic["current_child"] = child_issue
+                        self.state_store.save_epic(epic)
+                        terminal = self._run_child(epic, child_issue)
+                        self._record_child_outcome(epic, child_issue, terminal)
+                        self.state_store.save_epic(epic)
+                        if terminal == "NEEDS_HUMAN":
+                            return self._finish_needs_human(epic, child_issue)
+                except _StopEpic as stop:
+                    return self._finish_halted(epic, stop.reason)
+                return self._finish_done(epic)
+
+    def _init_or_load_epic(self, epic_issue: int, slug: str) -> EpicState:
+        if self.state_store.epic_path(epic_issue).exists():
+            return self.state_store.load_epic(epic_issue)
+        children = self.git_ops.list_child_issues(epic_issue)
+        if not children:
+            raise _StopEpic(f"no child issues found for epic #{epic_issue}")
+        try:
+            epic_branch = self.git_ops.create_epic_branch(epic_issue, slug)
+        except GitOpsError as exc:
+            raise _StopEpic(f"failed to create epic branch: {exc}") from exc
+        return self.state_store.init_epic(epic_issue, epic_branch, children)
+
+    def _apply_retry_failed(self, epic: EpicState, retry_failed: list[int]) -> None:
+        """Reset specified failed children and put them back at the head of the queue."""
+        for child_issue in retry_failed:
+            if child_issue not in epic["children_failed"]:
+                continue
+            child_path = self.state_store.child_path(epic["epic_issue_number"], child_issue)
+            if child_path.exists():
+                child_path.unlink()
+            bak = child_path.with_suffix(child_path.suffix + ".bak")
+            if bak.exists():
+                bak.unlink()
+            epic["children_failed"].remove(child_issue)
+            epic["children_queue"].insert(0, child_issue)
+            self._log(
+                epic["epic_issue_number"],
+                {"event": "retry_failed", "child": child_issue},
+            )
+
+    # ------------------------------------------------------------ per child
+
+    def _run_child(self, epic: EpicState, child_issue: int) -> ChildStatus:
+        epic_n = epic["epic_issue_number"]
+        if self.state_store.child_path(epic_n, child_issue).exists():
+            child = self.state_store.load_child(epic_n, child_issue)
+        else:
+            try:
+                branch = self.git_ops.create_child_branch(epic["epic_branch"], child_issue)
+            except GitOpsError as exc:
+                child = self.state_store.init_child(epic_n, child_issue, branch="")
+                child["needs_human_reason"] = f"create_child_branch failed: {exc}"
+                self.transition(epic, child, "NEEDS_HUMAN")
+                return "NEEDS_HUMAN"
+            child = self.state_store.init_child(epic_n, child_issue, branch)
+
+        if child["status"] == "INIT":
+            self.transition(epic, child, "TRIAGE")
+
+        while child["status"] not in {"DONE", "SKIPPED", "NEEDS_HUMAN"}:
+            self._guard_checkpoints(epic, child)
+            handler = _HANDLERS[child["status"]]
+            handler(self, epic, child)
+
+        return child["status"]
+
+    # --------------------------------------------------------- checkpoints
+
+    def _guard_checkpoints(self, epic: EpicState, child: ChildState) -> None:
+        kill = kill_switch(self.repo_root)
+        if kill.tripped:
+            raise _StopEpic(kill.reason)
+        cost = cost_check(epic["cost_usd"])
+        if cost.tripped:
+            raise _StopEpic(cost.reason)
+        diff = diff_check(self.git_ops.diff_lines(epic["epic_branch"]))
+        if diff.tripped:
+            child["needs_human_reason"] = diff.reason
+            self.transition(epic, child, "NEEDS_HUMAN")
+
+    # ------------------------------------------------------------- helpers
+
+    def transition(self, epic: EpicState, child: ChildState, dst: ChildStatus) -> None:
+        src = child["status"]
+        if src == dst:
+            return
+        if not is_legal(src, dst):
+            raise AssertionError(f"illegal transition: {src} -> {dst}")
+        child["status"] = dst
+        self.state_store.save_child(epic["epic_issue_number"], child)
+        self._log(
+            epic["epic_issue_number"],
+            {"event": "transition", "child": child["issue_number"], "from": src, "to": dst},
+        )
+
+    def record_subagent(
+        self,
+        epic: EpicState,
+        child: ChildState,
+        slash: str,
+        result: SubagentResult,
+        artifact_name: str,
+    ) -> Path:
+        child["cost_usd"] += result.cost_usd
+        epic["cost_usd"] += result.cost_usd
+        path = self.state_store.write_artifact(
+            epic["epic_issue_number"],
+            child["issue_number"],
+            artifact_name,
+            result.raw_stdout,
+        )
+        child["artifacts"][artifact_name] = str(path.relative_to(self.state_store.root))
+        self.state_store.save_child(epic["epic_issue_number"], child)
+        self.state_store.save_epic(epic)
+        self._log(
+            epic["epic_issue_number"],
+            {
+                "event": "subagent",
+                "child": child["issue_number"],
+                "slash": slash,
+                "exit_code": result.exit_code,
+                "session_id": result.session_id,
+                "cost_usd": result.cost_usd,
+            },
+        )
+        return path
+
+    def _record_child_outcome(
+        self,
+        epic: EpicState,
+        child_issue: int,
+        terminal: ChildStatus,
+    ) -> None:
+        if epic["children_queue"] and epic["children_queue"][0] == child_issue:
+            epic["children_queue"].pop(0)
+        if terminal == "DONE":
+            epic["children_done"].append(child_issue)
+        elif terminal == "SKIPPED":
+            epic["children_skipped"].append(child_issue)
+        elif terminal == "NEEDS_HUMAN":
+            epic["children_failed"].append(child_issue)
+        epic["current_child"] = None
+
+    def _log(self, epic_issue: int, event: dict[str, object]) -> None:
+        self.state_store.append_log(epic_issue, event)
+
+    # --------------------------------------------------------- signals
+
+    @contextmanager
+    def _signal_guard(self) -> Iterator[None]:
+        """Install SIGINT/SIGTERM handlers that flip a flag instead of killing.
+
+        The flag is checked before each child so the current handler completes
+        and state is saved before exit. Restored on context exit.
+        """
+        if not self.install_signal_handlers:
+            yield
+            return
+        prev_int = signal.getsignal(signal.SIGINT)
+        prev_term = signal.getsignal(signal.SIGTERM)
+
+        def _flip(_signum: int, _frame: object) -> None:
+            self._signal_received = True
+
+        try:
+            signal.signal(signal.SIGINT, _flip)
+            signal.signal(signal.SIGTERM, _flip)
+            yield
+        finally:
+            signal.signal(signal.SIGINT, prev_int)
+            signal.signal(signal.SIGTERM, prev_term)
+            self._signal_received = False
+
+    # --------------------------------------------------------- terminations
+
+    def _finish_needs_human(self, epic: EpicState, child_issue: int) -> int:
+        epic["status"] = "HALTED"
+        self.state_store.save_epic(epic)
+        child = self.state_store.load_child(epic["epic_issue_number"], child_issue)
+        body = render_needs_human(
+            epic_issue=epic["epic_issue_number"],
+            child_issue=child_issue,
+            state_path=self._repo_relative_path(
+                self.state_store.child_path(epic["epic_issue_number"], child_issue)
+            ),
+            failed_state=child["status"],
+            last_verdict=child["last_verdict"],
+            detail=child["needs_human_reason"] or "(no detail)",
+        )
+        self.escalator.comment(epic["epic_issue_number"], body)
+        return EXIT_NEEDS_HUMAN
+
+    def _repo_relative_path(self, path: Path) -> str:
+        try:
+            return str(path.relative_to(self.repo_root))
+        except ValueError:
+            return str(path)
+
+    def _finish_halted(self, epic: EpicState, reason: str) -> int:
+        epic["status"] = "HALTED"
+        if epic["epic_issue_number"]:
+            self.state_store.save_epic(epic)
+        self.escalator.comment(
+            epic["epic_issue_number"], render_halted(epic["epic_issue_number"], reason)
+        )
+        return EXIT_HALTED
+
+    def _finish_done(self, epic: EpicState) -> int:
+        epic["status"] = "DONE"
+        self.state_store.save_epic(epic)
+        self.escalator.comment(
+            epic["epic_issue_number"],
+            render_epic_done(
+                epic["epic_issue_number"],
+                epic["children_done"],
+                epic["children_skipped"],
+            ),
+        )
+        return EXIT_OK
+
+
+# ============================================================
+# State handlers
+# ============================================================
+
+
+def _handle_triage(runner: Runner, epic: EpicState, child: ChildState) -> None:
+    body = runner.git_ops.fetch_issue_body(child["issue_number"])
+    runner.state_store.write_artifact(
+        epic["epic_issue_number"], child["issue_number"], "issue.txt", body
+    )
+    result = runner.subagent.invoke("/triage-issue", body, PER_STAGE_BUDGET_USD)
+    runner.record_subagent(epic, child, "/triage-issue", result, "triage.md")
+    if result.exit_code != 0:
+        _retry_or_escalate(
+            runner, epic, child,
+            key="triage", limit=TRIAGE_MAX_ATTEMPTS,
+            reason="triage exit_code != 0",
+        )
+        return
+    try:
+        readiness = parse_triage(result.raw_stdout)
+    except ParseError as exc:
+        child["needs_human_reason"] = f"triage parse failed: {exc}"
+        runner.transition(epic, child, "NEEDS_HUMAN")
+        return
+    if readiness == "ready":
+        runner.transition(epic, child, "PACKETIZE")
+    elif readiness == "do-not-run":
+        runner.transition(epic, child, "SKIPPED")
+    else:
+        child["needs_human_reason"] = "triage readiness=needs-confirmation"
+        runner.transition(epic, child, "NEEDS_HUMAN")
+
+
+def _handle_packetize(runner: Runner, epic: EpicState, child: ChildState) -> None:
+    issue_path = runner.state_store.child_dir(
+        epic["epic_issue_number"], child["issue_number"]
+    ) / "issue.txt"
+    body = issue_path.read_text(encoding="utf-8") if issue_path.exists() else ""
+    result = runner.subagent.invoke("/make-execution-packet", body, PER_STAGE_BUDGET_USD)
+    runner.record_subagent(epic, child, "/make-execution-packet", result, "packet.yaml")
+    if result.exit_code != 0:
+        _retry_or_escalate(
+            runner, epic, child,
+            key="packetize", limit=PACKETIZE_MAX_ATTEMPTS,
+            reason="packetize exit_code != 0",
+        )
+        return
+    try:
+        parse_packet(result.raw_stdout)
+    except ParseError as exc:
+        child["needs_human_reason"] = f"packet parse failed: {exc}"
+        runner.transition(epic, child, "NEEDS_HUMAN")
+        return
+    runner.transition(epic, child, "PLAN")
+
+
+def _handle_plan(runner: Runner, epic: EpicState, child: ChildState) -> None:
+    packet_path = runner.state_store.child_dir(
+        epic["epic_issue_number"], child["issue_number"]
+    ) / "packet.yaml"
+    packet = packet_path.read_text(encoding="utf-8") if packet_path.exists() else ""
+    result = runner.subagent.invoke("/spec-architect", packet, PER_STAGE_BUDGET_USD)
+    runner.record_subagent(epic, child, "/spec-architect", result, "plan.md")
+    if result.exit_code != 0:
+        _retry_or_escalate(
+            runner, epic, child,
+            key="plan", limit=PLAN_MAX_ATTEMPTS,
+            reason="plan exit_code != 0",
+        )
+        return
+    try:
+        rec = parse_plan(result.raw_stdout)
+    except ParseError as exc:
+        _retry_or_escalate(
+            runner, epic, child,
+            key="plan", limit=PLAN_MAX_ATTEMPTS,
+            reason=f"plan parse failed: {exc}",
+        )
+        return
+    if rec == "proceed":
+        runner.transition(epic, child, "IMPLEMENT")
+    else:
+        child["needs_human_reason"] = f"plan recommendation={rec}"
+        runner.transition(epic, child, "NEEDS_HUMAN")
+
+
+def _handle_implement(runner: Runner, epic: EpicState, child: ChildState) -> None:
+    packet_path = runner.state_store.child_dir(
+        epic["epic_issue_number"], child["issue_number"]
+    ) / "packet.yaml"
+    packet = packet_path.read_text(encoding="utf-8") if packet_path.exists() else ""
+    result = runner.subagent.invoke("/run-dev-loop", packet, PER_STAGE_BUDGET_USD)
+    runner.record_subagent(epic, child, "/run-dev-loop", result, "dev_loop.md")
+    if result.exit_code != 0:
+        _retry_or_escalate(
+            runner, epic, child,
+            key="implement", limit=IMPLEMENT_MAX_ATTEMPTS,
+            reason="dev-loop exit_code != 0",
+        )
+        return
+    try:
+        outcome = parse_dev_loop(result.raw_stdout)
+    except ParseError as exc:
+        child["needs_human_reason"] = f"dev-loop parse failed: {exc}"
+        runner.transition(epic, child, "NEEDS_HUMAN")
+        return
+    child["last_verdict"] = outcome.verdict
+    runner.state_store.save_child(epic["epic_issue_number"], child)
+    if outcome.verdict == "safe to merge":
+        runner.transition(epic, child, "VERIFY_PR")
+    elif outcome.verdict == "fix before merge":
+        _retry_or_escalate(
+            runner, epic, child,
+            key="implement", limit=IMPLEMENT_MAX_ATTEMPTS,
+            reason="verdict=fix before merge",
+        )
+    else:
+        child["needs_human_reason"] = f"verdict={outcome.verdict}"
+        runner.transition(epic, child, "NEEDS_HUMAN")
+
+
+def _handle_verify_pr(runner: Runner, epic: EpicState, child: ChildState) -> None:
+    url = runner.git_ops.find_pr_url(child["branch"], epic["epic_branch"])
+    if url is None:
+        if child["retry"]["verify_pr"] >= VERIFY_PR_MAX_ATTEMPTS:
+            child["needs_human_reason"] = "PR not found after retries"
+            runner.transition(epic, child, "NEEDS_HUMAN")
+            return
+        child["retry"]["verify_pr"] += 1
+        runner.state_store.save_child(epic["epic_issue_number"], child)
+        return
+    child["pr_url"] = url
+    # /pr-creation hard-codes `--base main`; retarget to the epic branch so the
+    # epic accumulates child PRs as designed. Soft-fail: a failed retarget logs
+    # but doesn't escalate (the PR still exists, just on the wrong base).
+    retargeted = runner.git_ops.retarget_pr(url, epic["epic_branch"])
+    runner._log(
+        epic["epic_issue_number"],
+        {
+            "event": "pr_retarget",
+            "child": child["issue_number"],
+            "pr_url": url,
+            "new_base": epic["epic_branch"],
+            "ok": retargeted,
+        },
+    )
+    runner.transition(epic, child, "DONE")
+
+
+_HANDLERS: dict[ChildStatus, Handler] = {
+    "TRIAGE": _handle_triage,
+    "PACKETIZE": _handle_packetize,
+    "PLAN": _handle_plan,
+    "IMPLEMENT": _handle_implement,
+    "VERIFY_PR": _handle_verify_pr,
+}
+
+
+def _retry_or_escalate(
+    runner: Runner,
+    epic: EpicState,
+    child: ChildState,
+    *,
+    key: RetryKey,
+    limit: int,
+    reason: str,
+) -> None:
+    """Increment the retry counter for `key`. If the limit is reached, escalate."""
+    current = get_retry(child["retry"], key)
+    if current >= limit:
+        child["needs_human_reason"] = f"{reason} (retry exhausted: {key}={current}/{limit})"
+        runner.transition(epic, child, "NEEDS_HUMAN")
+        return
+    set_retry(child["retry"], key, current + 1)
+    runner.state_store.save_child(epic["epic_issue_number"], child)
+
+
+def _placeholder_epic(epic_issue: int) -> EpicState:
+    placeholder: EpicState = {
+        "epic_issue_number": epic_issue,
+        "epic_branch": "",
+        "status": "HALTED",
+        "children_queue": [],
+        "children_done": [],
+        "children_skipped": [],
+        "children_failed": [],
+        "current_child": None,
+        "started_at": "",
+        "updated_at": "",
+        "cost_usd": 0.0,
+        "diff_lines": 0,
+        "schema_version": 1,
+    }
+    return placeholder

--- a/manager/state_store.py
+++ b/manager/state_store.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+from .limits import SCHEMA_VERSION
+from .types import ChildState, EpicState, RetryCounters
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _atomic_write(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    bak = path.with_suffix(path.suffix + ".bak")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    if path.exists():
+        os.replace(path, bak)
+    os.replace(tmp, path)
+
+
+def _safe_read(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, FileNotFoundError):
+        bak = path.with_suffix(path.suffix + ".bak")
+        if bak.exists():
+            return json.loads(bak.read_text(encoding="utf-8"))
+        raise
+
+
+class LockTaken(Exception):
+    """Another Manager process holds the epic lock."""
+
+
+class StateStore:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+
+    def epic_dir(self, epic_issue: int) -> Path:
+        return self.root / f"epic-{epic_issue}"
+
+    def epic_path(self, epic_issue: int) -> Path:
+        return self.epic_dir(epic_issue) / "epic.json"
+
+    def child_dir(self, epic_issue: int, child_issue: int) -> Path:
+        return self.epic_dir(epic_issue) / "children" / f"child-{child_issue}"
+
+    def child_path(self, epic_issue: int, child_issue: int) -> Path:
+        return self.child_dir(epic_issue, child_issue) / "state.json"
+
+    def lock_path(self, epic_issue: int) -> Path:
+        return self.epic_dir(epic_issue) / "lock"
+
+    def log_path(self, epic_issue: int) -> Path:
+        return self.epic_dir(epic_issue) / "log.jsonl"
+
+    def init_epic(
+        self,
+        epic_issue: int,
+        epic_branch: str,
+        children: list[int],
+    ) -> EpicState:
+        ts = now_iso()
+        state: EpicState = {
+            "epic_issue_number": epic_issue,
+            "epic_branch": epic_branch,
+            "status": "RUNNING",
+            "children_queue": list(children),
+            "children_done": [],
+            "children_skipped": [],
+            "children_failed": [],
+            "current_child": None,
+            "started_at": ts,
+            "updated_at": ts,
+            "cost_usd": 0.0,
+            "diff_lines": 0,
+            "schema_version": SCHEMA_VERSION,
+        }
+        self.save_epic(state)
+        return state
+
+    def load_epic(self, epic_issue: int) -> EpicState:
+        return _coerce_epic(_safe_read(self.epic_path(epic_issue)))
+
+    def save_epic(self, state: EpicState) -> None:
+        state["updated_at"] = now_iso()
+        _atomic_write(self.epic_path(state["epic_issue_number"]), dict(state))
+
+    def init_child(self, epic_issue: int, child_issue: int, branch: str) -> ChildState:
+        ts = now_iso()
+        retry: RetryCounters = {
+            "plan": 0,
+            "implement": 0,
+            "triage": 0,
+            "packetize": 0,
+            "verify_pr": 0,
+        }
+        state: ChildState = {
+            "issue_number": child_issue,
+            "branch": branch,
+            "status": "INIT",
+            "started_at": ts,
+            "updated_at": ts,
+            "retry": retry,
+            "last_verdict": None,
+            "pr_url": None,
+            "needs_human_reason": None,
+            "artifacts": {},
+            "cost_usd": 0.0,
+        }
+        self.save_child(epic_issue, state)
+        return state
+
+    def load_child(self, epic_issue: int, child_issue: int) -> ChildState:
+        return _coerce_child(_safe_read(self.child_path(epic_issue, child_issue)))
+
+    def save_child(self, epic_issue: int, state: ChildState) -> None:
+        state["updated_at"] = now_iso()
+        _atomic_write(self.child_path(epic_issue, state["issue_number"]), dict(state))
+
+    def write_artifact(
+        self,
+        epic_issue: int,
+        child_issue: int,
+        name: str,
+        content: str,
+    ) -> Path:
+        path = self.child_dir(epic_issue, child_issue) / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def append_log(self, epic_issue: int, event: dict[str, Any]) -> None:
+        record = dict(event)
+        record["ts"] = now_iso()
+        path = self.log_path(epic_issue)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fp:
+            fp.write(json.dumps(record, sort_keys=True) + "\n")
+
+    @contextmanager
+    def epic_lock(self, epic_issue: int) -> Iterator[None]:
+        path = self.lock_path(epic_issue)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fp = path.open("a+")
+        try:
+            fcntl.flock(fp.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            fp.close()
+            raise LockTaken(f"epic-{epic_issue} lock taken") from exc
+        try:
+            fp.seek(0)
+            fp.truncate()
+            fp.write(str(os.getpid()))
+            fp.flush()
+            yield
+        finally:
+            try:
+                fcntl.flock(fp.fileno(), fcntl.LOCK_UN)
+            finally:
+                fp.close()
+
+
+def _coerce_epic(raw: dict[str, Any]) -> EpicState:
+    state: EpicState = {
+        "epic_issue_number": int(raw["epic_issue_number"]),
+        "epic_branch": str(raw["epic_branch"]),
+        "status": raw["status"],
+        "children_queue": [int(x) for x in raw.get("children_queue", [])],
+        "children_done": [int(x) for x in raw.get("children_done", [])],
+        "children_skipped": [int(x) for x in raw.get("children_skipped", [])],
+        "children_failed": [int(x) for x in raw.get("children_failed", [])],
+        "current_child": (int(raw["current_child"]) if raw.get("current_child") is not None else None),
+        "started_at": str(raw["started_at"]),
+        "updated_at": str(raw["updated_at"]),
+        "cost_usd": float(raw.get("cost_usd", 0.0)),
+        "diff_lines": int(raw.get("diff_lines", 0)),
+        "schema_version": int(raw.get("schema_version", 1)),
+    }
+    return state
+
+
+def _coerce_child(raw: dict[str, Any]) -> ChildState:
+    retry_raw = raw.get("retry", {})
+    retry: RetryCounters = {
+        "plan": int(retry_raw.get("plan", 0)),
+        "implement": int(retry_raw.get("implement", 0)),
+        "triage": int(retry_raw.get("triage", 0)),
+        "packetize": int(retry_raw.get("packetize", 0)),
+        "verify_pr": int(retry_raw.get("verify_pr", 0)),
+    }
+    state: ChildState = {
+        "issue_number": int(raw["issue_number"]),
+        "branch": str(raw["branch"]),
+        "status": raw["status"],
+        "started_at": str(raw["started_at"]),
+        "updated_at": str(raw["updated_at"]),
+        "retry": retry,
+        "last_verdict": raw.get("last_verdict"),
+        "pr_url": raw.get("pr_url"),
+        "needs_human_reason": raw.get("needs_human_reason"),
+        "artifacts": dict(raw.get("artifacts", {})),
+        "cost_usd": float(raw.get("cost_usd", 0.0)),
+    }
+    return state

--- a/manager/states.py
+++ b/manager/states.py
@@ -1,0 +1,55 @@
+"""State machine definition.
+
+Pure data: every transition condition is encoded here as a name. The runner is
+responsible for *evaluating* the conditions; this module is responsible only for
+declaring which transitions are *legal*. That split is what lets us assert in
+tests that no illegal transition exists in the codebase.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .types import ChildStatus
+
+TERMINAL_STATES: frozenset[ChildStatus] = frozenset({"DONE", "SKIPPED", "NEEDS_HUMAN"})
+
+
+@dataclass(frozen=True)
+class Transition:
+    src: ChildStatus
+    dst: ChildStatus
+    condition: str
+
+
+LEGAL_TRANSITIONS: tuple[Transition, ...] = (
+    Transition("INIT", "TRIAGE", "branch created"),
+    Transition("INIT", "NEEDS_HUMAN", "git ops failed"),
+
+    Transition("TRIAGE", "PACKETIZE", "readiness=ready"),
+    Transition("TRIAGE", "NEEDS_HUMAN", "readiness=needs-confirmation"),
+    Transition("TRIAGE", "SKIPPED", "readiness=do-not-run"),
+    Transition("TRIAGE", "TRIAGE", "retry within budget"),
+    Transition("TRIAGE", "NEEDS_HUMAN", "triage retry exhausted"),
+
+    Transition("PACKETIZE", "PLAN", "packet parsed"),
+    Transition("PACKETIZE", "NEEDS_HUMAN", "packet parse failed"),
+
+    Transition("PLAN", "IMPLEMENT", "recommendation=proceed"),
+    Transition("PLAN", "NEEDS_HUMAN", "recommendation=confirm first"),
+    Transition("PLAN", "PLAN", "plan retry within budget"),
+    Transition("PLAN", "NEEDS_HUMAN", "plan retry exhausted"),
+
+    Transition("IMPLEMENT", "VERIFY_PR", "verdict=safe to merge"),
+    Transition("IMPLEMENT", "IMPLEMENT", "verdict=fix before merge, retry"),
+    Transition("IMPLEMENT", "NEEDS_HUMAN", "verdict=confirm before merge"),
+    Transition("IMPLEMENT", "NEEDS_HUMAN", "implement retry exhausted"),
+
+    Transition("VERIFY_PR", "DONE", "PR found"),
+    Transition("VERIFY_PR", "VERIFY_PR", "PR not found, retry"),
+    Transition("VERIFY_PR", "NEEDS_HUMAN", "verify_pr retry exhausted"),
+)
+
+
+def is_legal(src: ChildStatus, dst: ChildStatus) -> bool:
+    return any(t.src == src and t.dst == dst for t in LEGAL_TRANSITIONS)

--- a/manager/subagent.py
+++ b/manager/subagent.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from ._subprocess import CommandTimeout, run
+from .limits import NETWORK_BACKOFF_SECONDS, SUBAGENT_TIMEOUT_SECONDS
+
+_ENV_DENYLIST_PREFIXES: tuple[str, ...] = ("ANTHROPIC_",)
+
+
+def sanitized_env() -> dict[str, str]:
+    """Parent env minus any `ANTHROPIC_*` keys.
+
+    The Manager's RealSubagent uses Claude Code OAuth (Max plan via macOS
+    keychain). If `ANTHROPIC_API_KEY` ever leaks into the spawned `claude -p`
+    env (e.g. via `.env` auto-discovery, a parent harness, or a hook), the
+    inner subagent silently switches to API key billing. Stripping the
+    `ANTHROPIC_*` namespace defends against that.
+    """
+    return {
+        k: v for k, v in os.environ.items()
+        if not any(k.startswith(p) for p in _ENV_DENYLIST_PREFIXES)
+    }
+
+_TRANSIENT_STDERR_RE = re.compile(
+    r"rate.?limit|429|503|504|temporarily unavailable|connection reset|"
+    r"socket hang up|ETIMEDOUT|ECONNRESET|Anthropic.{0,40}overloaded",
+    re.IGNORECASE,
+)
+
+
+def is_transient_failure(exit_code: int, stderr: str) -> bool:
+    if exit_code == 0:
+        return False
+    return bool(_TRANSIENT_STDERR_RE.search(stderr))
+
+
+@dataclass(frozen=True)
+class SubagentResult:
+    exit_code: int
+    raw_stdout: str
+    raw_stderr: str
+    cost_usd: float
+    session_id: str
+
+
+class Subagent(Protocol):
+    def invoke(self, slash: str, args_text: str, budget_usd: float) -> SubagentResult: ...
+
+
+class DummySubagent:
+    """Returns scripted responses keyed by slash command. Used by tests."""
+
+    def __init__(self, scripted: dict[str, list[SubagentResult]]) -> None:
+        self._scripted: dict[str, list[SubagentResult]] = {
+            slash: list(responses) for slash, responses in scripted.items()
+        }
+        self.calls: list[tuple[str, str, float]] = []
+
+    def invoke(self, slash: str, args_text: str, budget_usd: float) -> SubagentResult:
+        self.calls.append((slash, args_text, budget_usd))
+        queue = self._scripted.get(slash, [])
+        if not queue:
+            raise RuntimeError(f"DummySubagent: no scripted response for {slash}")
+        return queue.pop(0)
+
+
+def make_result(
+    raw_stdout: str,
+    *,
+    exit_code: int = 0,
+    cost_usd: float = 0.05,
+    session_id: str = "00000000-0000-0000-0000-000000000000",
+    raw_stderr: str = "",
+) -> SubagentResult:
+    """Convenience constructor for tests / fixtures."""
+    return SubagentResult(
+        exit_code=exit_code,
+        raw_stdout=raw_stdout,
+        raw_stderr=raw_stderr,
+        cost_usd=cost_usd,
+        session_id=session_id,
+    )
+
+
+def build_invocation_prompt(slash: str, args_text: str) -> str:
+    """The exact prompt format used to invoke any of the existing slash commands.
+
+    Matches the template in `.claude/skills/orchestrator.md` so the subagent
+    behaves identically whether invoked by `/orchestrate` (LLM router) or by
+    Manager (state machine).
+    """
+    name = slash.lstrip("/")
+    return (
+        f"あなたは /{name} として動作する。\n"
+        f"以下の command ファイルを最初に Read tool で読み、"
+        f"その Required Reading セクションに書かれた全ファイルを読んでから開始すること。\n"
+        f"- .claude/commands/{name}.md\n"
+        f"\n"
+        f"入力 ($ARGUMENTS):\n"
+        f"{args_text}\n"
+        f"\n"
+        f"出力は .claude/commands/{name}.md の Output Format に厳密に従うこと。\n"
+    )
+
+
+@dataclass
+class RealSubagent:
+    """Phase 3+ implementation: shells out to `claude -p`.
+
+    Defaults are tuned to keep cost on the Claude Code OAuth (Max plan) path:
+
+    - `--bare`: skip CLAUDE.md auto-discovery, hooks, MCP, attribution. With
+      `--bare` set AND `ANTHROPIC_API_KEY` removed from env, claude must use
+      the keychain OAuth credential — nothing else is consulted.
+    - `env=sanitized_env()`: strip `ANTHROPIC_*` from the spawned env so a
+      stray `.env` line or parent injection can't silently switch billing to
+      API credit.
+    - `--dangerously-skip-permissions`: required because non-interactive `-p`
+      mode can't surface a tool-permission prompt. Manager's own kill-switch /
+      cost / diff limit / NEEDS_HUMAN escalation is the safety net.
+    - `--output-format=json`: gives us `result` (text), `total_cost_usd`, and
+      `session_id` for telemetry.
+    - `--no-session-persistence`: failed runs leave nothing on disk.
+    """
+
+    repo_root: Path
+    claude_bin: str = "claude"
+    timeout: int = SUBAGENT_TIMEOUT_SECONDS
+    extra_add_dirs: tuple[Path, ...] = ()
+    dangerously_skip_permissions: bool = True
+    bare: bool = True
+
+    def invoke(self, slash: str, args_text: str, budget_usd: float) -> SubagentResult:
+        session_id = str(uuid.uuid4())
+        prompt = build_invocation_prompt(slash, args_text)
+        argv = self._build_argv(session_id, budget_usd)
+        result = self._run_with_transient_backoff(argv, prompt)
+        if isinstance(result, CommandTimeout):
+            return SubagentResult(
+                exit_code=124,
+                raw_stdout="",
+                raw_stderr=str(result),
+                cost_usd=0.0,
+                session_id=session_id,
+            )
+        if result.exit_code != 0:
+            return SubagentResult(
+                exit_code=result.exit_code,
+                raw_stdout=result.stdout,
+                raw_stderr=result.stderr,
+                cost_usd=0.0,
+                session_id=session_id,
+            )
+        text, cost, returned_session = _decode_claude_json(result.stdout)
+        return SubagentResult(
+            exit_code=0,
+            raw_stdout=text,
+            raw_stderr=result.stderr,
+            cost_usd=cost,
+            session_id=returned_session or session_id,
+        )
+
+    def _run_with_transient_backoff(self, argv: list[str], prompt: str):  # type: ignore[no-untyped-def]
+        """Retry on transient stderr patterns (429 / 5xx / connection reset).
+
+        Permanent failures (auth, bad args, schema mismatch) come back fast
+        without matching `_TRANSIENT_STDERR_RE` and are returned as-is.
+        """
+        env = sanitized_env()
+        last = None
+        attempts = len(NETWORK_BACKOFF_SECONDS)
+        for attempt, delay in enumerate(NETWORK_BACKOFF_SECONDS):
+            try:
+                result = run(argv, stdin=prompt, timeout=self.timeout, env=env)
+            except CommandTimeout as exc:
+                return exc
+            if not is_transient_failure(result.exit_code, result.stderr):
+                return result
+            last = result
+            if attempt < attempts - 1:
+                time.sleep(delay)
+        assert last is not None
+        return last
+
+    def _build_argv(self, session_id: str, budget_usd: float) -> list[str]:
+        argv: list[str] = [
+            self.claude_bin,
+            "-p",
+            "--output-format", "json",
+            "--input-format", "text",
+            "--no-session-persistence",
+            "--max-budget-usd", f"{budget_usd}",
+            "--session-id", session_id,
+            "--add-dir", str(self.repo_root),
+        ]
+        if self.bare:
+            argv.append("--bare")
+        if self.dangerously_skip_permissions:
+            argv.append("--dangerously-skip-permissions")
+        for extra in self.extra_add_dirs:
+            argv.extend(["--add-dir", str(extra)])
+        return argv
+
+
+def _decode_claude_json(stdout: str) -> tuple[str, float, str | None]:
+    """Extract `result`, `total_cost_usd`, `session_id` from `claude -p --output-format json`.
+
+    Defensive: if the wrapper schema changes, fall back to treating stdout as raw text.
+    """
+    stripped = stdout.strip()
+    if not stripped:
+        return "", 0.0, None
+    try:
+        payload = json.loads(stripped)
+    except json.JSONDecodeError:
+        return stdout, 0.0, None
+    if not isinstance(payload, dict):
+        return stdout, 0.0, None
+    text_value = payload.get("result")
+    text = text_value if isinstance(text_value, str) else stdout
+    cost_raw = payload.get("total_cost_usd", 0.0)
+    cost = float(cost_raw) if isinstance(cost_raw, (int, float)) else 0.0
+    session_raw = payload.get("session_id")
+    session = session_raw if isinstance(session_raw, str) else None
+    return text, cost, session

--- a/manager/tests/conftest.py
+++ b/manager/tests/conftest.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def fixtures_dir() -> Path:
+    return FIXTURES
+
+
+@pytest.fixture
+def state_root(tmp_path: Path) -> Iterator[Path]:
+    root = tmp_path / "state"
+    root.mkdir()
+    yield root
+
+
+@pytest.fixture
+def repo_root(tmp_path: Path) -> Iterator[Path]:
+    """Isolated repo_root so kill-switch checks don't see real `.claude/STOP`."""
+    root = tmp_path / "repo"
+    (root / ".claude").mkdir(parents=True)
+    yield root
+
+
+def load_fixture(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")

--- a/manager/tests/fixtures/dev_loop_blocked.md
+++ b/manager/tests/fixtures/dev_loop_blocked.md
@@ -1,0 +1,9 @@
+# Blocked
+## Reason
+unknown migration apply window
+
+## What Needs Human Confirmation
+operational window for ALTER
+
+## Current Status
+pytest pending

--- a/manager/tests/fixtures/dev_loop_confirm.md
+++ b/manager/tests/fixtures/dev_loop_confirm.md
@@ -1,0 +1,14 @@
+# Implementation Summary
+## Pytest Status
+- Pytest Passed
+## Dry-run Status
+- Dry-run Passed
+## Migration Apply Status
+- Migration Pending
+
+# Review Verdict
+- confirm before merge
+
+# PR Summary
+## Title
+- chore: pending migration

--- a/manager/tests/fixtures/dev_loop_fix.md
+++ b/manager/tests/fixtures/dev_loop_fix.md
@@ -1,0 +1,14 @@
+# Implementation Summary
+## Pytest Status
+- Pytest Failed
+## Dry-run Status
+- Dry-run Not Run
+## Migration Apply Status
+- Migration N/A
+
+# Review Verdict
+- fix before merge
+
+# PR Summary
+## Title
+- (not created)

--- a/manager/tests/fixtures/dev_loop_safe.md
+++ b/manager/tests/fixtures/dev_loop_safe.md
@@ -1,0 +1,24 @@
+# Plan
+small change
+
+# Implementation Summary
+## Affected Areas
+- fetchers/example.py
+
+## Pytest Status
+- Pytest Passed
+## Dry-run Status
+- Dry-run Passed
+## Migration Apply Status
+- Migration N/A
+
+# Review Verdict
+- safe to merge
+
+# Review Notes
+
+# PR Summary
+## Title
+- feat: add example fetcher
+## Summary
+small fetcher

--- a/manager/tests/fixtures/packet_minimal.md
+++ b/manager/tests/fixtures/packet_minimal.md
@@ -1,0 +1,20 @@
+```yaml
+issue_id: 101
+title: "add example fetcher"
+classification: auto-fixable
+scope: small
+goal: "implement a tiny new fetcher"
+acceptance_criteria:
+  - "new fetcher returns Article list"
+  - "pytest passes"
+constraints:
+  - "no new external API"
+impacted_areas:
+  - fetchers/
+target_tests:
+  - tests/fetchers/test_example.py
+stop_conditions:
+  - "YouTube search.list newly required"
+out_of_scope:
+  - unrelated refactor
+```

--- a/manager/tests/fixtures/plan_confirm.md
+++ b/manager/tests/fixtures/plan_confirm.md
@@ -1,0 +1,5 @@
+# Goal
+HMAC rotation
+
+# Recommendation
+- confirm first

--- a/manager/tests/fixtures/plan_proceed.md
+++ b/manager/tests/fixtures/plan_proceed.md
@@ -1,0 +1,12 @@
+# Goal
+add fetcher
+
+# Acceptance Criteria
+- pytest passes
+
+# Minimal Plan
+- new file
+- 1 test
+
+# Recommendation
+- proceed

--- a/manager/tests/fixtures/triage_needs_confirmation.md
+++ b/manager/tests/fixtures/triage_needs_confirmation.md
@@ -1,0 +1,11 @@
+# Classification
+- confirm-first
+
+# Scope
+- medium
+
+# Why
+HMAC rotation hint detected.
+
+# Execution Readiness
+- needs-confirmation

--- a/manager/tests/fixtures/triage_ready.md
+++ b/manager/tests/fixtures/triage_ready.md
@@ -1,0 +1,17 @@
+# Classification
+- auto-fixable
+
+# Scope
+- small
+
+# Risk Flags
+
+# Why
+small fetcher addition, no schema change
+
+# Missing Information
+
+# Blocking Question
+
+# Execution Readiness
+- ready

--- a/manager/tests/fixtures/triage_skip.md
+++ b/manager/tests/fixtures/triage_skip.md
@@ -1,0 +1,14 @@
+# Classification
+- blocked
+
+# Scope
+- large
+
+# Risk Flags
+- schema-breaking
+
+# Why
+DROP COLUMN required.
+
+# Execution Readiness
+- do-not-run

--- a/manager/tests/test_escalate_real.py
+++ b/manager/tests/test_escalate_real.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence
+
+import pytest
+
+from manager import escalate as esc_mod
+from manager._subprocess import CommandResult
+from manager.escalate import RealEscalator
+from manager.git_ops import GitOpsError
+
+
+def _patch(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    exit_code: int = 0,
+    stderr: str = "",
+) -> dict[str, object]:
+    captured: dict[str, object] = {}
+
+    def fake_run(
+        argv: Sequence[str],
+        *,
+        stdin: str | None = None,
+        timeout: int = 0,
+        cwd: str | None = None,
+    ) -> CommandResult:
+        captured["argv"] = list(argv)
+        captured["stdin"] = stdin
+        captured["cwd"] = cwd
+        return CommandResult(exit_code=exit_code, stdout="", stderr=stderr, elapsed_seconds=0.0)
+
+    monkeypatch.setattr(esc_mod, "run", fake_run)
+    return captured
+
+
+def test_real_escalator_posts_via_stdin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured = _patch(monkeypatch)
+    esc = RealEscalator(repo_root=tmp_path)
+    body = "## Detail\nMulti-line\nbody with `code` and # markers"
+    esc.comment(42, body)
+    assert captured["argv"] == ["gh", "issue", "comment", "42", "-F", "-"]
+    assert captured["stdin"] == body
+    assert captured["cwd"] == str(tmp_path)
+
+
+def test_real_escalator_raises_on_gh_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _patch(monkeypatch, exit_code=1, stderr="auth required")
+    esc = RealEscalator(repo_root=tmp_path)
+    with pytest.raises(GitOpsError) as exc:
+        esc.comment(42, "hi")
+    assert "auth required" in str(exc.value)

--- a/manager/tests/test_git_ops_real.py
+++ b/manager/tests/test_git_ops_real.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence
+
+import pytest
+
+from manager import git_ops as git_mod
+from manager._subprocess import CommandResult
+from manager.git_ops import GitOpsError, RealGitOps, parse_children_from_body
+
+
+def test_parse_children_from_body_extracts_in_order() -> None:
+    body = """\
+# Epic: Add 3 fetchers
+
+## Goal
+Cover 3 missing sources.
+
+## Children
+- #11 add fetcher A
+- #12 add fetcher B
+- #13 add fetcher C
+
+## Notes
+- references #99 (not a child, in a different section)
+"""
+    assert parse_children_from_body(body) == [11, 12, 13]
+
+
+def test_parse_children_from_body_dedupes() -> None:
+    body = "## Children\n- #5 first\n- #5 dupe\n- #6 next\n"
+    assert parse_children_from_body(body) == [5, 6]
+
+
+def test_parse_children_from_body_returns_empty_when_section_missing() -> None:
+    assert parse_children_from_body("## Goal\nno children listed\n") == []
+
+
+def test_parse_children_from_body_japanese_heading() -> None:
+    body = """\
+## 背景
+foo
+
+## 子 Issue
+
+- [ ] #40 feat(email): rewrite digest template
+- [ ] #41 feat(web): edition page
+- [ ] #42 feat(web): archive index
+
+## 非交渉ルール
+- something else with #99
+"""
+    assert parse_children_from_body(body) == [40, 41, 42]
+
+
+class _FakeRunner:
+    """Records calls; returns scripted CommandResult per (binary, first-arg) pair."""
+
+    def __init__(self, scripted: dict[tuple[str, ...], CommandResult]) -> None:
+        self.scripted = scripted
+        self.calls: list[list[str]] = []
+
+    def __call__(
+        self,
+        argv: Sequence[str],
+        *,
+        stdin: str | None = None,
+        timeout: int = 0,
+        cwd: str | None = None,
+    ) -> CommandResult:
+        argv_list = list(argv)
+        self.calls.append(argv_list)
+        for key, result in self.scripted.items():
+            if tuple(argv_list[: len(key)]) == key:
+                return result
+        # Default: success with empty stdout.
+        return CommandResult(exit_code=0, stdout="", stderr="", elapsed_seconds=0.0)
+
+
+def _patch(monkeypatch: pytest.MonkeyPatch, runner: _FakeRunner) -> None:
+    monkeypatch.setattr(git_mod, "run", runner)
+
+
+def test_create_epic_branch_when_not_exists(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    runner = _FakeRunner({
+        ("git", "fetch", "origin", "main"): CommandResult(0, "", "", 0.0),
+        ("git", "rev-parse", "--verify", "--quiet", "epic/42-foo"):
+            CommandResult(1, "", "", 0.0),
+        ("git", "checkout", "-b", "epic/42-foo", "origin/main"):
+            CommandResult(0, "", "", 0.0),
+    })
+    _patch(monkeypatch, runner)
+    ops = RealGitOps(repo_root=tmp_path)
+    branch = ops.create_epic_branch(42, "foo")
+    assert branch == "epic/42-foo"
+    bins = [c[0] for c in runner.calls]
+    assert bins.count("git") == 3
+    # Idempotent path NOT taken (no plain `checkout` call).
+    assert ["git", "checkout", "epic/42-foo"] not in runner.calls
+
+
+def test_create_epic_branch_idempotent_when_exists(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runner = _FakeRunner({
+        ("git", "rev-parse", "--verify", "--quiet", "epic/42-foo"):
+            CommandResult(0, "deadbeef\n", "", 0.0),
+    })
+    _patch(monkeypatch, runner)
+    ops = RealGitOps(repo_root=tmp_path)
+    branch = ops.create_epic_branch(42, "foo")
+    assert branch == "epic/42-foo"
+    assert ["git", "checkout", "epic/42-foo"] in runner.calls
+    assert not any("checkout" in c and "-b" in c for c in runner.calls)
+
+
+def test_create_epic_branch_raises_on_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runner = _FakeRunner({
+        ("git", "fetch", "origin", "main"):
+            CommandResult(128, "", "could not fetch", 0.0),
+    })
+    _patch(monkeypatch, runner)
+    ops = RealGitOps(repo_root=tmp_path)
+    with pytest.raises(GitOpsError) as exc:
+        ops.create_epic_branch(42, "foo")
+    assert "fetch" in str(exc.value)
+
+
+def test_create_child_branch_off_epic(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    runner = _FakeRunner({
+        ("git", "rev-parse", "--verify", "--quiet", "epic/42-foo-child-7"):
+            CommandResult(1, "", "", 0.0),
+    })
+    _patch(monkeypatch, runner)
+    ops = RealGitOps(repo_root=tmp_path)
+    branch = ops.create_child_branch("epic/42-foo", 7)
+    assert branch == "epic/42-foo-child-7"
+    assert ["git", "checkout", "epic/42-foo"] in runner.calls
+    assert ["git", "checkout", "-b", "epic/42-foo-child-7"] in runner.calls
+
+
+def test_child_branch_name_does_not_use_slash() -> None:
+    """git rejects `refs/heads/X` and `refs/heads/X/Y` coexisting."""
+    from manager.git_ops import child_branch_name
+    name = child_branch_name("epic/39-design-system", 40)
+    assert name == "epic/39-design-system-child-40"
+    assert "/child-" not in name
+
+
+def test_diff_lines_sums_numstat(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    numstat = "10\t2\tfoo.py\n5\t0\tbar.py\n-\t-\timg.png\n"
+    runner = _FakeRunner({
+        ("git", "diff", "--numstat", "main...HEAD"):
+            CommandResult(0, numstat, "", 0.0),
+    })
+    _patch(monkeypatch, runner)
+    ops = RealGitOps(repo_root=tmp_path)
+    assert ops.diff_lines("main") == 17
+
+
+def test_diff_lines_returns_zero_on_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runner = _FakeRunner({
+        ("git", "diff", "--numstat", "main...HEAD"):
+            CommandResult(128, "", "bad refs", 0.0),
+    })
+    _patch(monkeypatch, runner)
+    assert RealGitOps(repo_root=tmp_path).diff_lines("main") == 0
+
+
+def test_find_pr_url_returns_url_or_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runner = _FakeRunner({
+        ("gh", "pr", "list", "--head", "branch-with-pr"):
+            CommandResult(0, "https://github.com/x/repo/pull/123\n", "", 0.0),
+        ("gh", "pr", "list", "--head", "branch-without-pr"):
+            CommandResult(0, "\n", "", 0.0),
+    })
+    _patch(monkeypatch, runner)
+    ops = RealGitOps(repo_root=tmp_path)
+    assert ops.find_pr_url("branch-with-pr", "epic/x") == "https://github.com/x/repo/pull/123"
+    assert ops.find_pr_url("branch-without-pr", "epic/x") is None
+
+
+def test_find_pr_url_does_not_filter_by_base(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Phase 3 limitation: /pr-creation forces base=main, so we accept any base."""
+    runner = _FakeRunner({})
+    _patch(monkeypatch, runner)
+    RealGitOps(repo_root=tmp_path).find_pr_url("any-branch", "epic/x")
+    # `--base epic/x` must NOT be in the gh argv.
+    assert all("--base" not in c for c in runner.calls)
+
+
+def test_fetch_issue_body(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    runner = _FakeRunner({
+        ("gh", "issue", "view", "42"):
+            CommandResult(0, "issue body text", "", 0.0),
+    })
+    _patch(monkeypatch, runner)
+    assert RealGitOps(repo_root=tmp_path).fetch_issue_body(42) == "issue body text"
+
+
+def test_list_child_issues_parses_epic_body(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    body = "## Goal\nx\n## Children\n- #11 a\n- #12 b\n## Notes\n- ref #99\n"
+    runner = _FakeRunner({
+        ("gh", "issue", "view", "42"): CommandResult(0, body, "", 0.0),
+    })
+    _patch(monkeypatch, runner)
+    assert RealGitOps(repo_root=tmp_path).list_child_issues(42) == [11, 12]

--- a/manager/tests/test_main_cli.py
+++ b/manager/tests/test_main_cli.py
@@ -1,0 +1,64 @@
+"""CLI tests for `python -m manager` subcommands (status / run / resume)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from manager import __main__ as cli
+from manager.state_store import StateStore
+
+
+def test_cli_status_missing_epic(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    monkeypatch.setattr(cli, "STATE_ROOT", tmp_path / "state")
+    rc = cli.main(["status", "999"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "no state for epic #999" in err
+
+
+def test_cli_status_prints_epic_and_children(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    state_root = tmp_path / "state"
+    monkeypatch.setattr(cli, "STATE_ROOT", state_root)
+    store = StateStore(state_root)
+    store.init_epic(7, "epic/7-foo", [10, 11])
+    store.init_child(7, 10, "epic/7-foo-child-10")
+
+    rc = cli.main(["status", "7"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    parsed = json.loads(out.split("\n  child")[0])
+    assert parsed["epic_issue_number"] == 7
+    assert parsed["status"] == "RUNNING"
+    assert "child #10: INIT" in out
+
+
+def test_cli_run_dry_run_creates_state_then_raises_on_dummy(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`run --children N` with default Dummy* creates state up to first subagent call,
+    then raises because Dummy has no scripted response. The state on disk is the
+    proof that argparse / wiring works end-to-end without --live."""
+    state_root = tmp_path / "state"
+    monkeypatch.setattr(cli, "STATE_ROOT", state_root)
+    monkeypatch.setattr(cli, "REPO_ROOT", tmp_path)
+    with pytest.raises(RuntimeError, match="DummySubagent: no scripted response"):
+        cli.main(["run", "8", "--slug", "demo", "--children", "20"])
+    assert (state_root / "epic-8" / "epic.json").exists()
+
+
+def test_cli_resume_alias_for_run(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """`resume` accepts the same args as `run` (verified by argparse parsing)."""
+    state_root = tmp_path / "state"
+    monkeypatch.setattr(cli, "STATE_ROOT", state_root)
+    monkeypatch.setattr(cli, "REPO_ROOT", tmp_path)
+    parser_args = cli.argparse.ArgumentParser(prog="manager")
+    # Just verify argv parses without crashing.
+    with pytest.raises(SystemExit):
+        cli.main(["resume", "--help"])

--- a/manager/tests/test_parsers.py
+++ b/manager/tests/test_parsers.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from manager.parsers import ParseError
+from manager.parsers.dev_loop import parse_dev_loop
+from manager.parsers.packet import parse_packet
+from manager.parsers.plan import parse_plan
+from manager.parsers.triage import parse_classification, parse_triage
+
+
+def _read(fixtures_dir: Path, name: str) -> str:
+    return (fixtures_dir / name).read_text(encoding="utf-8")
+
+
+def test_parse_triage_ready(fixtures_dir: Path) -> None:
+    assert parse_triage(_read(fixtures_dir, "triage_ready.md")) == "ready"
+    assert parse_classification(_read(fixtures_dir, "triage_ready.md")) == "auto-fixable"
+
+
+def test_parse_triage_skip(fixtures_dir: Path) -> None:
+    assert parse_triage(_read(fixtures_dir, "triage_skip.md")) == "do-not-run"
+
+
+def test_parse_triage_needs_confirmation(fixtures_dir: Path) -> None:
+    assert (
+        parse_triage(_read(fixtures_dir, "triage_needs_confirmation.md"))
+        == "needs-confirmation"
+    )
+
+
+def test_parse_triage_missing_section_raises() -> None:
+    with pytest.raises(ParseError):
+        parse_triage("# Some Other Section\n- ready\n")
+
+
+def test_parse_packet_minimal(fixtures_dir: Path) -> None:
+    parsed = parse_packet(_read(fixtures_dir, "packet_minimal.md"))
+    assert parsed["issue_id"] == 101
+    assert parsed["scope"] == "small"
+
+
+def test_parse_packet_missing_required_raises() -> None:
+    with pytest.raises(ParseError) as exc:
+        parse_packet("```yaml\nissue_id: 1\ntitle: x\n```")
+    assert "必須フィールド欠落" in str(exc.value)
+
+
+def test_parse_plan_proceed(fixtures_dir: Path) -> None:
+    assert parse_plan(_read(fixtures_dir, "plan_proceed.md")) == "proceed"
+
+
+def test_parse_plan_confirm(fixtures_dir: Path) -> None:
+    assert parse_plan(_read(fixtures_dir, "plan_confirm.md")) == "confirm first"
+
+
+def test_parse_plan_missing_raises() -> None:
+    with pytest.raises(ParseError):
+        parse_plan("# Goal\nnothing")
+
+
+def test_parse_dev_loop_safe(fixtures_dir: Path) -> None:
+    outcome = parse_dev_loop(_read(fixtures_dir, "dev_loop_safe.md"))
+    assert outcome.verdict == "safe to merge"
+    assert outcome.pytest_status == "Pytest Passed"
+    assert outcome.dryrun_status == "Dry-run Passed"
+    assert outcome.migration_status == "Migration N/A"
+    assert outcome.pr_title == "feat: add example fetcher"
+    assert outcome.blocked is False
+
+
+def test_parse_dev_loop_fix(fixtures_dir: Path) -> None:
+    outcome = parse_dev_loop(_read(fixtures_dir, "dev_loop_fix.md"))
+    assert outcome.verdict == "fix before merge"
+    assert outcome.pytest_status == "Pytest Failed"
+
+
+def test_parse_dev_loop_confirm(fixtures_dir: Path) -> None:
+    outcome = parse_dev_loop(_read(fixtures_dir, "dev_loop_confirm.md"))
+    assert outcome.verdict == "confirm before merge"
+    assert outcome.migration_status == "Migration Pending"
+
+
+def test_parse_dev_loop_blocked(fixtures_dir: Path) -> None:
+    outcome = parse_dev_loop(_read(fixtures_dir, "dev_loop_blocked.md"))
+    assert outcome.blocked is True
+    assert outcome.verdict == "confirm before merge"
+
+
+def test_parse_dev_loop_missing_verdict_raises() -> None:
+    with pytest.raises(ParseError):
+        parse_dev_loop("# Implementation Summary\n## Pytest Status\n- Pytest Passed\n")

--- a/manager/tests/test_runner.py
+++ b/manager/tests/test_runner.py
@@ -1,0 +1,235 @@
+"""End-to-end runner tests with DummySubagent / DummyGitOps / DummyEscalator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from manager.escalate import DummyEscalator
+from manager.git_ops import DummyGitOps, GitOpsError
+from manager.limits import EXIT_HALTED, EXIT_NEEDS_HUMAN, EXIT_OK
+from manager.runner import Runner
+from manager.state_store import StateStore
+from manager.subagent import DummySubagent, make_result
+
+
+def _read(fixtures_dir: Path, name: str) -> str:
+    return (fixtures_dir / name).read_text(encoding="utf-8")
+
+
+def _build(
+    state_root: Path,
+    repo_root: Path,
+    *,
+    children: list[int],
+    scripted: dict[str, list],
+    pr_urls: dict[str, str] | None = None,
+    failures: dict[str, GitOpsError] | None = None,
+) -> tuple[Runner, DummyEscalator, DummyGitOps]:
+    default_prs = {f"epic/1-test-child-{c}": f"https://x/pr/{c}" for c in children}
+    git_ops = DummyGitOps(
+        child_listing={1: children},
+        pr_urls=default_prs if pr_urls is None else pr_urls,
+        issue_bodies={c: f"body of {c}" for c in children},
+        failures=failures or {},
+    )
+    escalator = DummyEscalator()
+    runner = Runner(
+        state_store=StateStore(state_root),
+        subagent=DummySubagent(scripted),
+        git_ops=git_ops,
+        escalator=escalator,
+        repo_root=repo_root,
+    )
+    return runner, escalator, git_ops
+
+
+def _happy_scripted(fixtures_dir: Path, n_children: int) -> dict[str, list]:
+    return {
+        "/triage-issue": [make_result(_read(fixtures_dir, "triage_ready.md")) for _ in range(n_children)],
+        "/make-execution-packet": [make_result(_read(fixtures_dir, "packet_minimal.md")) for _ in range(n_children)],
+        "/spec-architect": [make_result(_read(fixtures_dir, "plan_proceed.md")) for _ in range(n_children)],
+        "/run-dev-loop": [make_result(_read(fixtures_dir, "dev_loop_safe.md")) for _ in range(n_children)],
+    }
+
+
+def test_happy_path_two_children(
+    state_root: Path, repo_root: Path, fixtures_dir: Path
+) -> None:
+    runner, escalator, _git = _build(
+        state_root, repo_root, children=[10, 11],
+        scripted=_happy_scripted(fixtures_dir, 2),
+    )
+    rc = runner.run_epic(1, slug="test")
+    assert rc == EXIT_OK
+
+    epic = runner.state_store.load_epic(1)
+    assert epic["status"] == "DONE"
+    assert epic["children_done"] == [10, 11]
+    assert epic["children_failed"] == []
+    assert epic["children_queue"] == []
+
+    for c in (10, 11):
+        child = runner.state_store.load_child(1, c)
+        assert child["status"] == "DONE"
+        assert child["pr_url"] == f"https://x/pr/{c}"
+        assert child["last_verdict"] == "safe to merge"
+
+    assert any("finished epic" in body for _, body in escalator.posted)
+
+
+def test_skip_on_do_not_run(
+    state_root: Path, repo_root: Path, fixtures_dir: Path
+) -> None:
+    scripted = {
+        "/triage-issue": [make_result(_read(fixtures_dir, "triage_skip.md"))],
+        # No subsequent calls expected — DummySubagent would raise if invoked.
+    }
+    runner, _esc, _git = _build(state_root, repo_root, children=[10], scripted=scripted)
+    rc = runner.run_epic(1, slug="test")
+    assert rc == EXIT_OK
+    epic = runner.state_store.load_epic(1)
+    assert epic["children_skipped"] == [10]
+    assert epic["children_done"] == []
+
+
+def test_needs_confirmation_escalates(
+    state_root: Path, repo_root: Path, fixtures_dir: Path
+) -> None:
+    scripted = {
+        "/triage-issue": [make_result(_read(fixtures_dir, "triage_needs_confirmation.md"))],
+    }
+    runner, escalator, _git = _build(
+        state_root, repo_root, children=[10], scripted=scripted
+    )
+    rc = runner.run_epic(1, slug="test")
+    assert rc == EXIT_NEEDS_HUMAN
+    child = runner.state_store.load_child(1, 10)
+    assert child["status"] == "NEEDS_HUMAN"
+    assert "needs-confirmation" in (child["needs_human_reason"] or "")
+    assert any("halted on child" in body for _, body in escalator.posted)
+
+
+def test_plan_confirm_first_escalates(
+    state_root: Path, repo_root: Path, fixtures_dir: Path
+) -> None:
+    scripted = {
+        "/triage-issue": [make_result(_read(fixtures_dir, "triage_ready.md"))],
+        "/make-execution-packet": [make_result(_read(fixtures_dir, "packet_minimal.md"))],
+        "/spec-architect": [make_result(_read(fixtures_dir, "plan_confirm.md"))],
+    }
+    runner, _esc, _git = _build(state_root, repo_root, children=[10], scripted=scripted)
+    rc = runner.run_epic(1, slug="test")
+    assert rc == EXIT_NEEDS_HUMAN
+    child = runner.state_store.load_child(1, 10)
+    assert child["status"] == "NEEDS_HUMAN"
+    assert "confirm first" in (child["needs_human_reason"] or "")
+
+
+def test_implement_fix_then_safe_succeeds(
+    state_root: Path, repo_root: Path, fixtures_dir: Path
+) -> None:
+    """fix before merge first, then safe to merge — must DONE."""
+    scripted = {
+        "/triage-issue": [make_result(_read(fixtures_dir, "triage_ready.md"))],
+        "/make-execution-packet": [make_result(_read(fixtures_dir, "packet_minimal.md"))],
+        "/spec-architect": [make_result(_read(fixtures_dir, "plan_proceed.md"))],
+        "/run-dev-loop": [
+            make_result(_read(fixtures_dir, "dev_loop_fix.md")),
+            make_result(_read(fixtures_dir, "dev_loop_safe.md")),
+        ],
+    }
+    runner, _esc, _git = _build(state_root, repo_root, children=[10], scripted=scripted)
+    rc = runner.run_epic(1, slug="test")
+    assert rc == EXIT_OK
+    child = runner.state_store.load_child(1, 10)
+    assert child["status"] == "DONE"
+    assert child["retry"]["implement"] == 1
+
+
+def test_implement_fix_exhausts_retry_then_escalates(
+    state_root: Path, repo_root: Path, fixtures_dir: Path
+) -> None:
+    fix = _read(fixtures_dir, "dev_loop_fix.md")
+    scripted = {
+        "/triage-issue": [make_result(_read(fixtures_dir, "triage_ready.md"))],
+        "/make-execution-packet": [make_result(_read(fixtures_dir, "packet_minimal.md"))],
+        "/spec-architect": [make_result(_read(fixtures_dir, "plan_proceed.md"))],
+        "/run-dev-loop": [
+            make_result(fix), make_result(fix), make_result(fix), make_result(fix),
+        ],  # 1 initial + 3 retries (limit) + 1 to trigger escalation
+    }
+    runner, _esc, _git = _build(state_root, repo_root, children=[10], scripted=scripted)
+    rc = runner.run_epic(1, slug="test")
+    assert rc == EXIT_NEEDS_HUMAN
+    child = runner.state_store.load_child(1, 10)
+    assert child["status"] == "NEEDS_HUMAN"
+    assert "retry exhausted" in (child["needs_human_reason"] or "")
+
+
+def test_dev_loop_blocked_treated_as_confirm(
+    state_root: Path, repo_root: Path, fixtures_dir: Path
+) -> None:
+    scripted = {
+        "/triage-issue": [make_result(_read(fixtures_dir, "triage_ready.md"))],
+        "/make-execution-packet": [make_result(_read(fixtures_dir, "packet_minimal.md"))],
+        "/spec-architect": [make_result(_read(fixtures_dir, "plan_proceed.md"))],
+        "/run-dev-loop": [make_result(_read(fixtures_dir, "dev_loop_blocked.md"))],
+    }
+    runner, _esc, _git = _build(state_root, repo_root, children=[10], scripted=scripted)
+    rc = runner.run_epic(1, slug="test")
+    assert rc == EXIT_NEEDS_HUMAN
+    child = runner.state_store.load_child(1, 10)
+    assert child["status"] == "NEEDS_HUMAN"
+    assert child["last_verdict"] == "confirm before merge"
+
+
+def test_kill_switch_halts(
+    state_root: Path, repo_root: Path, fixtures_dir: Path
+) -> None:
+    (repo_root / ".claude" / "STOP").write_text("halt please", encoding="utf-8")
+    scripted = _happy_scripted(fixtures_dir, 1)
+    runner, escalator, _git = _build(
+        state_root, repo_root, children=[10], scripted=scripted
+    )
+    rc = runner.run_epic(1, slug="test")
+    assert rc == EXIT_HALTED
+    epic = runner.state_store.load_epic(1)
+    assert epic["status"] == "HALTED"
+    assert any("halted epic" in body for _, body in escalator.posted)
+
+
+def test_pr_not_found_retries_then_escalates(
+    state_root: Path, repo_root: Path, fixtures_dir: Path
+) -> None:
+    scripted = _happy_scripted(fixtures_dir, 1)
+    runner, _esc, _git = _build(
+        state_root, repo_root, children=[10],
+        scripted=scripted,
+        pr_urls={},  # gh finds nothing
+    )
+    rc = runner.run_epic(1, slug="test")
+    assert rc == EXIT_NEEDS_HUMAN
+    child = runner.state_store.load_child(1, 10)
+    assert child["status"] == "NEEDS_HUMAN"
+    assert "PR not found" in (child["needs_human_reason"] or "")
+    assert child["retry"]["verify_pr"] == 3
+
+
+def test_no_children_halts(state_root: Path, repo_root: Path) -> None:
+    runner, escalator, _git = _build(state_root, repo_root, children=[], scripted={})
+    rc = runner.run_epic(1, slug="test")
+    assert rc == EXIT_HALTED
+    assert any("no child issues" in body for _, body in escalator.posted)
+
+
+def test_artifacts_persisted(
+    state_root: Path, repo_root: Path, fixtures_dir: Path
+) -> None:
+    scripted = _happy_scripted(fixtures_dir, 1)
+    runner, _esc, _git = _build(state_root, repo_root, children=[10], scripted=scripted)
+    runner.run_epic(1, slug="test")
+    child_dir = runner.state_store.child_dir(1, 10)
+    for name in ("issue.txt", "triage.md", "packet.yaml", "plan.md", "dev_loop.md"):
+        assert (child_dir / name).exists(), f"missing artifact: {name}"

--- a/manager/tests/test_runner_phase4.py
+++ b/manager/tests/test_runner_phase4.py
@@ -1,0 +1,197 @@
+"""Phase 4 runner tests: resume, retry-failed, PR retarget, signal halt, repo-relative paths."""
+
+from __future__ import annotations
+
+import os
+import signal
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from manager.escalate import DummyEscalator
+from manager.git_ops import DummyGitOps
+from manager.limits import EXIT_HALTED, EXIT_NEEDS_HUMAN, EXIT_OK
+from manager.runner import Runner
+from manager.state_store import StateStore
+from manager.subagent import DummySubagent, make_result
+
+
+def _read(fixtures_dir: Path, name: str) -> str:
+    return (fixtures_dir / name).read_text(encoding="utf-8")
+
+
+def _happy(fixtures_dir: Path, n: int) -> dict[str, list]:
+    return {
+        "/triage-issue": [make_result(_read(fixtures_dir, "triage_ready.md")) for _ in range(n)],
+        "/make-execution-packet": [make_result(_read(fixtures_dir, "packet_minimal.md")) for _ in range(n)],
+        "/spec-architect": [make_result(_read(fixtures_dir, "plan_proceed.md")) for _ in range(n)],
+        "/run-dev-loop": [make_result(_read(fixtures_dir, "dev_loop_safe.md")) for _ in range(n)],
+    }
+
+
+def _build(
+    state_root: Path,
+    repo_root: Path,
+    *,
+    children: list[int],
+    scripted: dict[str, list],
+    pr_urls: dict[str, str] | None = None,
+    install_signal_handlers: bool = False,
+) -> tuple[Runner, DummyEscalator, DummyGitOps]:
+    default_prs = {f"epic/1-test-child-{c}": f"https://x/pr/{c}" for c in children}
+    git_ops = DummyGitOps(
+        child_listing={1: children},
+        pr_urls=default_prs if pr_urls is None else pr_urls,
+        issue_bodies={c: f"body of {c}" for c in children},
+    )
+    escalator = DummyEscalator()
+    runner = Runner(
+        state_store=StateStore(state_root),
+        subagent=DummySubagent(scripted),
+        git_ops=git_ops,
+        escalator=escalator,
+        repo_root=repo_root,
+        install_signal_handlers=install_signal_handlers,
+    )
+    return runner, escalator, git_ops
+
+
+# ===================================================================
+# resume + retry_failed
+# ===================================================================
+
+
+def test_resume_continues_from_halted_state(
+    state_root: Path, repo_root: Path, fixtures_dir: Path
+) -> None:
+    """First run: child #10 halts at TRIAGE (needs-confirmation). Resume: #11 proceeds."""
+    scripted_first = {
+        "/triage-issue": [make_result(_read(fixtures_dir, "triage_needs_confirmation.md"))],
+    }
+    runner1, _esc1, _git1 = _build(state_root, repo_root, children=[10, 11], scripted=scripted_first)
+    rc1 = runner1.run_epic(1, slug="test")
+    assert rc1 == EXIT_NEEDS_HUMAN
+
+    epic = runner1.state_store.load_epic(1)
+    assert epic["status"] == "HALTED"
+    assert epic["children_failed"] == [10]
+    assert epic["children_queue"] == [11]
+
+    scripted_resume = _happy(fixtures_dir, 1)
+    runner2, _esc2, _git2 = _build(state_root, repo_root, children=[10, 11], scripted=scripted_resume)
+    rc2 = runner2.run_epic(1, slug="test")
+    assert rc2 == EXIT_OK
+    epic = runner2.state_store.load_epic(1)
+    assert epic["status"] == "DONE"
+    assert epic["children_done"] == [11]
+    assert epic["children_failed"] == [10]  # #10 stays failed unless retry-flag
+
+
+def test_retry_failed_resets_child_and_re_attempts(
+    state_root: Path, repo_root: Path, fixtures_dir: Path
+) -> None:
+    """First run: #10 halts. Resume with retry_failed=[10]: #10 re-runs successfully."""
+    scripted_first = {
+        "/triage-issue": [make_result(_read(fixtures_dir, "triage_needs_confirmation.md"))],
+    }
+    runner1, _esc1, _git1 = _build(state_root, repo_root, children=[10], scripted=scripted_first)
+    runner1.run_epic(1, slug="test")
+
+    scripted_retry = _happy(fixtures_dir, 1)
+    runner2, _esc2, _git2 = _build(state_root, repo_root, children=[10], scripted=scripted_retry)
+    rc = runner2.run_epic(1, slug="test", retry_failed=[10])
+    assert rc == EXIT_OK
+    epic = runner2.state_store.load_epic(1)
+    assert epic["status"] == "DONE"
+    assert epic["children_done"] == [10]
+    assert epic["children_failed"] == []
+
+
+def test_retry_failed_ignores_unknown_child(
+    state_root: Path, repo_root: Path, fixtures_dir: Path
+) -> None:
+    """Asking to retry a child that wasn't failed must be a no-op (no crash)."""
+    runner1, _esc, _git = _build(
+        state_root, repo_root, children=[10], scripted=_happy(fixtures_dir, 1)
+    )
+    runner1.run_epic(1, slug="test")  # #10 → DONE
+    # Resume asking to retry #10 (which is in done, not failed) — must no-op.
+    runner2, _esc2, _git2 = _build(state_root, repo_root, children=[10], scripted={})
+    rc = runner2.run_epic(1, slug="test", retry_failed=[10])
+    assert rc == EXIT_OK
+
+
+# ===================================================================
+# PR retarget
+# ===================================================================
+
+
+def test_verify_pr_retargets_to_epic_branch(
+    state_root: Path, repo_root: Path, fixtures_dir: Path
+) -> None:
+    runner, _esc, git = _build(
+        state_root, repo_root, children=[10], scripted=_happy(fixtures_dir, 1),
+    )
+    runner.run_epic(1, slug="test")
+    assert git.retargeted == {"https://x/pr/10": "epic/1-test"}
+
+
+# ===================================================================
+# Signal handler
+# ===================================================================
+
+
+def test_signal_received_halts_between_children(
+    state_root: Path, repo_root: Path, fixtures_dir: Path
+) -> None:
+    """SIGINT arriving between children causes a clean HALTED + state save."""
+    runner, escalator, _git = _build(
+        state_root, repo_root, children=[10, 11, 12],
+        scripted=_happy(fixtures_dir, 3),
+        install_signal_handlers=True,
+    )
+
+    # Fire SIGINT after a tiny delay, so it lands during the first child's processing.
+    pid = os.getpid()
+    fired = threading.Event()
+
+    def _shoot() -> None:
+        time.sleep(0.05)
+        os.kill(pid, signal.SIGINT)
+        fired.set()
+
+    threading.Thread(target=_shoot, daemon=True).start()
+    rc = runner.run_epic(1, slug="test")
+    fired.wait(timeout=2.0)
+
+    # Either HALTED before completing all children, or completed entirely (race).
+    assert rc in (EXIT_OK, EXIT_HALTED)
+    epic = runner.state_store.load_epic(1)
+    if rc == EXIT_HALTED:
+        assert epic["status"] == "HALTED"
+        assert any("halted epic" in body for _, body in escalator.posted)
+
+
+# ===================================================================
+# Repo-relative paths in escalation
+# ===================================================================
+
+
+def test_escalation_path_is_repo_relative(
+    state_root: Path, repo_root: Path, fixtures_dir: Path
+) -> None:
+    """state_path in the Issue comment must resolve to a path under the repo."""
+    # Anchor state_root inside repo_root so the relative-to actually matches.
+    inner_state = repo_root / ".claude" / "state"
+    inner_state.mkdir(parents=True)
+    runner, escalator, _git = _build(
+        inner_state, repo_root, children=[10],
+        scripted={
+            "/triage-issue": [make_result(_read(fixtures_dir, "triage_needs_confirmation.md"))],
+        },
+    )
+    runner.run_epic(1, slug="test")
+    body = escalator.posted[0][1]
+    assert ".claude/state/epic-1/children/child-10/state.json" in body

--- a/manager/tests/test_state_store.py
+++ b/manager/tests/test_state_store.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from manager.state_store import LockTaken, StateStore
+
+
+def test_init_epic_round_trip(state_root: Path) -> None:
+    store = StateStore(state_root)
+    epic = store.init_epic(42, epic_branch="epic/42-foo", children=[1, 2, 3])
+    assert epic["status"] == "RUNNING"
+    assert epic["children_queue"] == [1, 2, 3]
+    loaded = store.load_epic(42)
+    assert loaded == epic
+
+
+def test_init_child_round_trip(state_root: Path) -> None:
+    store = StateStore(state_root)
+    store.init_epic(42, "epic/42-foo", [1])
+    child = store.init_child(42, 1, "epic/42-foo/child-1")
+    assert child["status"] == "INIT"
+    assert child["retry"]["plan"] == 0
+    loaded = store.load_child(42, 1)
+    assert loaded == child
+
+
+def test_atomic_write_creates_bak_on_overwrite(state_root: Path) -> None:
+    store = StateStore(state_root)
+    store.init_epic(42, "epic/42-foo", [1])
+    epic = store.load_epic(42)
+    epic["status"] = "DONE"
+    store.save_epic(epic)
+    bak = store.epic_path(42).with_suffix(".json.bak")
+    assert bak.exists()
+    bak_data = json.loads(bak.read_text(encoding="utf-8"))
+    assert bak_data["status"] == "RUNNING"
+
+
+def test_safe_read_falls_back_to_bak(state_root: Path) -> None:
+    store = StateStore(state_root)
+    store.init_epic(42, "epic/42-foo", [1])
+    epic = store.load_epic(42)
+    epic["status"] = "DONE"
+    store.save_epic(epic)
+    # Corrupt the live file; .bak should still load.
+    store.epic_path(42).write_text("{ broken json", encoding="utf-8")
+    loaded = store.load_epic(42)
+    assert loaded["status"] == "RUNNING"
+
+
+def test_write_artifact(state_root: Path) -> None:
+    store = StateStore(state_root)
+    path = store.write_artifact(42, 1, "plan.md", "# hello")
+    assert path.read_text(encoding="utf-8") == "# hello"
+    assert path.parent.name == "child-1"
+
+
+def test_append_log_jsonl(state_root: Path) -> None:
+    store = StateStore(state_root)
+    store.append_log(42, {"event": "a"})
+    store.append_log(42, {"event": "b"})
+    lines = store.log_path(42).read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["event"] == "a"
+
+
+def test_epic_lock_blocks_concurrent_holder(state_root: Path) -> None:
+    store = StateStore(state_root)
+    with store.epic_lock(42):
+        with pytest.raises(LockTaken):
+            with store.epic_lock(42):
+                pass
+
+
+def test_lock_released_after_exit(state_root: Path) -> None:
+    store = StateStore(state_root)
+    with store.epic_lock(42):
+        pass
+    with store.epic_lock(42):
+        pass  # second acquire must succeed

--- a/manager/tests/test_states.py
+++ b/manager/tests/test_states.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+
+from manager.states import LEGAL_TRANSITIONS, TERMINAL_STATES, is_legal
+
+
+def test_terminal_states_have_no_outgoing_transitions() -> None:
+    for state in TERMINAL_STATES:
+        assert not [t for t in LEGAL_TRANSITIONS if t.src == state], (
+            f"terminal state {state} must not have outgoing transitions"
+        )
+
+
+def test_every_non_terminal_state_can_reach_a_terminal() -> None:
+    # BFS from every src to confirm no orphan loop exists.
+    graph: dict[str, set[str]] = {}
+    for t in LEGAL_TRANSITIONS:
+        graph.setdefault(t.src, set()).add(t.dst)
+    for src in graph:
+        seen: set[str] = set()
+        stack = [src]
+        reached_terminal = False
+        while stack:
+            node = stack.pop()
+            if node in TERMINAL_STATES:
+                reached_terminal = True
+                break
+            if node in seen:
+                continue
+            seen.add(node)
+            stack.extend(graph.get(node, ()))
+        assert reached_terminal, f"{src} cannot reach a terminal state"
+
+
+def test_is_legal_accepts_known_transition() -> None:
+    assert is_legal("TRIAGE", "PACKETIZE")
+
+
+def test_is_legal_rejects_unknown_transition() -> None:
+    assert not is_legal("TRIAGE", "DONE")
+    assert not is_legal("DONE", "INIT")

--- a/manager/tests/test_subagent_real.py
+++ b/manager/tests/test_subagent_real.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Sequence
+
+import pytest
+
+from manager import _subprocess as sp_mod
+from manager import subagent as sub_mod
+from manager._subprocess import CommandResult, CommandTimeout
+from manager.subagent import RealSubagent, build_invocation_prompt
+
+
+def _capture(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    captured: dict[str, object] = {}
+
+    def fake_run(
+        argv: Sequence[str],
+        *,
+        stdin: str | None = None,
+        timeout: int = 0,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> CommandResult:
+        captured["argv"] = list(argv)
+        captured["stdin"] = stdin
+        captured["timeout"] = timeout
+        captured["cwd"] = cwd
+        captured["env"] = env
+        payload = json.dumps(
+            {
+                "result": "# Execution Readiness\n- ready\n",
+                "total_cost_usd": 0.0123,
+                "session_id": "session-from-claude",
+                "is_error": False,
+            }
+        )
+        return CommandResult(exit_code=0, stdout=payload, stderr="", elapsed_seconds=0.1)
+
+    monkeypatch.setattr(sub_mod, "run", fake_run)
+    return captured
+
+
+def test_real_subagent_constructs_expected_command(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured = _capture(monkeypatch)
+    sub = RealSubagent(repo_root=tmp_path, claude_bin="claude")
+    sub.invoke("/triage-issue", "issue body here", budget_usd=1.0)
+
+    argv = captured["argv"]
+    assert isinstance(argv, list)
+    assert argv[0] == "claude"
+    assert argv[1] == "-p"
+    assert "--output-format" in argv and argv[argv.index("--output-format") + 1] == "json"
+    assert "--no-session-persistence" in argv
+    assert "--max-budget-usd" in argv and argv[argv.index("--max-budget-usd") + 1] == "1.0"
+    assert "--bare" in argv, "must use --bare to keep auth strictly env/keychain"
+    assert "--dangerously-skip-permissions" in argv
+    assert "--add-dir" in argv and str(tmp_path) in argv
+    # session-id is a uuid we generated
+    sid_idx = argv.index("--session-id")
+    assert isinstance(argv[sid_idx + 1], str) and len(argv[sid_idx + 1]) == 36
+
+
+def test_real_subagent_passes_prompt_via_stdin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured = _capture(monkeypatch)
+    sub = RealSubagent(repo_root=tmp_path)
+    sub.invoke("/triage-issue", "MY ISSUE BODY", budget_usd=0.5)
+    stdin = captured["stdin"]
+    assert isinstance(stdin, str)
+    assert "/triage-issue" in stdin
+    assert ".claude/commands/triage-issue.md" in stdin
+    assert "MY ISSUE BODY" in stdin
+
+
+def test_real_subagent_extracts_text_cost_session(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _capture(monkeypatch)
+    sub = RealSubagent(repo_root=tmp_path)
+    result = sub.invoke("/triage-issue", "x", budget_usd=1.0)
+    assert result.exit_code == 0
+    assert result.raw_stdout.strip().startswith("# Execution Readiness")
+    assert result.cost_usd == pytest.approx(0.0123)
+    assert result.session_id == "session-from-claude"
+
+
+def test_real_subagent_handles_non_json_fallback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def fake_run(argv: Sequence[str], **kwargs: object) -> CommandResult:
+        return CommandResult(exit_code=0, stdout="raw plain text", stderr="", elapsed_seconds=0.0)
+
+    monkeypatch.setattr(sub_mod, "run", fake_run)
+    sub = RealSubagent(repo_root=tmp_path)
+    result = sub.invoke("/triage-issue", "x", budget_usd=1.0)
+    assert result.exit_code == 0
+    assert result.raw_stdout == "raw plain text"
+    assert result.cost_usd == 0.0
+
+
+def test_real_subagent_handles_non_zero_exit_non_transient(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Permanent failure: returned as-is, no retry."""
+    calls = {"n": 0}
+
+    def fake_run(argv: Sequence[str], **kwargs: object) -> CommandResult:
+        calls["n"] += 1
+        return CommandResult(exit_code=1, stdout="", stderr="bad arguments", elapsed_seconds=0.0)
+
+    monkeypatch.setattr(sub_mod, "run", fake_run)
+    sub = RealSubagent(repo_root=tmp_path)
+    result = sub.invoke("/triage-issue", "x", budget_usd=1.0)
+    assert result.exit_code == 1
+    assert "bad arguments" in result.raw_stderr
+    assert calls["n"] == 1, "non-transient failure should NOT retry"
+
+
+def test_real_subagent_retries_on_transient_then_returns(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Transient stderr triggers backoff retry. We mock time.sleep to keep fast."""
+    calls = {"n": 0}
+
+    def fake_run(argv: Sequence[str], **kwargs: object) -> CommandResult:
+        calls["n"] += 1
+        return CommandResult(exit_code=1, stdout="", stderr="429 rate-limit hit", elapsed_seconds=0.0)
+
+    monkeypatch.setattr(sub_mod, "run", fake_run)
+    monkeypatch.setattr(sub_mod.time, "sleep", lambda _s: None)
+    sub = RealSubagent(repo_root=tmp_path)
+    result = sub.invoke("/triage-issue", "x", budget_usd=1.0)
+    assert result.exit_code == 1
+    assert calls["n"] == 3, "should retry up to NETWORK_BACKOFF_SECONDS attempts"
+
+
+def test_real_subagent_succeeds_after_one_transient(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """First attempt 429, second attempt success."""
+    calls = {"n": 0}
+    success_payload = '{"result": "# Execution Readiness\\n- ready\\n", "total_cost_usd": 0.01}'
+
+    def fake_run(argv: Sequence[str], **kwargs: object) -> CommandResult:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return CommandResult(1, "", "503 Service unavailable", 0.0)
+        return CommandResult(0, success_payload, "", 0.0)
+
+    monkeypatch.setattr(sub_mod, "run", fake_run)
+    monkeypatch.setattr(sub_mod.time, "sleep", lambda _s: None)
+    sub = RealSubagent(repo_root=tmp_path)
+    result = sub.invoke("/triage-issue", "x", budget_usd=1.0)
+    assert result.exit_code == 0
+    assert calls["n"] == 2
+    assert "ready" in result.raw_stdout
+
+
+def test_is_transient_failure_classifier() -> None:
+    from manager.subagent import is_transient_failure
+    assert is_transient_failure(1, "Anthropic API overloaded, retry") is True
+    assert is_transient_failure(1, "429 Too Many Requests") is True
+    assert is_transient_failure(1, "ECONNRESET") is True
+    assert is_transient_failure(1, "Invalid argument: --bogus-flag") is False
+    assert is_transient_failure(0, "anything") is False  # success is not transient
+
+
+def test_real_subagent_strips_anthropic_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """ANTHROPIC_* env vars must NOT reach the spawned `claude -p`."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-leak-this-must-not-pass")
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://leak.example")
+    monkeypatch.setenv("PATH", "/usr/bin")
+    captured = _capture(monkeypatch)
+    sub = RealSubagent(repo_root=tmp_path)
+    sub.invoke("/triage-issue", "x", budget_usd=1.0)
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "ANTHROPIC_BASE_URL" not in env
+    assert env.get("PATH") == "/usr/bin", "non-ANTHROPIC env must pass through"
+
+
+def test_sanitized_env_drops_only_anthropic_namespace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from manager.subagent import sanitized_env
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "x")
+    monkeypatch.setenv("ANTHROPIC_LOG", "info")
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "abc")
+    monkeypatch.setenv("PATH", "/usr/bin")
+    env = sanitized_env()
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "ANTHROPIC_LOG" not in env
+    assert env.get("CLAUDE_CODE_SESSION_ID") == "abc", "claude code own env stays"
+    assert env.get("PATH") == "/usr/bin"
+
+
+def test_real_subagent_handles_timeout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def fake_run(argv: Sequence[str], **kwargs: object) -> CommandResult:
+        raise CommandTimeout("timeout after 900s: claude -p ...")
+
+    monkeypatch.setattr(sub_mod, "run", fake_run)
+    sub = RealSubagent(repo_root=tmp_path)
+    result = sub.invoke("/triage-issue", "x", budget_usd=1.0)
+    assert result.exit_code == 124
+    assert "timeout" in result.raw_stderr
+
+
+def test_build_invocation_prompt_includes_required_reading_directive() -> None:
+    prompt = build_invocation_prompt("/spec-architect", "PACKET YAML HERE")
+    assert "/spec-architect" in prompt
+    assert ".claude/commands/spec-architect.md" in prompt
+    assert "Required Reading" in prompt
+    assert "PACKET YAML HERE" in prompt
+    assert "Output Format" in prompt

--- a/manager/types.py
+++ b/manager/types.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+EpicStatus = Literal["INIT", "RUNNING", "DONE", "HALTED"]
+
+ChildStatus = Literal[
+    "INIT",
+    "TRIAGE",
+    "PACKETIZE",
+    "PLAN",
+    "IMPLEMENT",
+    "VERIFY_PR",
+    "DONE",
+    "SKIPPED",
+    "NEEDS_HUMAN",
+]
+
+RetryKey = Literal["plan", "implement", "triage", "packetize", "verify_pr"]
+
+TerminalChildStatus = Literal["DONE", "SKIPPED", "NEEDS_HUMAN"]
+
+TriageReadiness = Literal["ready", "needs-confirmation", "do-not-run"]
+PlanRecommendation = Literal["proceed", "proceed with caution", "confirm first"]
+ReviewVerdict = Literal["safe to merge", "fix before merge", "confirm before merge"]
+
+
+class RetryCounters(TypedDict):
+    plan: int
+    implement: int
+    triage: int
+    packetize: int
+    verify_pr: int
+
+
+class ChildState(TypedDict):
+    issue_number: int
+    branch: str
+    status: ChildStatus
+    started_at: str
+    updated_at: str
+    retry: RetryCounters
+    last_verdict: str | None
+    pr_url: str | None
+    needs_human_reason: str | None
+    artifacts: dict[str, str]
+    cost_usd: float
+
+
+class EpicState(TypedDict):
+    epic_issue_number: int
+    epic_branch: str
+    status: EpicStatus
+    children_queue: list[int]
+    children_done: list[int]
+    children_skipped: list[int]
+    children_failed: list[int]
+    current_child: int | None
+    started_at: str
+    updated_at: str
+    cost_usd: float
+    diff_lines: int
+    schema_version: int
+
+
+def get_retry(counters: RetryCounters, key: RetryKey) -> int:
+    if key == "plan":
+        return counters["plan"]
+    if key == "implement":
+        return counters["implement"]
+    if key == "triage":
+        return counters["triage"]
+    if key == "packetize":
+        return counters["packetize"]
+    return counters["verify_pr"]
+
+
+def set_retry(counters: RetryCounters, key: RetryKey, value: int) -> None:
+    if key == "plan":
+        counters["plan"] = value
+    elif key == "implement":
+        counters["implement"] = value
+    elif key == "triage":
+        counters["triage"] = value
+    elif key == "packetize":
+        counters["packetize"] = value
+    else:
+        counters["verify_pr"] = value


### PR DESCRIPTION
## Summary

- New `manager/` Python package: a code-driven state machine that drives one **epic Issue → child Issues → PRs** end-to-end via the existing 7 slash commands. **No existing slash command was modified**.
- 76 unit tests, sub-second. 1 live run on epic #39 validated end-to-end and surfaced 2 real defects that mocks could not (now fixed).
- Auth path locked to **Claude Code OAuth (Max plan)** via `--bare` + sanitized env. Inner subagent cannot silently switch to Anthropic API ($).

## Design

| Aspect | Choice |
|---|---|
| Transition model | `LEGAL_TRANSITIONS` table in `manager/states.py`; `is_legal()` gate in runner asserts on illegal transitions |
| State persistence | Atomic JSON under `.claude/state/<epic>/`, `flock(2)` per epic, `.bak` fallback on corruption |
| Stage mapping | Plan = `/spec-architect`, Implementation+Review+PR = `/run-dev-loop` (output parsed for verdict) |
| Retries / cost / diff / timeout | Hard-coded constants in `manager/limits.py` (no env override) |
| Kill-switch | `.claude/STOP` checked before every transition, `.claude/STOP_NOW` for immediate kill |
| PR retarget | `gh pr edit <url> --base <epic-branch>` after VERIFY_PR (works around `/pr-creation`'s hard-coded `--base main`) |
| Resume | `python -m manager run <#> --retry <child#>` resets failed children and continues |

## Live test learnings (epic #39)

| Defect | Fix |
|---|---|
| git refuses `refs/heads/X` to coexist with `refs/heads/X/Y` | Child branch naming `epic/<n>-<slug>-child-<m>` (no `/`) |
| `.env` auto-discovery silently routed billing to Anthropic API | `--bare` re-added + `sanitized_env()` strips `ANTHROPIC_*` from spawned env. User confirmed via console.anthropic.com that the leak existed |

## CLI

\`\`\`
python -m manager status <epic#>
python -m manager run <epic#> [--live] [--slug X] [--children N M] [--retry N M]
python -m manager resume <epic#> [--live] [--retry N M]
\`\`\`

## Test plan

- [x] \`python -m pytest manager/tests/\` → 76 passed
- [x] \`python -m manager 39 --slug design-system --live\` ran on epic #39 → caught ambiguity in #40 triage and escalated to NEEDS_HUMAN as designed (Issue #39 has the comment)
- [ ] (Out of scope here) Live verify cost-cap trip, kill-switch trip mid-stage, multi-epic parallel

## Notes

- \`ANTHROPIC_API_KEY\` was removed from local \`.env\` (gitignored, not in this PR). **Please rotate that key** at console.anthropic.com — it was exposed momentarily during debugging
- Local-only artifacts left from the live test: branches \`epic/39-design-system\` and \`epic/39-design-system-child-40\`, and \`.claude/state/epic-39/\`. Safe to delete after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)