### PR TITLE
feat(email): rewrite digest template with Hibi design system #40

### DIFF
--- a/daily_news.py
+++ b/daily_news.py
@@ -6,7 +6,6 @@ Fetches YouTube uploads + RSS articles → summarizes with Claude → sends Gmai
 import base64
 import hashlib
 import hmac
-import html as html_lib
 import os
 import random
 import sys
@@ -24,7 +23,9 @@ from anthropic import Anthropic
 from db import get_conn, is_already_sent, save_article
 from fetchers import rss as rss_fetcher
 from fetchers import youtube as youtube_fetcher
+from mailer import build_html as build_hibi_html
 from ranking import compute_interest_centroid, cosine_similarity, count_recent_clicks
+from send_mail import format_subject
 
 # ============================================================
 # CONFIG
@@ -212,31 +213,27 @@ def _redirect_url(article_id: str | None, original_url: str) -> str:
 
 
 # ============================================================
-# Build HTML email
+# Build HTML email (Hibi design-system; see `mailer.build_html`)
 # ============================================================
-def build_email_html(sections: list[dict]) -> str:
-    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    html = f"""<html><body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;max-width:640px;margin:0 auto;padding:16px;color:#222;">
-<h1 style="margin:0 0 4px 0;">📰 Personal AI Newspaper</h1>
-<p style="color:#888;margin:0 0 24px 0;">{today}</p>
-"""
+def _sections_to_articles(sections: list[dict]) -> list[dict]:
+    """Flatten `sections` (grouped by source) into the flat `articles` shape
+    `mailer.build_html` expects, applying the click-tracking redirect to
+    each URL so signed `/r/<id>` links survive the new template.
+    """
+    articles: list[dict] = []
     for section in sections:
-        source_name = html_lib.escape(section["source_name"])
-        html += f'<h2 style="border-bottom:2px solid #333;padding-bottom:4px;margin-top:32px;">{source_name}</h2>'
+        source_name = section["source_name"]
         for item in section["items"]:
-            title = html_lib.escape(item["title"])
-            link_url = html_lib.escape(_redirect_url(item.get("article_id"), item["url"]))
-            summary_html = html_lib.escape(item["summary"]).replace("\n", "<br>")
-            html += f"""
-<div style="margin:16px 0;padding:12px 16px;background:#f7f7f7;border-radius:8px;">
-  <h3 style="margin:0 0 8px 0;font-size:16px;">
-    <a href="{link_url}" style="color:#1a73e8;text-decoration:none;">{title}</a>
-  </h3>
-  <div style="color:#444;line-height:1.6;font-size:14px;">{summary_html}</div>
-</div>
-"""
-    html += "</body></html>"
-    return html
+            articles.append({
+                "title": item["title"],
+                "url": _redirect_url(item.get("article_id"), item["url"]),
+                "summary": item["summary"],
+                "source": source_name,
+                # category / source_type / learning / practical_application:
+                # not surfaced by daily_news pipeline yet; `_story_html`
+                # handles their absence gracefully.
+            })
+    return articles
 
 
 # ============================================================
@@ -464,10 +461,11 @@ def main():
         print("\n⚠️  No content to send today.")
         return
 
-    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    html = build_email_html(sections)
+    date_str = datetime.now(timezone.utc).strftime("%Y.%m.%d")
+    articles = _sections_to_articles(sections)
+    html = build_hibi_html(articles, date_str)
     send_email(
-        subject=f"📰 Daily News — {today}",
+        subject=format_subject(date_str, count=len(articles)),
         html_body=html,
         to=recipient,
     )

--- a/mailer.py
+++ b/mailer.py
@@ -1,3 +1,4 @@
+import html
 import os
 import smtplib
 from email.mime.multipart import MIMEMultipart
@@ -9,93 +10,183 @@ SMTP_PORT = 587
 
 TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), "templates", "email.html")
 
-CATEGORY_PILL = {
-    "AI/LLM":    ("AI/LLM",    "pill-ai"),
-    "Frontend":  ("Frontend",  "pill-fe"),
-    "Startup":   ("Startup",   "pill-st"),
-    "Career":    ("Career",    "pill-ca"),
-    "Tech News": ("Tech News", "pill-tn"),
-}
+FONT_JP = (
+    "'Noto Sans JP',system-ui,-apple-system,"
+    "'Yu Gothic','Hiragino Kaku Gothic ProN',sans-serif"
+)
+FONT_EN = "'Inter',system-ui,-apple-system,sans-serif"
 
