### PR TITLE
feat(db): editions table DDL (PR1 of #51 split)

### DIFF
--- a/migrations/004_editions.sql
+++ b/migrations/004_editions.sql
@@ -1,0 +1,37 @@
+-- ================================================================
+-- Editions schema (DDL only — PR1 of #51's 3-PR split)
+--
+--   * `editions` table — 1 メール / 1 web ページ = 1 edition の集約単位
+--     `issue_no` は配信日順に決定的に振る（auto-increment ではない）。
+--     `standfirst` / `daily_title` は #T4-3 で埋める。
+--     `sources_scanned` は #T4-2 で埋める。
+--
+--   * `articles.edition_id` — 既存 articles を edition に紐付ける
+--     nullable FK。backfill は別 migration / scripts/ で行い、
+--     全件が埋まったことを確認した後、別 PR で NOT NULL 化する想定。
+--     ここを直接 NOT NULL にすると既存行が無 edition で残ったまま
+--     migration が走るので、backfill との順序が乱れる。
+--
+-- 2 回流しても壊れないよう全部 idempotent。
+--
+-- 同日複数配信を禁ずる `editions.date UNIQUE` を入れている。将来
+-- 「号外」要件が出た場合はこの UNIQUE を外し、(date, issue_no) の
+-- 複合 UNIQUE などに切り替える別 migration を切ること。
+--
+-- 関連: epic #39 / issue #51
+-- ================================================================
+
+CREATE TABLE IF NOT EXISTS editions (
+    issue_no        INTEGER     PRIMARY KEY,
+    date            DATE        NOT NULL UNIQUE,
+    standfirst      TEXT,
+    daily_title     TEXT,
+    sources_scanned JSONB,
+    generated_at    TIMESTAMPTZ DEFAULT now()
+);
+
+-- articles に nullable FK を追加。backfill 後の NOT NULL 化は別 PR。
+ALTER TABLE articles
+    ADD COLUMN IF NOT EXISTS edition_id INTEGER REFERENCES editions(issue_no);
+
+CREATE INDEX IF NOT EXISTS articles_edition_id_idx ON articles (edition_id);


### PR DESCRIPTION
First of the 3-PR split for #51. **DDL only** — no backfill, no NOT NULL flip, no \`daily_news.py\` wiring.

Refs #51.

## Changes

- New table \`editions\`:
  - \`issue_no INTEGER PRIMARY KEY\` — deterministic, not auto-increment. Backfill (PR2) and \`daily_news.py\` (later PR) assign explicit values in date order.
  - \`date DATE NOT NULL UNIQUE\` — one edition per day (see Q3 decision below).
  - \`standfirst TEXT\` — filled by #T4-3.
  - \`daily_title TEXT\` — filled by #T4-3.
  - \`sources_scanned JSONB\` — filled by #T4-2.
  - \`generated_at TIMESTAMPTZ DEFAULT now()\`.
- \`articles.edition_id INTEGER REFERENCES editions(issue_no)\` — **nullable** for now.
- \`articles_edition_id_idx\` index.

Idempotent (\`IF NOT EXISTS\` everywhere) — safe to re-run.

## Decisions on the open questions Manager triage raised

Manager's \`/triage-issue\` ran on #51 and correctly halted at \`readiness=confirm-first\` with three open questions. Resolved as:

- **Q1: when to NOT NULL \`articles.edition_id\`?** Deferred to a later PR (PR3) after PR2's backfill proves every row can be assigned an \`edition_id\`. Flipping it in this migration would couple backfill order to migration order, which the "DDL/DML separate PRs" rule (and acceptance criterion) explicitly forbids.
- **Q2: backfill mechanism?** \`scripts/backfill_editions.py\` invoked manually, not embedded in a SQL migration. Keeps the migration sequence pure SQL DDL / DML, and lets the backfill be safely re-runnable.
- **Q3: same-day issue policy?** Enforced via \`editions.date UNIQUE\`. If a future 号外 requirement surfaces, switch to a composite key in a separate migration — today's design stays simple.

## Manager-flow context

This PR is the result of Manager's triage on Track 4 (\`/manager resume 39 --live\` after enqueueing #51–#55). The triage spent \$0.25 on a thoughtful analysis, identified the 3-PR split, and stopped at \`NEEDS_HUMAN\` — exactly the safety behavior the state machine is designed for. The remaining decisions belonged to a human (these three), so PR1 (this one) is written by hand following the triage's recommendation.

## Test plan

- [x] \`pytest tests/ manager/tests/ -q\` — 93 passed (no DB code changed)
- [ ] Post-merge: apply to Neon dev DB, verify \`editions\` and \`articles.edition_id\` exist
- [ ] Post-merge: PR2 (backfill) follows

## What's NOT in this PR (intentional)

- No \`scripts/backfill_editions.py\` — that's PR2.
- No NOT NULL on \`articles.edition_id\` — that's PR3 after backfill.
- No \`daily_news.py\` edition creation logic — Issue #51 explicitly defers this to a later PR ("daily_news.py への edition 作成ロジック追加はチケット内に「別 PR で対応可」と明記済み").

🤖 Generated with [Claude Code](https://claude.com/claude-code)