### PR TITLE
fix(manager): re-checkout child branch on resume + re-check status after guard

### DIFF
--- a/manager/runner.py
+++ b/manager/runner.py
@@ -38,7 +38,7 @@ from .parsers.packet import parse_packet
 from .parsers.plan import parse_plan
 from .parsers.triage import parse_triage
 from .state_store import StateStore
-from .states import is_legal
+from .states import TERMINAL_STATES, is_legal
 from .subagent import Subagent, SubagentResult
 from .types import (
     ChildState,
@@ -149,8 +149,25 @@ class Runner:
 
     def _run_child(self, epic: EpicState, child_issue: int) -> ChildStatus:
         epic_n = epic["epic_issue_number"]
-        if self.state_store.child_path(epic_n, child_issue).exists():
+        is_resume = self.state_store.child_path(epic_n, child_issue).exists()
+
+        if is_resume:
             child = self.state_store.load_child(epic_n, child_issue)
+            # Resume must re-checkout the child branch. Without this, every git
+            # operation in this run (including `diff_lines` inside
+            # `_guard_checkpoints`) measures from whatever branch the working
+            # tree happens to be on — e.g. after manual state surgery or a
+            # branch switch between Manager invocations — producing a phantom
+            # diff that trips MAX_DIFF_LINES_PER_CHILD on the first iteration.
+            # `create_child_branch` is idempotent: if the branch already
+            # exists it just checks it out.
+            if child["status"] not in TERMINAL_STATES:
+                try:
+                    self.git_ops.create_child_branch(epic["epic_branch"], child_issue)
+                except GitOpsError as exc:
+                    child["needs_human_reason"] = f"resume checkout failed: {exc}"
+                    self.transition(epic, child, "NEEDS_HUMAN")
+                    return "NEEDS_HUMAN"
         else:
             try:
                 branch = self.git_ops.create_child_branch(epic["epic_branch"], child_issue)
@@ -164,8 +181,14 @@ class Runner:
         if child["status"] == "INIT":
             self.transition(epic, child, "TRIAGE")
 
-        while child["status"] not in {"DONE", "SKIPPED", "NEEDS_HUMAN"}:
+        while child["status"] not in TERMINAL_STATES:
             self._guard_checkpoints(epic, child)
+            # _guard_checkpoints can transition status to NEEDS_HUMAN (diff cap
+            # trip). Re-check before the handler lookup — without this, the
+            # next line raises KeyError on `_HANDLERS["NEEDS_HUMAN"]` because
+            # terminal states have no handler.
+            if child["status"] in TERMINAL_STATES:
+                break
             handler = _HANDLERS[child["status"]]
             handler(self, epic, child)
 

--- a/manager/tests/test_runner.py
+++ b/manager/tests/test_runner.py
@@ -233,3 +233,76 @@ def test_artifacts_persisted(
     child_dir = runner.state_store.child_dir(1, 10)
     for name in ("issue.txt", "triage.md", "packet.yaml", "plan.md", "dev_loop.md"):
         assert (child_dir / name).exists(), f"missing artifact: {name}"
+
+
+def test_diff_cap_trip_lands_at_needs_human_without_keyerror(
+    state_root: Path, repo_root: Path, fixtures_dir: Path
+) -> None:
+    """`_guard_checkpoints` can transition status -> NEEDS_HUMAN (diff cap
+    trip). The `_run_child` loop must re-check status before the next
+    handler lookup, otherwise `_HANDLERS["NEEDS_HUMAN"]` raises KeyError
+    (NEEDS_HUMAN is terminal, has no handler).
+    """
+    runner, _esc, git_ops = _build(
+        state_root, repo_root, children=[10],
+        scripted={},  # subagent never called: diff trips before first stage
+    )
+    git_ops.diff_lines_value = 5000  # > MAX_DIFF_LINES_PER_CHILD (1500)
+
+    rc = runner.run_epic(1, slug="test")
+    assert rc == EXIT_NEEDS_HUMAN
+    child = runner.state_store.load_child(1, 10)
+    assert child["status"] == "NEEDS_HUMAN"
+    assert "diff" in (child["needs_human_reason"] or "").lower()
+
+
+def test_resume_checks_out_child_branch(
+    state_root: Path, repo_root: Path, fixtures_dir: Path
+) -> None:
+    """Resuming an existing child must re-invoke `create_child_branch` so the
+    working tree returns to the child branch. Without that, subsequent
+    git_ops calls (diff_lines, find_pr_url) measure from the wrong base.
+    """
+    calls: list[tuple[str, int]] = []
+
+    class _CountingGitOps(DummyGitOps):
+        def create_child_branch(self, epic_branch: str, child_issue: int) -> str:
+            calls.append((epic_branch, child_issue))
+            return super().create_child_branch(epic_branch, child_issue)
+
+    git_ops = _CountingGitOps(
+        child_listing={1: [10]},
+        pr_urls={"epic/1-test-child-10": "https://x/pr/10"},
+        issue_bodies={10: "body"},
+        failures={},
+    )
+    runner = Runner(
+        state_store=StateStore(state_root),
+        subagent=DummySubagent(_happy_scripted(fixtures_dir, 1)),
+        git_ops=git_ops,
+        escalator=DummyEscalator(),
+        repo_root=repo_root,
+    )
+    runner.run_epic(1, slug="test")
+    initial_calls = len(calls)
+    assert initial_calls >= 1, "first run must check out child branch"
+
+    # Reset child to a non-terminal status and re-run: the resume path must
+    # re-checkout. We park it at PLAN with retry counters cleared so the
+    # scripted subagent can drive it the rest of the way.
+    child = runner.state_store.load_child(1, 10)
+    child["status"] = "PLAN"
+    runner.state_store.save_child(1, child)
+    epic = runner.state_store.load_epic(1)
+    epic["children_done"] = []
+    epic["children_queue"] = [10]
+    epic["status"] = "RUNNING"
+    runner.state_store.save_epic(epic)
+
+    # Re-arm scripted responses for the stages the resumed child will run
+    runner.subagent = DummySubagent({
+        "/spec-architect": [make_result(_read(fixtures_dir, "plan_proceed.md"))],
+        "/run-dev-loop": [make_result(_read(fixtures_dir, "dev_loop_safe.md"))],
+    })
+    runner.run_epic(1, slug="test")
+    assert len(calls) > initial_calls, "resume path must call create_child_branch again"


### PR DESCRIPTION
## Summary

Two related bugs surfaced when recovering a child past NEEDS_HUMAN (via `--retry` or manual state surgery):

1. **Resume didn't re-checkout the child branch.** `_run_child` only checked out via `create_child_branch` on the *fresh* path. On resume it assumed the working tree was already on the right branch — so `diff_lines(epic_branch)` measured against whatever branch the user happened to be on between Manager invocations. In the live case this reported 3427 lines, tripping `MAX_DIFF_LINES_PER_CHILD` on the first iteration.

2. **`_guard_checkpoints` could transition status to NEEDS_HUMAN, but the loop didn't re-check before the handler lookup.** When the diff cap tripped, the next line raised `KeyError: 'NEEDS_HUMAN'` (terminal states intentionally have no handler).

## Why this matters

Post-NEEDS_HUMAN flows are the only way to advance a child whose plan needs human confirmation. With these bugs the resume path crashes before the IMPLEMENT stage even gets a chance to run — every retry produces the same KeyError.

## Fix

- Resume path now calls `create_child_branch` (idempotent: checks out the existing branch).
- The per-child while loop re-checks `child["status"]` after `_guard_checkpoints` and breaks if it's terminal.
- Replace the inline ``{"DONE", "SKIPPED", "NEEDS_HUMAN"}`` set with `TERMINAL_STATES` from `states.py` (DRY).

## Test plan

- [x] `pytest manager/tests/ -q` — 78 passed (up from 76, two new cases)
- [x] `test_diff_cap_trip_lands_at_needs_human_without_keyerror` reproduces bug 2: pre-fix raises `KeyError`, post-fix returns `EXIT_NEEDS_HUMAN` cleanly
- [x] `test_resume_checks_out_child_branch` counts `create_child_branch` calls across initial run + resume to prove the resume path now invokes it

## Out of scope

The epic in the original repro (epic #39 / child #40) is rooted on a pre-Manager commit (`4fa6d7a`), so even after these fixes the diff against `epic/39-design-system` is unreasonable. That's a data-shape issue (the epic needs to be rebased onto a manager-aware commit), not a code bug, and is intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)