-STARS = {3: "★★★", 2: "★★☆", 1: "★☆☆"}
+STORY_WRAPPER = (
+    "padding:28px 48px;border-bottom:1px solid #E8E6E1;"
+)
+STORY_WRAPPER_LAST = (
+    "padding:28px 48px;"
+)
+NUM_STYLE = (
+    f"font-family:{FONT_EN};font-variant-numeric:tabular-nums;"
+    "font-weight:500;font-size:32px;color:#1A1A1A;line-height:1;"
+    "letter-spacing:-0.02em;width:48px;vertical-align:top;padding-right:24px;"
+)
+META_STYLE = (
+    f"font-family:{FONT_EN};font-size:10px;letter-spacing:0.25em;"
+    "text-transform:uppercase;color:#9B9894;margin-bottom:10px;"
+)
+META_SEP_STYLE = "color:#E8E6E1;padding:0 8px;"
+META_CAT_STYLE = "color:#1A1A1A;font-weight:500;"
+H2_STYLE = (
+    f"font-family:{FONT_JP};font-size:22px;font-weight:700;line-height:1.35;"
+    "color:#1A1A1A;margin:0 0 12px;letter-spacing:-0.01em;"
+)
+P_STYLE = (
+    f"font-family:{FONT_JP};font-size:15px;line-height:1.75;"
+    "color:#5C5A57;margin:0 0 6px;"
+)
+SRC_STYLE = (
+    f"margin-top:14px;font-family:{FONT_EN};font-size:11px;"
+    "letter-spacing:0.15em;text-transform:uppercase;color:#9B9894;"
+)
+SRC_LINK_STYLE = (
+    "color:#1A1A1A;border-bottom:1px solid #1A1A1A;"
+    "padding-bottom:1px;text-decoration:none;"
+)
 
-GROUP_LABELS = {
-    3: "★★★ 最重要 — Kazuki's priorities",
-    2: "★★☆ 注目",
-    1: "★☆☆ その他",
-}
+SOURCE_ROW_STYLE = (
+    f"font-family:{FONT_EN};font-size:12px;letter-spacing:0.05em;color:#1A1A1A;"
+    "padding:6px 0;border-bottom:1px solid #E8E6E1;"
+)
+SOURCE_KIND_STYLE = (
+    "color:#9B9894;font-size:10px;letter-spacing:0.2em;text-transform:uppercase;"
+    "text-align:right;"
+)
 
 
-def _pill(category: str) -> str:
-    label, css = CATEGORY_PILL.get(category, ("Tech News", "pill-tn"))
-    return f'<span class="pill {css}">{label}</span>'
+def _story_html(index: int, article: dict, is_last: bool) -> str:
+    """Render a single Story row matching design-system/ui_kits/email.
 
+    User-controlled strings (title, summary, learning, practical, category,
+    source name, source type, url) are escaped before interpolation so a feed
+    containing `&`, `<`, `>`, or a stray `"` can't corrupt the rendered Gmail
+    body or break the anchor `href`. URLs go through `quote=True` so quotes
+    inside an href are neutralized.
+    """
+    title = html.escape(article.get("title", ""))
+    url = html.escape(article.get("url", "#"), quote=True)
+    summary = html.escape(article.get("summary", ""))
+    learning = html.escape(article.get("learning", ""))
+    practical = html.escape(article.get("practical_application", ""))
+    category = html.escape(article.get("category") or "News")
+    source_name = html.escape(article.get("source") or article.get("source_name") or "")
+    source_type = html.escape(article.get("source_type") or "")
 
-def _article_html(article: dict) -> str:
-    title = article.get("title", "")
-    url = article.get("url", "#")
-    summary = article.get("summary", "")
-    learning = article.get("learning", "")
-    practical = article.get("practical_application", "")
-    category = article.get("category", "Tech News")
-    importance = article.get("importance", 1)
+    # Meta line: CATEGORY · SOURCE_TYPE (caps), no emoji, no pill backgrounds.
+    meta_parts: list[str] = [f'<span style="{META_CAT_STYLE}">{category}</span>']
+    if source_type:
+        meta_parts.append(f'<span style="{META_SEP_STYLE}">·</span>')
+        meta_parts.append(f"<span>{source_type}</span>")
+    meta_html = "".join(meta_parts)
 
-    fields = ""
+    body_parts: list[str] = []
     if summary:
-        fields += f"""
-        <div class="field">
-          <div class="field-label">概要</div>
-          <div class="field-body">{summary}</div>
-        </div>"""
+        body_parts.append(f'<p style="{P_STYLE}">{summary}</p>')
     if learning:
-        fields += f"""
-        <div class="field">
-          <div class="field-label">学べること</div>
-          <div class="field-body">{learning}</div>
-        </div>"""
+        body_parts.append(f'<p style="{P_STYLE}">{learning}</p>')
     if practical:
-        fields += f"""
-        <div class="field">
-          <div class="field-label">実践的な応用</div>
-          <div class="field-body">{practical}</div>
-        </div>"""
+        body_parts.append(f'<p style="{P_STYLE}">{practical}</p>')
+    body_html = "".join(body_parts)
 
