### PR TITLE
feat(backend): edition creation + sources_scanned per run (#52)

### DIFF
--- a/daily_news.py
+++ b/daily_news.py
@@ -20,7 +20,13 @@ from youtube_transcript_api import YouTubeTranscriptApi
 from youtube_transcript_api.proxies import WebshareProxyConfig
 from anthropic import Anthropic
 
-from db import get_conn, is_already_sent, save_article
+from db import (
+    get_conn,
+    get_or_create_edition_for_today,
+    is_already_sent,
+    save_article,
+    update_edition_sources_scanned,
+)
 from fetchers import rss as rss_fetcher
 from fetchers import youtube as youtube_fetcher
 from mailer import build_html as build_hibi_html
@@ -354,18 +360,51 @@ def main():
         )
     )
 
+    # 今朝の edition 行を確保。articles.edition_id が NOT NULL (migration 005)
+    # なので save_article 呼び出し前に必ず取る。再実行された場合は同じ
+    # issue_no を再利用する (editions.date UNIQUE)。
+    edition_issue_no = get_or_create_edition_for_today()
+    print(f"📰 Edition: issue_no={edition_issue_no}")
+
     # Stage A: 全ソースからメタデータのみ取得（本文/要約なし）
+    # `sources_scanned` は #52 で editions に保存。fetched_count は取得試行数
+    # (14日窓 / unsent フィルタ前)。fetch 自体が例外で落ちた場合は error 文字列
+    # を 200 文字で打ち切って残す。
     print("🔎 Gathering candidates (metadata only)...")
     candidates: list[dict] = []
+    sources_scanned: list[dict] = []
     for source in sources:
-        items = _fetch_items(source, youtube_client, METADATA_PER_SOURCE)
+        source_name = source["name"]
+        source_kind = "YouTube" if source["type"] == "youtube" else "RSS"
+        try:
+            items = _fetch_items(source, youtube_client, METADATA_PER_SOURCE)
+            entry: dict = {
+                "name": source_name,
+                "kind": source_kind,
+                "fetched_count": len(items),
+            }
+        except Exception as exc:
+            items = []
+            entry = {
+                "name": source_name,
+                "kind": source_kind,
+                "fetched_count": 0,
+                "error": str(exc)[:200],
+            }
+        sources_scanned.append(entry)
+
         fresh = [i for i in items if _is_within_lookback(i["published_at"])]
         unsent = [i for i in fresh if not is_already_sent(i["content_id"])]
         candidates.extend(unsent)
+        suffix = f", error: {entry['error']}" if entry.get("error") else ""
         print(
-            f"  📡 [{source['type']}] {source['name']}: {len(items)} fetched, "
-            f"{len(fresh)} within {MAX_LOOKBACK_DAYS}d, {len(unsent)} unsent"
+            f"  📡 [{source['type']}] {source_name}: {len(items)} fetched, "
+            f"{len(fresh)} within {MAX_LOOKBACK_DAYS}d, {len(unsent)} unsent{suffix}"
         )
+
+    # Stage A 完了時点で sources_scanned は確定するので editions に書き戻す。
+    # 配信が後段で失敗しても透明性ログは残る (= 何をスキャンしたかの記録)。
+    update_edition_sources_scanned(edition_issue_no, sources_scanned)
 
     print(f"\n📊 Total unsent candidates: {len(candidates)}")
 
@@ -428,7 +467,8 @@ def main():
                 "category": item.get("category"),
                 "embedding": embedding,
                 "embedding_model": EMBEDDING_MODEL if embedding is not None else None,
