### PR TITLE
fix(manager): drop --bare so Max plan keychain auth works

### DIFF
--- a/.claude/rules/manager-agent.md
+++ b/.claude/rules/manager-agent.md
@@ -12,8 +12,8 @@ Manager Agent (`manager/` パッケージ) の改修・テスト時に適用す�
 - subagent 出力のパーサ追加・変更時は `manager/tests/fixtures/*.md` にゴールデン入力を追加し、parser テストでカバーする
 - `Subagent` / `GitOps` / `Escalator` の Protocol を破らない。Real 実装と Dummy 実装は同 Protocol を満たす
 - `subprocess.run` 系は必ず `timeout=SUBAGENT_TIMEOUT_SECONDS` を渡し、`TimeoutExpired` をハンドルする
-- `claude -p` 起動時は `--bare`, `--no-session-persistence`, `--max-budget-usd`, `--session-id`, `--add-dir <repo_root>`, `--output-format json`, `--dangerously-skip-permissions` を必ず付ける
-  - `--bare` の理由: CLAUDE.md auto-discovery / hooks / MCP / `.env` の意図せぬ読み込みを完全停止する。`.env` に `ANTHROPIC_API_KEY` が残っていた場合、`--bare` 無しだと `claude -p` が auto-discovery で API key を拾い、**Claude Max plan ではなく API ($) 課金にサイレントに切り替わる**。Phase 3 live 1 回目で実際に発生した
+- `claude -p` 起動時は `--no-session-persistence`, `--max-budget-usd`, `--session-id`, `--add-dir <repo_root>`, `--output-format json`, `--dangerously-skip-permissions` を必ず付ける
+  - `--bare` は **付けない** (`RealSubagent.bare` default = `False`)。CLI v2.1+ で `--bare` が keychain/OAuth lookup も無効化する仕様になったため、`--bare` + `sanitized_env()` の `ANTHROPIC_*` 剥がしを併用すると認証経路が全部消えて "Not logged in" になる。Max plan 課金の防衛は `sanitized_env()` で `ANTHROPIC_*` を剥がす一段でカバー (`.env` から `ANTHROPIC_API_KEY` を削除済みの前提も維持する)
   - skip-permissions の理由: 非対話 `-p` モードで Edit/Write/Bash の許可ダイアログが起きると subagent が deadlock する。Manager 自身が kill-switch / cost limit / diff limit / NEEDS_HUMAN escalation で安全網を担っているため、内側の subagent は trusted モードで動かす
 - subprocess.run は env を `sanitized_env()` で明示渡し、`ANTHROPIC_*` を **除去** する。env 経由で API key が再混入することを物理的に防ぐ
 - 既知の Phase 4 まで残る制約: `/pr-creation` が `--base main` ハードコードのため子 PR は一旦 main に向く。`_handle_verify_pr` が `gh pr edit <url> --base <epic-branch>` で retarget する (soft-fail: retarget 失敗してもログのみ、PR 自体は残る)

--- a/manager/subagent.py
+++ b/manager/subagent.py
@@ -117,12 +117,16 @@ class RealSubagent:
 
     Defaults are tuned to keep cost on the Claude Code OAuth (Max plan) path:
 
-    - `--bare`: skip CLAUDE.md auto-discovery, hooks, MCP, attribution. With
-      `--bare` set AND `ANTHROPIC_API_KEY` removed from env, claude must use
-      the keychain OAuth credential — nothing else is consulted.
     - `env=sanitized_env()`: strip `ANTHROPIC_*` from the spawned env so a
       stray `.env` line or parent injection can't silently switch billing to
-      API credit.
+      API credit. This is the primary defense — Max plan stays in effect
+      because keychain OAuth is the only remaining auth path.
+    - `bare=False` (default): in CLI v2.1+ `--bare` *disables* keychain/OAuth
+      reads (only API key / apiKeyHelper auth survives). Combined with
+      `sanitized_env()` stripping `ANTHROPIC_*`, `--bare` leaves no usable
+      auth path → spawned `claude -p` exits with "Not logged in". We keep
+      the flag as a knob (for setups that intentionally pass an API key via
+      `--settings`), but default it off so keychain works.
     - `--dangerously-skip-permissions`: required because non-interactive `-p`
       mode can't surface a tool-permission prompt. Manager's own kill-switch /
       cost / diff limit / NEEDS_HUMAN escalation is the safety net.