-    return f"""
-    <div class="article">
-      <div class="article-header">
-        {_pill(category)}
-        <span class="stars">{STARS.get(importance, "★☆☆")}</span>
-      </div>
-      <div class="article-title">{title}</div>
-      {fields}
-      <a class="source-link" href="{url}" target="_blank">→ ソースを読む</a>
-    </div>"""
+    src_label = source_name or "Source"
+    src_html = (
+        f'<div style="{SRC_STYLE}">'
+        f'Source <a href="{url}" style="{SRC_LINK_STYLE}">{src_label}</a>'
+        f"</div>"
+    )
+
+    wrapper = STORY_WRAPPER_LAST if is_last else STORY_WRAPPER
+    return (
+        f'<article style="{wrapper}">'
+        '<table role="presentation" width="100%" cellpadding="0" '
+        'cellspacing="0" border="0" style="border-collapse:collapse;">'
+        "<tr>"
+        f'<td style="{NUM_STYLE}">{index:02d}</td>'
+        "<td>"
+        f'<div style="{META_STYLE}">{meta_html}</div>'
+        f'<h2 style="{H2_STYLE}">{title}</h2>'
+        f"{body_html}"
+        f"{src_html}"
+        "</td>"
+        "</tr>"
+        "</table>"
+        "</article>"
+    )
+
+
+def _sources_html(articles: list[dict]) -> str:
+    """Render the Sources block as a 2-column table.
+
+    Inline styles only; styles come from design-system tokens (no class refs).
+    """
+    seen: dict[str, str] = {}
+    for a in articles:
+        name = a.get("source") or a.get("source_name")
+        if not name:
+            continue
+        if name not in seen:
+            seen[name] = a.get("source_type") or ""
+    if not seen:
+        return ""
+
+    items = [(html.escape(name), html.escape(kind)) for name, kind in seen.items()]
+    rows: list[str] = []
+    for i in range(0, len(items), 2):
+        left_name, left_kind = items[i]
+        right = items[i + 1] if i + 1 < len(items) else None
+        left_cell = (
+            f'<td style="{SOURCE_ROW_STYLE}">{left_name}'
+            f'<span style="{SOURCE_KIND_STYLE};margin-left:12px;">{left_kind}</span>'
+            "</td>"
+        )
+        if right is None:
+            right_cell = (
+                f'<td style="{SOURCE_ROW_STYLE};border-bottom:none;"></td>'
+            )
+        else:
+            right_name, right_kind = right
+            right_cell = (
+                f'<td style="{SOURCE_ROW_STYLE};padding-left:24px;">{right_name}'
+                f'<span style="{SOURCE_KIND_STYLE};margin-left:12px;">{right_kind}</span>'
+                "</td>"
+            )
+        rows.append(f"<tr>{left_cell}{right_cell}</tr>")
+    return "".join(rows)
 
 
 def build_html(articles: list[dict], date: str) -> str:
-    """Build HTML email from enriched articles list."""
+    """Build the daily email HTML from enriched article dicts.
+
+    Articles are rendered top-to-bottom with numeric prefix 01..N matching
+    design-system/ui_kits/email. Importance scores no longer drive layout —
+    Hibi's design-system removes group headings, pills, and stars.
+    """
     with open(TEMPLATE_PATH, encoding="utf-8") as f:
         template = Template(f.read())
 
-    # Sort by importance descending
-    sorted_articles = sorted(articles, key=lambda a: -a.get("importance", 1))
+    article_blocks: list[str] = []
+    total = len(articles)
+    for idx, article in enumerate(articles, start=1):
+        article_blocks.append(
+            _story_html(idx, article, is_last=(idx == total))
+        )
+    articles_html = "".join(article_blocks)
 
-    articles_html = ""
-    current_group = None
-    for article in sorted_articles:
-        importance = article.get("importance", 1)
-        if importance != current_group:
-            current_group = importance
-            articles_html += f'<div class="group-heading">{GROUP_LABELS[importance]}</div>'
-        articles_html += _article_html(article)
-
-    sources = sorted({a.get("source", "") for a in articles if a.get("source")})
+    sources_html = _sources_html(articles)
+    source_count = len({a.get("source") or a.get("source_name") for a in articles if a.get("source") or a.get("source_name")})
 
     return template.safe_substitute(
         date=date,
         article_count=len(articles),
         articles_html=articles_html,
-        source_count=len(sources),
+        sources_html=sources_html,
+        source_count=source_count,
     )
 
 

--- a/send_mail.py
+++ b/send_mail.py
@@ -16,6 +16,14 @@ from mailer import send
 load_dotenv()
 
 
+def format_subject(date_str: str, count: int) -> str:
+    """Build the daily subject line.
+
+    Format: ``YYYY.MM.DD — 今朝のN本`` (half-width period + em-dash, no emoji).
+    """
+    return f"{date_str} — 今朝の{count}本"
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--subject", default=None, help="Email subject (default: auto-generated)")
@@ -23,11 +31,12 @@ def main():
     parser.add_argument("--date", default=None, help="Date string shown in email header (default: today)")
     args = parser.parse_args()
 