-            }
+            },
+            edition_id=edition_issue_no,
         )
 
         processed_by_source.setdefault(item["source_name"], []).append(

--- a/db.py
+++ b/db.py
@@ -3,8 +3,10 @@
 import os
 import sys
 from contextlib import contextmanager
+from datetime import datetime, timezone
 
 import psycopg
+from psycopg.types.json import Jsonb
 
 try:
     from pgvector.psycopg import register_vector
@@ -46,7 +48,7 @@ def is_already_sent(content_id: str) -> bool:
         return row is not None
 
 
-def save_article(article: dict) -> str | None:
+def save_article(article: dict, edition_id: int) -> str | None:
     """articles テーブルに1件保存し、その行の id (uuid, str) を返す。
 
     content_id が既存の場合も既存行の id を返す。DB 接続不可などで保存できなか
@@ -63,12 +65,16 @@ def save_article(article: dict) -> str | None:
             - category: str | None  (optional; source_metrics_30d の GROUP BY に使う)
             - embedding: list[float] | None  (optional; vector(1536))
             - embedding_model: str | None    (optional; どの model で埋め込んだか)
+        edition_id: 紐付ける editions.issue_no。`articles.edition_id` は
+            migration 005 で NOT NULL になっているので必須。日次の caller は
+            `get_or_create_edition_for_today()` で 1 回取得して使い回す想定。
     """
     params = {
         **article,
         "category": article.get("category"),
         "embedding": article.get("embedding"),
         "embedding_model": article.get("embedding_model"),
+        "edition_id": edition_id,
     }
     # ON CONFLICT DO UPDATE で no-op update を掛けることで、衝突時も RETURNING
     # が発火する。content_id = EXCLUDED.content_id は元値への no-op。
@@ -77,11 +83,11 @@ def save_article(article: dict) -> str | None:
             """
             insert into articles
               (source_type, source_name, content_id, title, url, summary, category,
-               embedding, embedding_model, sent_at)
+               embedding, embedding_model, edition_id, sent_at)
             values
               (%(source_type)s, %(source_name)s, %(content_id)s,
                %(title)s, %(url)s, %(summary)s, %(category)s,
-               %(embedding)s, %(embedding_model)s, now())
+               %(embedding)s, %(embedding_model)s, %(edition_id)s, now())
             on conflict (content_id) do update
               set content_id = excluded.content_id
             returning id
@@ -90,3 +96,56 @@ def save_article(article: dict) -> str | None:
         ).fetchone()
         conn.commit()
         return str(row[0]) if row else None
+
+
+# ============================================================
+# Editions
+# ============================================================
+def _today_utc():
+    """UTC の今日の date。backfill / migration とタイムゾーン整合を取る。"""
+    return datetime.now(timezone.utc).date()
+
+
+def get_or_create_edition_for_today() -> int:
+    """今日の `editions` 行を取得。無ければ作る。返り値は issue_no。
+
+    冪等: 同じ日に複数回呼んでも同じ issue_no を返す (editions.date UNIQUE
+    に依拠)。`issue_no` は MAX(issue_no) + 1 で採番。
+
+    `articles.edition_id` が NOT NULL の制約 (migration 005) を満たすため、
+    `save_article` を呼ぶ前に必ず 1 回呼ぶこと。
+    """
+    today = _today_utc()
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute("select issue_no from editions where date = %s", (today,))
+            row = cur.fetchone()
+            if row:
+                return int(row[0])
+            cur.execute("select coalesce(max(issue_no), 0) + 1 from editions")
+            next_no = int(cur.fetchone()[0])
+            cur.execute(
+                "insert into editions (issue_no, date) values (%s, %s)",
+                (next_no, today),
+            )
+        conn.commit()
+        return next_no
+
+
+def update_edition_sources_scanned(
+    issue_no: int, sources_scanned: list[dict]
+) -> None:
+    """`editions.sources_scanned` を更新する。
+
+    形式は Issue #52 に従う:
+        [{"name": str, "kind": "YouTube"|"RSS",
+          "fetched_count": int, "error": str (optional)}, ...]
+
+    上書き保存。1 日 1 回 (Stage A 完了直後) 呼ぶ想定。
+    """
+    with get_conn() as conn:
+        conn.execute(
+            "update editions set sources_scanned = %s where issue_no = %s",
+            (Jsonb(sources_scanned), issue_no),
+        )
+        conn.commit()


### PR DESCRIPTION
Closes #52. Critical hotfix component bundled — see "wider scope" section below.

## Summary

Every morning's \`daily_news.py\` run now:

1. **Reserves an \`editions\` row for today** via \`get_or_create_edition_for_today()\` (issue_no = MAX + 1, idempotent per UTC date).
2. **Collects \`sources_scanned\`** during Stage A — every \`sources.yaml\` entry gets \`{name, kind, fetched_count, error?}\` in a JSONB array.
3. **Persists that JSONB** into \`editions.sources_scanned\` immediately after Stage A, so the transparency log survives later-stage crashes.
4. **Passes \`edition_id\` through to \`save_article\`** so the \`NOT NULL\` constraint from migration 005 is honored.

## Why the scope is wider than the issue title

#51's PR3 (#63) flipped \`articles.edition_id\` to \`NOT NULL\` on production. Without the edition wiring this PR adds, the **next 7:00 JST cron would fail at the first \`save_article\` INSERT**. The "edition creation logic" #51 deferred to a later PR HAD to land before that next run, so pairing it with the sources_scanned work (which needs the same edition row) keeps the change coherent and avoids a hotfix-then-feature loop.

## Decisions on the open questions Manager triage raised for #52

- **\`fetched_count\` unit**: **取得試行数** (\`len(items)\` before the 14-day / unsent filters). Matches "what did this source return today" rather than "what survived our filters".
- **error message granularity**: **1 行サマリ** (\`str(exc)[:200]\`). Full tracebacks bloat JSONB and aren't useful in the email/web UIs; operators can still get tracebacks from the cron log.

## Behavior reference

\`\`\`
🔎 Gathering candidates (metadata only)...
📰 Edition: issue_no=17
  📡 [youtube] Anthropic: 5 fetched, 5 within 14d, 2 unsent
  📡 [rss] web.dev: 12 fetched, 8 within 14d, 6 unsent
  📡 [rss] Bun Blog: 0 fetched, 0 within 14d, 0 unsent, error: HTTP 404
\`\`\`

Saved to \`editions.sources_scanned\`:

\`\`\`json
[
  {"name": "Anthropic", "kind": "YouTube", "fetched_count": 5},
  {"name": "web.dev", "kind": "RSS", "fetched_count": 12},
  {"name": "Bun Blog", "kind": "RSS", "fetched_count": 0, "error": "HTTP 404"}
]
\`\`\`

## Test plan

- [x] \`pytest tests/ manager/tests/ -q\` — 93 passed (no new DB tests; \`db.py\` has no existing unit tests, this PR matches that convention)
- [x] Import smoke: \`import db\` exposes the 3 new public symbols; \`import daily_news\` loads cleanly
- [x] \`save_article\` caller audit: only 1 call site in repo (daily_news.py), updated
- [ ] **Post-merge / next cron run**: confirm \`editions.sources_scanned\` is populated and \`save_article\` no longer hits the NOT NULL constraint

## Files changed

| File | What |
|---|---|
| \`db.py\` | + \`get_or_create_edition_for_today()\`, + \`update_edition_sources_scanned()\`, \`save_article\` gains required \`edition_id\` param |
| \`daily_news.py\` | call \`get_or_create_edition_for_today()\` early; wrap Stage A fetches in try/except; persist \`sources_scanned\`; pass \`edition_id\` to \`save_article\` |

## What's NOT in this PR (intentional)

- No standfirst / daily_title generation (#T4-3 / #53).
- No retroactive backfill of \`sources_scanned\` for the existing 16 editions — issue body explicitly allows \`sources_scanned IS NULL\` for past editions.
- No email/web UI surfacing of the new data — #40 / #42 territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)