### PR TITLE
fix(manager): raise PER_STAGE_BUDGET_USD 1→10 + account for cost on failed subagent

### DIFF
--- a/manager/limits.py
+++ b/manager/limits.py
@@ -28,7 +28,23 @@ SUBAGENT_TIMEOUT_SECONDS: int = 900
 # stays inside one 5-hour Max plan window (~$140 on 5x, ~$200+ on 20x)
 # so a runaway gets stopped before exhausting the window.
 EPIC_BUDGET_USD: float = 80.0
-PER_STAGE_BUDGET_USD: float = 1.0
+
+# PER_STAGE_BUDGET_USD is passed to `claude -p --max-budget-usd` per subagent
+# call as a soft cap. If the call exceeds it, claude returns
+# `subtype=error_max_budget_usd, is_error=true` and exits non-zero — the
+# work in progress is aborted mid-turn.
+#
+# At $1 the heaviest stage (`/run-dev-loop`) couldn't complete: a real
+# IMPLEMENT involves reading project context + design-system + writing
+# code + invoking implementation-reviewer/test-qa internally, easily
+# 30–50 turns. Empirically a single /run-dev-loop call hit $1 after only
+# 21 turns and bailed before finishing.
+#
+# At $10 cheap stages (TRIAGE ~$0.2–$0.3, PACKETIZE ~$0.3) stay nowhere
+# near the cap; PLAN ~$0.5–$1.5 has comfortable headroom; IMPLEMENT can
+# burn its full ~$5–$8 budget without truncation. The EPIC_BUDGET_USD
+# cap above is still the real safety net against runaways.
+PER_STAGE_BUDGET_USD: float = 10.0
 
 MAX_DIFF_LINES_PER_CHILD: int = 1500
 

--- a/manager/subagent.py
+++ b/manager/subagent.py
@@ -156,11 +156,18 @@ class RealSubagent:
                 session_id=session_id,
             )
         if result.exit_code != 0:
+            # A failed subagent (exit != 0) can still have spent real tokens —
+            # e.g. `claude -p` exits non-zero with `subtype=error_max_budget_usd`
+            # after burning the entire per-stage budget. Parse cost out of the
+            # JSON envelope even on failure so the epic-level accounting is
+            # honest; `_decode_claude_json` returns 0.0 if the body isn't a
+            # valid claude-p result envelope, which is the right fallback.
+            _, failed_cost, _ = _decode_claude_json(result.stdout)
             return SubagentResult(
                 exit_code=result.exit_code,
                 raw_stdout=result.stdout,
                 raw_stderr=result.stderr,
-                cost_usd=0.0,
+                cost_usd=failed_cost,
                 session_id=session_id,
             )
         text, cost, returned_session = _decode_claude_json(result.stdout)

--- a/manager/tests/test_subagent_real.py
+++ b/manager/tests/test_subagent_real.py
@@ -124,6 +124,38 @@ def test_real_subagent_handles_non_zero_exit_non_transient(
     assert calls["n"] == 1, "non-transient failure should NOT retry"
 
 
+def test_real_subagent_extracts_cost_on_non_zero_exit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A failed claude-p can still report cost via the JSON envelope (e.g.
+    `error_max_budget_usd` burns the full budget then exits non-zero). The
+    SubagentResult.cost_usd must reflect that real spend so epic-level
+    accounting is honest.
+    """
+    failed_payload = json.dumps({
+        "type": "result",
+        "subtype": "error_max_budget_usd",
+        "is_error": True,
+        "result": "Reached maximum budget ($10)",
+        "total_cost_usd": 10.057,
+        "session_id": "burned-budget-session",
+    })
+
+    def fake_run(argv: Sequence[str], **kwargs: object) -> CommandResult:
+        return CommandResult(
+            exit_code=1, stdout=failed_payload, stderr="", elapsed_seconds=0.0
+        )
+
+    monkeypatch.setattr(sub_mod, "run", fake_run)
+    sub = RealSubagent(repo_root=tmp_path)
+    result = sub.invoke("/run-dev-loop", "x", budget_usd=10.0)
+    assert result.exit_code == 1, "failure surfaces as non-zero"
+    assert result.cost_usd == pytest.approx(10.057), (
+        "cost from JSON envelope must reach the caller even when claude-p failed; "
+        "otherwise epic accounting silently under-counts every budget-exhausted retry"
+    )
+
+
 def test_real_subagent_retries_on_transient_then_returns(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

Two related issues surfaced when \`/run-dev-loop\` ran on a real IMPLEMENT stage for epic #39 child #40:

### 1. Per-stage budget cap too low

\`PER_STAGE_BUDGET_USD = 1.0\` was sized for cheap stages (TRIAGE/PACKETIZE). It's also passed to \`claude -p --max-budget-usd\` as the soft cap for the heaviest stage, \`/run-dev-loop\`, which:
- reads project context + design-system
- writes \`templates/email.html\`
- internally invokes \`/implementation-reviewer\` and \`/test-qa\`

Observed: a single \`/run-dev-loop\` call hit \$1 after 21 turns and aborted with \`subtype=error_max_budget_usd\`, leaving \`templates/email.html\` half-written. Bumped to \$10 so IMPLEMENT can complete; cheaper stages stay nowhere near the cap.

### 2. Cost accounting under-counts on failed subagent

\`RealSubagent.invoke\` returned \`cost_usd=0.0\` whenever \`exit_code != 0\`. But \`error_max_budget_usd\` is the literal case where the subagent **did spend real tokens** (the whole per-stage budget) and exits non-zero precisely because it spent them. Every budget-exhausted retry silently disappeared from epic accounting.

Concrete impact on epic #39: log showed \$2.69 spent; the real spend (counting failed-budget retries) is closer to \$5+ — within \`EPIC_BUDGET_USD=80\` headroom, but observable bias.

Fix: parse the JSON envelope on failure too. \`_decode_claude_json\` already returns \`(text, 0.0, None)\` for non-JSON bodies, which is the right fallback for legitimate non-cost failures (bad args, malformed output).

## Test plan

- [x] \`pytest manager/tests/ -q\` — 79 passed (one new test, \`test_real_subagent_extracts_cost_on_non_zero_exit\`)
- [x] New test feeds a fake \`error_max_budget_usd\` JSON with \`total_cost_usd=10.057\` and asserts the cost surfaces to the caller despite \`exit_code=1\`
- [x] Existing \`test_real_subagent_handles_non_zero_exit_non_transient\` (no JSON in stdout) still passes — fallback path stays at \$0

## Why hard-coded (not env-overridable)

\`.claude/rules/manager-agent.md\`: caps live in \`manager/limits.py\` with code review. This PR is that review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)