-    date_str = args.date or date.today().strftime("%Y-%m-%d")
-    subject = args.subject or f"Daily Tech News - {date_str}"
+    date_str = args.date or date.today().strftime("%Y.%m.%d")
 
     with open(args.from_enriched, encoding="utf-8") as f:
         articles = json.load(f)
+
+    subject = args.subject or format_subject(date_str, count=len(articles))
 
     gmail_address = os.environ["GMAIL_ADDRESS"]
     gmail_password = os.environ["GMAIL_APP_PASSWORD"]

--- a/templates/email.html
+++ b/templates/email.html
@@ -1,184 +1,64 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Personal AI Newspaper</title>
-  <style>
-    * { box-sizing: border-box; margin: 0; padding: 0; }
-
-    body {
-      font-family: -apple-system, 'Helvetica Neue', Arial, sans-serif;
-      background: #f0f2f5;
-      color: #1a1a2e;
-      padding: 24px 16px;
-    }
-
-    .wrapper {
-      max-width: 680px;
-      margin: 0 auto;
-    }
-
-    /* ── Header ── */
-    .header {
-      background: linear-gradient(135deg, #1a1a2e 0%, #16213e 60%, #0f3460 100%);
-      border-radius: 12px 12px 0 0;
-      padding: 32px 36px 28px;
-      color: white;
-    }
-    .header-label {
-      font-size: 11px;
-      font-weight: 600;
-      letter-spacing: 2px;
-      text-transform: uppercase;
-      color: #94a3b8;
-      margin-bottom: 8px;
-    }
-    .header-title {
-      font-size: 28px;
-      font-weight: 700;
-      margin-bottom: 12px;
-    }
-    .header-meta {
-      display: flex;
-      gap: 20px;
-      font-size: 13px;
-      color: #94a3b8;
-    }
-    .header-meta span { display: flex; align-items: center; gap: 5px; }
-
-    /* ── Body ── */
-    .body {
-      background: white;
-      padding: 28px 36px;
-    }
-
-    /* ── Article card ── */
-    .article {
-      border: 1px solid #e8ecf0;
-      border-radius: 10px;
-      padding: 20px 22px;
-      margin-bottom: 16px;
-      transition: box-shadow 0.15s;
-    }
-    .article:last-child { margin-bottom: 0; }
-
-    .article-header {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      margin-bottom: 10px;
-      flex-wrap: wrap;
-    }
-
-    /* Category pill */
-    .pill {
-      display: inline-block;
-      padding: 2px 10px;
-      border-radius: 999px;
-      font-size: 11px;
-      font-weight: 600;
-      letter-spacing: 0.4px;
-      white-space: nowrap;
-    }
-    .pill-ai    { background: #ede9fe; color: #6d28d9; }
-    .pill-fe    { background: #dbeafe; color: #1d4ed8; }
-    .pill-st    { background: #dcfce7; color: #15803d; }
-    .pill-ca    { background: #fff7ed; color: #c2410c; }
-    .pill-tn    { background: #f3f4f6; color: #374151; }
-
-    /* Importance stars */
-    .stars {
-      font-size: 13px;
-      letter-spacing: 1px;
-      color: #f59e0b;
-      margin-left: auto;
-    }
-
-    .article-title {
-      font-size: 16px;
-      font-weight: 700;
-      color: #111827;
-      margin-bottom: 14px;
-      line-height: 1.4;
-    }
-
-    /* Fields */
-    .field { margin-bottom: 10px; }
-    .field:last-child { margin-bottom: 0; }
-    .field-label {
-      font-size: 10px;
-      font-weight: 700;
-      letter-spacing: 1.2px;
-      text-transform: uppercase;
-      color: #9ca3af;
-      margin-bottom: 3px;
-    }
-    .field-body {
-      font-size: 13.5px;
-      line-height: 1.65;
-      color: #374151;
-    }
-
-    .source-link {
-      display: inline-block;
-      margin-top: 12px;
-      font-size: 12px;
-      color: #6366f1;
-      text-decoration: none;
-      font-weight: 500;
-    }
-    .source-link:hover { text-decoration: underline; }
-
-    /* Divider between importance groups */
-    .group-heading {
-      font-size: 11px;
-      font-weight: 700;
-      letter-spacing: 1.5px;
-      text-transform: uppercase;
-      color: #9ca3af;
-      padding: 16px 0 10px;
-      border-top: 1px solid #f3f4f6;
-      margin-top: 8px;
-    }
-    .group-heading:first-child { border-top: none; padding-top: 0; margin-top: 0; }
-
-    /* ── Footer ── */
-    .footer {
-      background: #f8fafc;
-      border-top: 1px solid #e8ecf0;
-      border-radius: 0 0 12px 12px;
-      padding: 20px 36px;
-      text-align: center;
-      font-size: 12px;
-      color: #9ca3af;
-    }
-    .footer strong { color: #6b7280; }
-  </style>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>日々 — $date</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Noto+Serif+JP:wght@400;500;700&family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
 </head>
-<body>
-  <div class="wrapper">
+<body style="margin:0;padding:32px 16px;background:#FAFAF7;font-family:'Noto Sans JP',system-ui,-apple-system,'Yu Gothic','Hiragino Kaku Gothic ProN',sans-serif;color:#1A1A1A;-webkit-font-smoothing:antialiased;">
+<div style="max-width:680px;margin:0 auto;background:#FFFFFF;">
 
-    <!-- Header -->
-    <div class="header">
-      <div class="header-label">Daily Intelligence Briefing</div>
-      <div class="header-title">Personal AI Newspaper</div>
-      <div class="header-meta">
-        <span>📅 $date</span>
-        <span>📰 $article_count 記事</span>
-      </div>
-    </div>
+  <header style="border-top:2px solid #1A1A1A;border-bottom:1px solid #E8E6E1;padding:32px 48px 28px;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;">
+      <tr>
+        <td valign="bottom" style="vertical-align:baseline;">
+          <table role="presentation" cellpadding="0" cellspacing="0" border="0"><tr>
+            <td style="font-family:'Noto Serif JP','Hiragino Mincho ProN',serif;font-weight:700;font-size:56px;line-height:1;letter-spacing:-0.02em;color:#1A1A1A;padding-right:18px;">日々</td>
+            <td style="font-family:'Inter',system-ui,-apple-system,sans-serif;font-size:10px;letter-spacing:0.25em;text-transform:uppercase;color:#5C5A57;border-left:1px solid #E8E6E1;padding-left:16px;line-height:1.5;">
+              <strong style="color:#1A1A1A;font-weight:500;">HIBI</strong><br>
+              DAILY · TOKYO
+            </td>
+          </tr></table>
+        </td>
+        <td align="right" valign="bottom" style="vertical-align:baseline;font-family:'Inter',system-ui,-apple-system,sans-serif;font-variant-numeric:tabular-nums;letter-spacing:0.2em;font-size:13px;color:#1A1A1A;text-align:right;line-height:1.5;">
+          $date
+          <div style="font-size:10px;color:#9B9894;letter-spacing:0.25em;text-transform:uppercase;">$article_count STORIES</div>
+        </td>
+      </tr>
+    </table>
+  </header>
 
-    <!-- Articles -->
-    <div class="body">
-      $articles_html
-    </div>
+  <section style="padding:28px 48px 24px;border-bottom:1px solid #E8E6E1;font-family:'Noto Sans JP',system-ui,-apple-system,'Yu Gothic','Hiragino Kaku Gothic ProN',sans-serif;font-size:18px;font-weight:400;line-height:1.6;color:#5C5A57;">
+    <em style="font-style:normal;color:#1A1A1A;font-weight:500;">今朝の$article_count本。</em>静かな朝の読みもの。
+  </section>
 
-    <!-- Footer -->
-    <div class="footer">
-      <strong>$source_count sources</strong> &nbsp;·&nbsp; Generated by Personal AI Newspaper
-    </div>
+  $articles_html
 
-  </div>
+  <section style="padding:32px 48px;border-top:1px solid #1A1A1A;background:#FAFAF7;">
+    <div style="font-family:'Inter',system-ui,-apple-system,sans-serif;font-size:10px;letter-spacing:0.25em;text-transform:uppercase;color:#9B9894;margin-bottom:14px;">Sources scanned this morning</div>
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;">
+      $sources_html
+    </table>
+  </section>
+
+  <footer style="padding:32px 48px 40px;background:#FAFAF7;border-top:1px solid #E8E6E1;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;">
+      <tr>
+        <td valign="top" style="vertical-align:top;">
+          <img src="https://raw.githubusercontent.com/kazuki-0418/Personal-Daily-News/main/design-system/ui_kits/email/seal.svg" width="72" height="72" alt="日々 seal" style="display:block;border:0;">
+        </td>
+        <td align="right" valign="top" style="vertical-align:top;font-family:'Inter',system-ui,-apple-system,sans-serif;font-size:11px;letter-spacing:0.15em;color:#9B9894;text-align:right;line-height:1.7;">
+          <div style="font-family:'Noto Sans JP',system-ui,-apple-system,'Yu Gothic','Hiragino Kaku Gothic ProN',sans-serif;letter-spacing:0;font-size:12px;color:#9B9894;">日々の小さな知らせ。</div>
+          Generated $date JST<br>
+          $source_count sources scanned
+        </td>
+      </tr>
+    </table>
+  </footer>
+
+</div>
 </body>
 </html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Top-level conftest. Adds the repo root to sys.path so the root-level
+modules (mailer, send_mail, daily_news, ...) import cleanly under pytest."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))

--- a/tests/test_email_template.py
+++ b/tests/test_email_template.py
@@ -1,0 +1,253 @@
+"""Template / mailer rendering tests for the design-system migration.
+
+Covered behaviors:
+- Story rendering produces numeric prefixes 01..N in order.
+- No emoji codepoints appear in the rendered HTML or subject.
+- Subject format ``YYYY.MM.DD — 今朝のN本`` (half-width period, em-dash).
+- Font stack includes the Google Fonts ``<link>`` plus a system fallback chain.
+- Seal SVG is referenced exactly once via a GitHub raw URL.
+- ``mailer.send`` signature stays exactly: (subject, articles, date, to,
+  from_addr, password) -> None. Old design-system fields (pill / star /
+  group) must not appear in the body.
+"""
+from __future__ import annotations
+
+import inspect
+import re
+import unicodedata
+from typing import Iterable
+
+import mailer
+from send_mail import format_subject
+
+SAMPLE_ARTICLES: list[dict] = [
+    {
+        "title": "Anthropic、Claude Sonnet 4.6 を公開",
+        "url": "https://anthropic.example/news/sonnet-4-6",
+        "summary": "長文要約とコード生成の精度が前世代比で大幅に向上した。",
+        "category": "AI/LLM",
+        "source": "Anthropic",
+        "source_type": "YouTube",
+    },
+    {
+        "title": "CSS Anchor Positioning がブラウザ三社で揃う",
+        "url": "https://web.dev/anchor-positioning",
+        "summary": "Firefox 138 で実装が揃った。",
+        "category": "Frontend",
+        "source": "web.dev",
+        "source_type": "RSS",
+    },
+    {
+        "title": "東京の AI スタートアップ二社が同日に調達発表",
+        "url": "https://thebridge.example/tokyo-ai",
+        "summary": "Sakana AI 系列のスピンアウトが Series A で十二億円を調達。",
+        "category": "Startup",
+        "source": "Bridge",
+        "source_type": "RSS",
+    },
+    {
+        "title": "開発者の燃え尽きについて静かな考察",
+        "url": "https://youtube.example/burnout",
+        "summary": "十年目のエンジニアが燃え尽き経験を一人語りで振り返る。",
+        "category": "Career",
+        "source": "Lex Fridman",
+        "source_type": "YouTube",
+    },
+    {
+        "title": "Bun 1.4、Node 互換性で実用域へ",
+        "url": "https://bun.example/1-4",
+        "summary": "Node.js の主要モジュールほぼ全てで互換性テストに通過した。",
+        "category": "Tooling",
+        "source": "Bun Blog",
+        "source_type": "RSS",
+    },
+]
+
+
+def _contains_emoji(text: str) -> bool:
+    """Return True iff ``text`` contains any Emoji/Symbol/Pictograph codepoints.
+
+    We flag the ranges Hibi's old template leaked into output:
+    - Pictographs / dingbats (U+2600..U+27BF)
+    - Stars used as importance markers (U+2605, U+2606)
+    - Variation selectors that pair with emoji (U+FE0F)
+    - Emoji planes (U+1F300..U+1FAFF)
+    """
+    for ch in text:
+        cp = ord(ch)
+        if 0x2600 <= cp <= 0x27BF:
+            return True
+        if cp in (0x2605, 0x2606, 0xFE0F):
+            return True
+        if 0x1F300 <= cp <= 0x1FAFF:
+            return True
+        # General Category 'So' (Other Symbol) catches the rest pragmatically.
+        if unicodedata.category(ch) == "So":
+            return True
+    return False
+
+
+def _all_text(strings: Iterable[str]) -> str:
+    return "\n".join(strings)
+
+
+# ── Story render — numeric prefixes, Masthead / Sources / Colophon ──────
+
+
+def test_build_html_renders_numeric_prefixes_in_order() -> None:
+    html = mailer.build_html(SAMPLE_ARTICLES, "2026.05.10")
+    for i, _ in enumerate(SAMPLE_ARTICLES, start=1):
+        # Each story has its 0N prefix in a <td>… numeric cell.
+        assert f">{i:02d}</td>" in html, f"expected 0{i} prefix in story {i}"
+    # Stories appear in the same order as input.
+    positions = [html.index(f">{i:02d}</td>") for i in range(1, 6)]
+    assert positions == sorted(positions)
+
+
+def test_build_html_contains_masthead_sources_and_colophon() -> None:
+    html = mailer.build_html(SAMPLE_ARTICLES, "2026.05.10")
+    assert "日々" in html  # Masthead wordmark
+    assert "DAILY · TOKYO" in html  # Masthead meta
+    assert "今朝の5本。" in html  # Standfirst
+    assert "Sources scanned this morning" in html  # Sources label
+    assert "日々の小さな知らせ。" in html  # Colophon tagline
+
+
+def test_build_html_drops_pill_and_star_markup() -> None:
+    html = mailer.build_html(SAMPLE_ARTICLES, "2026.05.10")
+    # Old design artifacts must be gone — these would survive into the
+    # rendered body if mailer fell back to the pre-design-system template.
+    forbidden = ['class="pill', "★", "★★☆", "group-heading", "最重要"]
+    for marker in forbidden:
+        assert marker not in html, f"unexpected legacy marker {marker!r} in body"
+
+
+# ── Emoji-free output ──────────────────────────────────────────────────
+
+
+def test_rendered_html_contains_no_emoji() -> None:
+    html = mailer.build_html(SAMPLE_ARTICLES, "2026.05.10")
+    assert not _contains_emoji(html), "rendered email body must not contain emoji"
+
+
+def test_subject_contains_no_emoji() -> None:
+    subject = format_subject("2026.05.10", count=5)
+    assert not _contains_emoji(subject), "subject must not contain emoji"
+
+
+# ── Subject format ─────────────────────────────────────────────────────
+
+
+def test_subject_format_matches_design_system() -> None:
+    subject = format_subject("2026.05.10", count=5)
+    assert subject == "2026.05.10 — 今朝の5本"
+    # Half-width period + em-dash, not full-width period or hyphen.
+    assert "．" not in subject
+    assert "—" in subject and "-" not in subject
+
+
+def test_subject_format_uses_dot_separated_date() -> None:
+    # Regex anchors the YYYY.MM.DD shape — guards against ISO-style drift.
+    subject = format_subject("2026.05.10", count=5)
+    assert re.match(r"^\d{4}\.\d{2}\.\d{2} — 今朝の\d+本$", subject)
+
+
+# ── Font fallback ──────────────────────────────────────────────────────
+
+
+def test_html_loads_google_fonts_via_preconnect_and_link() -> None:
+    html = mailer.build_html(SAMPLE_ARTICLES, "2026.05.10")
+    assert 'rel="preconnect" href="https://fonts.googleapis.com"' in html
+    assert 'rel="preconnect" href="https://fonts.gstatic.com"' in html
+    assert "fonts.googleapis.com/css2?family=Noto+Sans+JP" in html
+
+
+def test_html_includes_system_font_fallback_stack() -> None:
+    html = mailer.build_html(SAMPLE_ARTICLES, "2026.05.10")
+    # The fallback chain Gmail/Apple Mail will use when CDN fonts fail.
+    # Order matters: Noto Sans JP → system-ui → -apple-system → Yu Gothic →
+    # Hiragino Kaku Gothic ProN.
+    stack = (
+        "'Noto Sans JP',system-ui,-apple-system,"
+        "'Yu Gothic','Hiragino Kaku Gothic ProN',sans-serif"
+    )
+    assert stack in html
+
+
+# ── Seal SVG via GitHub raw URL ────────────────────────────────────────
+
+
+def test_seal_svg_referenced_via_github_raw_url_exactly_once() -> None:
+    html = mailer.build_html(SAMPLE_ARTICLES, "2026.05.10")
+    matches = re.findall(
+        r"https://raw\.githubusercontent\.com/[^\"']+/seal\.svg",
+        html,
+    )
+    assert len(matches) == 1, f"expected exactly one seal.svg raw URL, got {matches!r}"
+
+
+# ── Hairline rule color (Gmail / Apple Mail) ───────────────────────────
+
+
+def test_html_uses_design_system_hairline_color() -> None:
+    html = mailer.build_html(SAMPLE_ARTICLES, "2026.05.10")
+    # The single hairline color used for rules / borders per design tokens.
+    assert "1px solid #E8E6E1" in html
+    # No alternative grays leaking from the legacy template.
+    assert "#e8ecf0" not in html.lower()
+
+
+# ── mailer.send interface contract ─────────────────────────────────────
+
+
+def test_mailer_send_signature_unchanged() -> None:
+    sig = inspect.signature(mailer.send)
+    params = list(sig.parameters)
+    assert params == ["subject", "articles", "date", "to", "from_addr", "password"]
+    assert sig.return_annotation is None
+
+
+def test_build_html_returns_str_with_inline_styles_only() -> None:
+    html = mailer.build_html(SAMPLE_ARTICLES, "2026.05.10")
+    assert isinstance(html, str) and len(html) > 0
+    # The design-system migration inlines tokens via style="…" attributes;
+    # no <style> block, no premailer/juice dependency.
+    assert "<style" not in html.lower()
+    # Token color literals from design-system/colors_and_type.css.
+    for token in ("#1A1A1A", "#5C5A57", "#9B9894", "#FAFAF7", "#E8E6E1"):
+        assert token in html
+
+
+# ── HTML escaping of user-controlled fields ────────────────────────────
+
+
+def test_build_html_escapes_dangerous_chars_in_user_fields() -> None:
+    """A feed title containing `&`, `<`, `>`, or a stray `"` must not corrupt
+    the rendered Gmail body or break the anchor `href` attribute. The legacy
+    `daily_news.build_email_html` escaped these via `html.escape()`; the
+    Hibi-template path must preserve that property since it now owns the
+    production email render.
+    """
+    hostile = [{
+        "title": 'Anthropic & "Claude" <release>',
+        "url": 'https://x.example/p?q="unsafe"&a=<b>',
+        "summary": "Body with <script>alert(1)</script> and ampersand & quoted \"text\".",
+        "category": 'AI & <ML>',
+        "source": 'Source "Bridge" & co.',
+        "source_type": 'RSS <feed>',
+    }]
+    rendered = mailer.build_html(hostile, "2026.05.10")
+
+    # None of the raw dangerous characters survive into the body. We check
+    # for the specific dangerous substrings rather than just `<` (which the
+    # template legitimately uses) by looking for unescaped attacker payloads.
+    assert "<script>" not in rendered, "raw <script> escaped into body"
+    assert "<release>" not in rendered, "raw `<release>` survived"
+    assert "<ML>" not in rendered, "raw `<ML>` survived"
+    assert "<feed>" not in rendered, "raw `<feed>` survived"
+    # An href containing an unescaped double quote would break the attribute.
+    # The url should have `&quot;` (or `&#x27;`) in place of the literal `"`.
+    assert 'href="https://x.example/p?q="' not in rendered, "raw `\"` in href"
+    # The escaped form must be present.
+    assert "&amp;" in rendered, "ampersand should be escaped to &amp;"
+    assert "&lt;" in rendered and "&gt;" in rendered, "angle brackets escaped"


### PR DESCRIPTION
Closes #40.

## Summary

Migrate the daily-news email from the legacy purple-gradient template (\`📰 Personal AI Newspaper\`) to the Hibi design-system template (\`日々\`).

A previous Manager IMPLEMENT run produced a correct \`mailer.py\` / \`send_mail.py\` rewrite but **never wired it into \`daily_news.py\`** — which is what \`.github/workflows/daily-news.yml\` actually runs. The change wouldn't have reached the inbox. This PR completes the wiring and removes the legacy \`build_email_html\`.

(For full Manager-run context see PR #45–#49 in this branch's history.)

## Changes

### \`daily_news.py\`
- Drop inline \`build_email_html\` (purple gradient HTML).
- Route through \`mailer.build_html\` via a flat \`_sections_to_articles\` adapter; preserve click-tracking \`_redirect_url\` so signed \`/r/<id>\` links survive.
- Subject becomes \`YYYY.MM.DD — 今朝のN本\` via \`send_mail.format_subject\` (no emoji).

### \`mailer.py\`
- New \`build_html\` + \`_story_html\` + \`_sources_html\` rendering the design-system markup.
- **Added \`html.escape()\` around user-controlled fields** (title/url/summary/learning/practical/category/source/source_type). The dev-loop reviewer flagged escaping as missing; the legacy \`daily_news.build_email_html\` did escape, so this PR keeps that property.

### \`send_mail.py\`
- \`format_subject\` helper.
- CLI entry point for the enriched-articles JSON dev/test path.

### \`templates/email.html\`
- Design-system markup (inline styles only, no \`<style>\` block, no premailer dependency).

### \`tests/test_email_template.py\`
14 tests covering:
- numeric story prefixes (\`01\`..\`05\`)
- Masthead / Sources / Colophon presence
- subject format \`YYYY.MM.DD — 今朝のN本\`
- no-emoji invariant (body + subject)
- \`mailer.send\` signature stability
- inline-styles-only rendering
- HTML escaping of hostile feed values (new)

## Production effect

The cron runs \`python daily_news.py\` → \`mailer.build_html\` → \`templates/email.html\`. The email actually delivered to subscribers becomes the new Hibi template starting from the next run after merge.

## Test plan

- [x] \`pytest tests/ manager/tests/ -q\` — 93 passed
- [x] Manual smoke (no email send): \`_sections_to_articles\` flattens grouped sections correctly, \`build_hibi_html\` returns 8896-char HTML for a 3-article fixture, subject is \`2026.05.11 — 今朝の3本\`, no \`📰\` in body or subject
- [ ] **Post-merge**: Watch the next \`daily-news.yml\` cron run and confirm the rendered email matches \`design-system/ui_kits/email/index.html\`

## Out of scope (already flagged by dev-loop reviewer, deferred)

- Pipeline doesn't yet surface \`category\` / \`source_type\` / \`learning\` / \`practical_application\` per article. \`_story_html\` handles their absence gracefully (defaults to \`News\` / empty), but enriching the pipeline would let the template show more detail.
- \`daily_news.py --dry-run\` doesn't exist; smoke test was the closest available.
- \`source_count\` duplicated logic with \`_sources_html\`'s \`seen\` dict — minor refactor opportunity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)