@@ -136,7 +140,7 @@ class RealSubagent:
     timeout: int = SUBAGENT_TIMEOUT_SECONDS
     extra_add_dirs: tuple[Path, ...] = ()
     dangerously_skip_permissions: bool = True
-    bare: bool = True
+    bare: bool = False
 
     def invoke(self, slash: str, args_text: str, budget_usd: float) -> SubagentResult:
         session_id = str(uuid.uuid4())

--- a/manager/tests/test_subagent_real.py
+++ b/manager/tests/test_subagent_real.py
@@ -56,7 +56,10 @@ def test_real_subagent_constructs_expected_command(
     assert "--output-format" in argv and argv[argv.index("--output-format") + 1] == "json"
     assert "--no-session-persistence" in argv
     assert "--max-budget-usd" in argv and argv[argv.index("--max-budget-usd") + 1] == "1.0"
-    assert "--bare" in argv, "must use --bare to keep auth strictly env/keychain"
+    assert "--bare" not in argv, (
+        "default must NOT pass --bare: in CLI v2.1+ --bare disables keychain/OAuth "
+        "and sanitized_env() strips ANTHROPIC_*, leaving no auth path"
+    )
     assert "--dangerously-skip-permissions" in argv
     assert "--add-dir" in argv and str(tmp_path) in argv
     # session-id is a uuid we generated


### PR DESCRIPTION
## Summary

- Default `RealSubagent.bare` to `False` so spawned `claude -p` can read keychain OAuth credentials
- CLI v2.1+ silently changed `--bare` to disable keychain/OAuth lookup — combined with `sanitized_env()` stripping `ANTHROPIC_*`, the previous default left **no auth path** and every subagent exited with `"Not logged in"` at $0 cost
- Update rule (`.claude/rules/manager-agent.md`) and test (`test_subagent_real.py`) to match new contract

## Why this breaks if shipped as-is

Live smoke before the fix (epic #39, child #40):
```
TRIAGE → exit_code=1, cost=0.0, result="Not logged in · Please run /login"
TRIAGE retry → exit_code=1, cost=0.0, same
→ transition to NEEDS_HUMAN
```
Every retry on every child looped at auth — Manager was effectively unusable on CLI ≥ v2.1.

## Live smoke after fix (this branch)

```
TRIAGE      exit=0  cost=$0.21  → triage.md ("Execution Readiness: ready")
PACKETIZE   exit=0  cost=$0.28  → packet.yaml
PLAN        exit=0  cost=$0.88  → plan.md
PLAN retry  exit=0  cost=$0.39  → plan.md
→ NEEDS_HUMAN (reason: "plan recommendation=confirm first") — intentional
```
Child cost $1.76, epic cost $1.99 / $5.00 cap. **API console shows zero new entries** since the fix landed → all calls went through Max plan keychain OAuth, not API billing.

## Defense-in-depth after the change

Max plan billing is still defended, just by one layer instead of two:
- `sanitized_env()` strips `ANTHROPIC_*` from the spawned env (unchanged)
- `.env` no longer carries `ANTHROPIC_API_KEY` (already the case)
- `RealSubagent.bare` is still a knob — setups that want to pass an explicit API key via `--settings` can opt in

## Test plan

- [x] `pytest manager/tests/ -x -q` — 50 passed
- [x] Live smoke: `python -m manager resume 39 --live --retry 40` reached NEEDS_HUMAN at PLAN as designed
- [x] API console (platform.claude.com/.../logs) shows no entries during smoke window → OAuth path confirmed
- [ ] (post-merge) verify resume past PLAN → IMPLEMENT works after human confirms plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)