### PR TITLE
fix(manager): raise EPIC_BUDGET_USD 5→80, reframe as runaway protection

### DIFF
--- a/manager/limits.py
+++ b/manager/limits.py
@@ -14,7 +14,20 @@ VERIFY_PR_MAX_ATTEMPTS: int = 3
 
 SUBAGENT_TIMEOUT_SECONDS: int = 900
 
-EPIC_BUDGET_USD: float = 5.0
+# EPIC_BUDGET_USD is a runaway-protection cap, NOT a billing limit. The
+# `total_cost_usd` value reported by `claude -p` is the equivalent API price
+# computed from token usage; on Claude Max plan (the default auth path —
+# see `manager/subagent.py::RealSubagent` and `.claude/rules/manager-agent.md`)
+# none of it shows up on a card. The cap exists only to stop loops, stuck
+# children, or unexpected fanouts from burning Max plan quota indefinitely.
+#
+# Sizing: typical child runs $1–$3, heavy children with retries can hit
+# $5–$7. 5 heavy children per epic ≈ $35 natural max. Set the cap above
+# that so normal completion never trips it; reserve the trip for true
+# runaways (infinite retry loops, parser bugs, child fanout). $80 also
+# stays inside one 5-hour Max plan window (~$140 on 5x, ~$200+ on 20x)
+# so a runaway gets stopped before exhausting the window.
+EPIC_BUDGET_USD: float = 80.0
 PER_STAGE_BUDGET_USD: float = 1.0
 
 MAX_DIFF_LINES_PER_CHILD: int = 1500


### PR DESCRIPTION
## Summary

\`EPIC_BUDGET_USD\` was sized assuming \`total_cost_usd\` is an actual bill. On Max plan (the only auth path now that PR #45 dropped \`--bare\`) it isn't — it's just the equivalent API price reported for telemetry. The $5 cap was halting normal epics mid-pipeline for no real reason.

## Change

\`manager/limits.py\`:
- \`EPIC_BUDGET_USD: 5.0 → 80.0\`
- Add comment block reframing the constant as **runaway protection** rather than billing, with sizing rationale

## Why $80 (and not $30)

Sizing thought:
- typical child run: $1–$3 (TRIAGE + PACKETIZE + PLAN + IMPLEMENT + VERIFY_PR)
- heavy child with retries (large diff, multi-attempt IMPLEMENT): $5–$7
- 5 heavy children per epic ≈ **$35 natural max**
- 2× safety margin → $70, round to $80

Bounded check: $80 still fits inside **one 5-hour Max plan window** (~$140 on 5x, ~$200+ on 20x), so a runaway loop gets stopped *before* exhausting the window — that's the actual safety goal.

## Why hard-coded (not env-overridable)

\`.claude/rules/manager-agent.md\`:
> リトライ上限・コスト上限・タイムアウトは \`manager/limits.py\` に定数で持つ。env / 引数で動的変更しない

Caps must require a PR review to loosen. This PR is that review.

## Test plan

- [x] \`pytest manager/tests/ -q\` — 78 passed (no test asserts the specific cap value)
- [x] \`grep -r 'EPIC_BUDGET_USD\\|5\\.0' manager/\` — only 4 internal refs, all fine with the new value

## Observed in the wild

Epic #39 hit the previous $5 cap at child #40 IMPLEMENT (\$2.46 spent on TRIAGE+PACKETIZE+PLAN+blocked IMPLEMENT). Same epic with this PR merged should complete child #40 + remaining children inside $80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)