### PR TITLE
feat(db): articles.edition_id NOT NULL (PR3 of #51 split)

### DIFF
--- a/migrations/005_articles_edition_id_not_null.sql
+++ b/migrations/005_articles_edition_id_not_null.sql
@@ -1,0 +1,19 @@
+-- ================================================================
+-- articles.edition_id を NOT NULL に昇格 (PR3 of #51 split)
+--
+-- 前提 (PR3 を merge する前に production Neon で確認済み):
+--   * migration 004 適用済み (editions テーブル + articles.edition_id カラム存在)
+--   * scripts/backfill_editions.py --apply 実行済み
+--   * SELECT count(*) FROM articles WHERE edition_id IS NULL  → 0
+--   * SELECT count(*) FROM editions                            → 16
+--
+-- ALTER TABLE ... SET NOT NULL は ACCESS EXCLUSIVE lock を取って
+-- 全行を scan する。articles 規模 (現状 148 行) では一瞬で完了。
+-- NULL が 1 件でも残っていた場合 ALTER は失敗するので、その場合は
+-- backfill 再実行してからこの migration を再 apply すること。
+--
+-- 関連: epic #39 / issue #51 / PR1=#61 (DDL) / PR2=#62 (backfill script)
+-- ================================================================
+
+ALTER TABLE articles
+    ALTER COLUMN edition_id SET NOT NULL;


### PR DESCRIPTION
Closes #51 (after merge + Neon apply).

Third and final PR of #51's 3-PR split. Locks \`articles.edition_id\` to non-null after PR2's backfill populated every row.

Depends on:
- PR #61 (DDL) — merged
- PR #62 (backfill script) — merged

## Production preconditions verified before merging

On Neon production (Primary, neondb):

| Check | Result |
|---|---|
| \`SELECT count(*) FROM articles WHERE edition_id IS NULL\` | **0** ✓ |
| \`SELECT count(*) FROM editions\` | **16** ✓ |
| \`SELECT issue_no, date FROM editions ORDER BY issue_no LIMIT 5\` | issue_no \`1..5\`, dates \`2026-04-18..04-22\` ✓ |

All 148 articles have an \`edition_id\`. 16 editions cover the active period 2026-04-18..05-11 with issue_no \`1..16\` in date ascending order — matches the issue #51 acceptance criterion exactly.

## What this migration does

\`\`\`sql
ALTER TABLE articles
    ALTER COLUMN edition_id SET NOT NULL;
\`\`\`

That's it. One ALTER, no data movement.

## Safety analysis

- **Lock**: \`ACCESS EXCLUSIVE\` on the \`articles\` table for the duration of the ALTER. On 148 rows this is effectively instant (< 100ms). If the table ever grows to the millions, the standard mitigation is the \`CHECK (... IS NOT NULL) NOT VALID\` + \`VALIDATE CONSTRAINT\` pattern; not needed here.
- **Failure mode**: if any row still has \`edition_id IS NULL\` at apply time, Postgres rejects the ALTER and the column stays nullable. That's the desired behavior — re-run the backfill, then re-apply the migration.
- **Reversibility**: trivially reversible with \`ALTER COLUMN edition_id DROP NOT NULL\` if needed.

## Post-merge steps

1. Apply via Neon SQL Editor:
   \`\`\`sql
   ALTER TABLE articles ALTER COLUMN edition_id SET NOT NULL;
   \`\`\`
2. Verify:
   \`\`\`sql
   SELECT is_nullable FROM information_schema.columns
   WHERE table_name = 'articles' AND column_name = 'edition_id';
   -- expect: NO
   \`\`\`

## What's NOT in this PR (intentional)

- No \`daily_news.py\` edition creation logic — Issue #51 explicitly defers to a later PR. With \`edition_id\` now NOT NULL, the next concrete blocker is the production pipeline creating an editions row each morning. That's a separate work item.
- No web pipeline reads — that's #41/#42 territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)