### PR TITLE
chore(web): initial dump of editions 0001..0016 to content collection

### DIFF
--- a/web/src/content/editions/0001.json
+++ b/web/src/content/editions/0001.json
@@ -1,0 +1,169 @@
+{
+  "issue_no": 1,
+  "date": "2026-04-18",
+  "standfirst": null,
+  "daily_title": null,
+  "sources_scanned": null,
+  "articles": [
+    {
+      "title": "The biggest hustlers win.",
+      "url": "https://www.youtube.com/watch?v=2dUSbZX59oI",
+      "summary": "・UberはStarbucksのシフト勤務に対して、時給21ドルの柔軟な働き方という優れた条件を提示することで競争に勝利した。\n・最良の価格とサービスを提供する者が市場で勝つという資本主義の原則が、労働市場においても同様に機能している。\n・このモデルを国境を超えてグローバルに展開することで、さらに競争が激化し、より効率的なサービス提供が実現する可能性がある。",
+      "category": null,
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    },
+    {
+      "title": "I made an app to fix my terrible posture",
+      "url": "https://www.youtube.com/watch?v=j_T1pi4C4B4",
+      "summary": "動画の内容（トランスクリプト等）が提供されていないため、タイトルと説明文のみから推測して要約することになりますが、その旨をご了承ください。\n\n・姿勢矯正アプリ「SuperShrimp.io」を個人開発者が自身の悪姿勢を解決するために制作しており、実際の課題解決を起点としたプロダクト開発のアプローチが示されている。\n・シリアル起業家（33のスタートアップを手がける）が姿勢検知・通知などの機能を実装したと考えられ、カメラやセンサーを活用したリアルタイム検出技術が鍵となる可能性が高い。\n・自分自身の問題をプロダクトに昇華する「スクラッチ自分の痒い所」戦略は、開発者が市場検証コストを抑えつつMVPを素早くリリースする上で有効な手法である。\n\n---\n⚠️ 動画の実際のトランスクリプトや映像内容をご提供いただければ、より正確な要約が可能です。",
+      "category": null,
+      "source": "Marc Lou",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Someone is always getting blocked",
+      "url": "https://www.youtube.com/watch?v=hFf9XYR2v1I",
+      "summary": "以下は動画タイトルと説明文の情報をもとにした要約です。\n\n・バックエンドシステムにおいて「誰かは常にブロックされている」という原則があり、I/OバウンドかCPUバウンドかに関わらず、スレッドやプロセスは必ずどこかで待機状態が発生する。\n・Node.jsのような非同期アーキテクチャもイベントループや内部のlibuvスレッドプールでブロッキングが生じており、「ノンブロッキング」は完全な回避ではなくブロッキングの隠蔽・分散である。\n・開発者はアーキテクチャ設計時にOSレベルのI/O・スレッド・プロセスのブロッキング特性を理解した上で、スケーリング戦略（スレッド数・非同期モデルの選択）を判断することが重要である。",
+      "category": null,
+      "source": "Hussein Nasser",
+      "source_type": "youtube"
+    },
+    {
+      "title": "SaaS Growth Strategies That Actually Work: Pricing, Localization & Survival",
+      "url": "https://www.youtube.com/watch?v=YWUzN6zU-_A",
+      "summary": "・Paddleの19,000社・360億ドルARRのデータによると、価格改定は「値上げ」より**使用量ベースや追加機能課金などの段階的マネタイズ**が効果的で、定期的な価格見直しにより1アカウントあたり収益が103%増加する。\n・決済方法を1つ追加するだけでチェックアウトのコンバージョンが23%向上するなど、**ローカライゼーションや支払い体験の最適化**が即効性の高い成長レバーとして機能する。\n・ターゲット市場を絞り込んで他を切り捨てる集中戦略と、創業者自身ではなく顧客や第三者がストーリーを語る**ナラティブ設計**が、スケール時の持続的成長に不可欠である。",
+      "category": null,
+      "source": "MicroConf",
+      "source_type": "youtube"
+    },
+    {
+      "title": "The Junior Developer CRISIS: How to Build a Team When AI Does the Entry-Level Work",
+      "url": "https://www.youtube.com/watch?v=fHfkJRh2veg",
+      "summary": "・AIはジュニア開発者ではなく「記憶のない傭兵請負業者（Colin the Contractor）」として捉えるべきであり、好奇心や意識的な無知から学ぶ人間の開発者とは本質的に異なる存在である。\n・AIコードエージェントを効果的に活用するには、タスクを小さく明確に定義したステップに分割し、頻繁に検証を行うことでハルシネーションや無責任な出力をコントロールする運用戦略が重要である。\n・チームの設計方針や作業ルールをドキュメント化することは、人間のチームメンバーのオンボーディングだけでなくAIエージェントへの指示品質向上にも直結するため、開発組織の知識管理が今後さらに重要になる。",
+      "category": null,
+      "source": "Modern Software Engineering",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Pay her $1M for content!",
+      "url": "https://www.youtube.com/watch?v=q9qvTzLZteM",
+      "summary": "・StaplesのアルバイトKaeden Rowlandは、文房具や複合機への純粋な情熱をTikTokで発信することで582,000人のフォロワーを獲得した。\n・作られたコンテンツではなく「本物の熱量（Authentic Passion）」こそがバイラル拡散の核心であり、ニッチなテーマでも強力なエンゲージメントを生む。\n・企業開発者・マーケターへの示唆として、自社ブランドの「熱狂的なユーザー」を早期に発見しコラボする仕組みをプロダクトやCRMに組み込むことが、低コストで高効果なグロース戦略となり得る。",
+      "category": null,
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    },
+    {
+      "title": "The Psychology of Building and Selling a SaaS: 5 Lessons Exits Teach Founders",
+      "url": "https://www.youtube.com/watch?v=0NJNOZ1qNW4",
+      "summary": "・ビジネスの軌道を決めるのは戦略ではなく創業者自身の「価値観」であり、成長段階に応じてその価値観を見直すことが重要である。\n・意思決定には内なる子ども・不安な消防士・責任ある管理者という内的システムが無意識に関与しており、自己理解が経営判断の質を高める。\n・イグジットを意識した経営姿勢は実際に売却しない場合でも事業を強化し、一方でビジネスへの過度な執着（アタッチメントスタイル）は売却不可能な状態を招くリスクがある。",
+      "category": null,
+      "source": "MicroConf",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Head of Growth (Anthropic):  “Claude is growing itself at this point”",
+      "url": "https://www.youtube.com/watch?v=k-H4nsOTuxU",
+      "summary": "・AnthropicはClaudeを活用した社内ツール「CASH」でグロース実験を自動化しており、AIが実験の設計・実行・分析までを担うことで人間チームの意思決定を加速している。\n・AIによりエンジニアの生産性が指数関数的に向上する中、PMとエンジニアの比率を逆転させる（PMをより多く配置する）組織設計が今後の開発チームにとって重要な示唆となっている。\n・グロース戦略として微小な最適化より「大きな賭け」に70%のリソースを集中させるアプローチを採用しており、AIプロダクトにおけるアクティベーション（初期利用定着）が最も高いレバレッジを持つ課題として注目されている。",
+      "category": null,
+      "source": "Lenny's Podcast",
+      "source_type": "youtube"
+    },
+    {
+      "title": "The ‘Old Rules’ of SaaS Still Win",
+      "url": "https://www.youtube.com/watch?v=d9crNPUPj3w",
+      "summary": "・AIがSaaSを変革しつつある現代でも、チャーン率の最小化・顧客獲得コストの最適化・製品と市場の適合（PMF）など5つの根本的なビジネス指標は依然として成否を左右する。\n・AIは実装の効率化や機能強化に寄与するが、収益モデルや顧客維持の仕組みといったSaaSの基盤設計が脆弱であれば、AIを導入しても事業の持続性は得られない。\n・開発者・創業者はAI活用に注力する前に、NRR（純収益維持率）やLTV/CAC比率といった古典的SaaSメトリクスを正しく把握・改善することが最優先事項である。",
+      "category": null,
+      "source": "Rob Walling",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Rapid growth causes success disasters",
+      "url": "https://www.youtube.com/watch?v=0r_oVtEPLSY",
+      "summary": "申し訳ありませんが、提供されていただいた情報はタイトルとハッシュタグのみであり、**動画の実際のコンテンツ（トランスクリプトや詳細な説明文）が含まれていない**ため、正確な要約を行うことができません。\n\n## 確認できる情報から推測される内容\n\nタイトル「Rapid growth causes success disasters」とハッシュタグ（`#claudecode` `#anthropic` `#hypergrowth`）から、**Claude CodeなどAIツールの急速な普及に伴う技術的・運用上の課題**に関する動画である可能性が高いですが、憶測による要約は誤情報のリスクがあります。\n\n## お願い\n\n以下のいずれかをご提供いただけますか？\n\n- 動画の**字幕・トランスクリプト**\n- 動画の**詳細な説明文（概要欄の全文）**\n- 動画内で話されている**主要なポイント**\n\nそれらをいただければ、正確な3行要約を作成いたします。",
+      "category": null,
+      "source": "Lenny's Podcast",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Hard truths about building in the AI era | Keith Rabois (Khosla Ventures)",
+      "url": "https://www.youtube.com/watch?v=xCd9ykretlg",
+      "summary": "・AI时代においてPMの役割は縮小しつつあり、デザインとコーディングの融合が進む中で「バレル型人材（自律的に成果を出せる人）」の採用が企業の競争力を左右する。\n・顧客フィードバックへの過度な依存は消費者向けプロダクト開発において有害になり得るという逆説的な視点が提示されており、優れた製品直感を持つ少数精鋭チームの重要性が強調されている。\n・AIトークンの最大消費者はエンジニアではなくCMOになりつつあるという示唆は、開発者がAIツールの設計・実装において非技術職のユースケースを最優先に考慮すべきことを示している。",
+      "category": null,
+      "source": "Lenny's Podcast",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Why Does No One Use The Right React Hook",
+      "url": "https://www.youtube.com/watch?v=NBjycPpPHQQ",
+      "summary": "・`useSyncExternalStore`はReact外部（ブラウザAPIやグローバルストアなど）に保存されたデータをReactコンポーネントと安全に同期するためのフックで、多くの開発者に見過ごされているが非常に有用である。\n・このフックは`subscribe`（変更検知のコールバック登録）と`getSnapshot`（現在の値を返す関数）の2つの引数を基本とし、外部データの変更をReactのレンダリングサイクルに正確に伝える仕組みを提供する。\n・LocalStorageやmedia queryなどのブラウザAPIをReactのstateとして扱う際に`useState`＋`useEffect`の組み合わせより堅牢でレースコンディションを防げるため、外部データ連携が必要な場面では積極的に採用すべきフックである。",
+      "category": null,
+      "source": "Web Dev Simplified",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Build Your App With Me (Deep Work)",
+      "url": "https://www.youtube.com/watch?v=OSikNZ9P4oU",
+      "summary": "以下は動画の説明文と文脈をもとにした要約です（動画本編の内容は直接確認できないため、説明文から読み取れる情報に基づきます）。\n\n・Marc Louvionはソロ起業家として25以上のスタートアップを立ち上げており、ShipFa.stなどのツールを使って数日でプロダクトをリリースする高速開発スタイルを実践している。\n・「Deep Work（深い集中作業）」形式でアプリを実際にビルドする様子を見せており、コーディングから実装までのリアルなワークフローが学べる内容となっている。\n・CodeFa.stやShipFa.stといった自社ツールを活用することで、開発初学者でも短期間でスタートアップを構築・出荷できる実践的なアプローチが示唆されている。\n\n> ⚠️ 注意：この要約は動画の説明文・タイトル・リンク情報に基づくものです。動画本編のURLを共有いただければ、より正確な技術的要点を要約できます。",
+      "category": null,
+      "source": "Marc Lou",
+      "source_type": "youtube"
+    },
+    {
+      "title": "How to future-proof your career",
+      "url": "https://www.youtube.com/watch?v=E49a6h0p05k",
+      "summary": "申し訳ありませんが、提供された情報（タイトルと説明文のみ）では、動画の具体的な内容を把握することができません。\n\nYouTubeの動画本文（トランスクリプト・字幕データ）が共有されていないため、正確な要約を生成することができない状況です。\n\n---\n\n**対応方法として以下をご提案します：**\n\n1. **動画の字幕/トランスクリプト**をコピーしてこのチャットに貼り付けてください\n2. **動画の主要な内容**を文章で共有していただければ要約いたします\n\nタイトルと `#claudecode` タグから推測するに、**Claude AIを活用したキャリアの将来設計**に関する内容と思われますが、推測での要約は正確性を欠くためお控えします。\n\nトランスクリプトをご共有いただければ、すぐに要約いたします！",
+      "category": null,
+      "source": "Lenny's Podcast",
+      "source_type": "youtube"
+    },
+    {
+      "title": "World's First Tri-Folding Portable Projector",
+      "url": "https://www.youtube.com/watch?v=vueTMl6y4Ro",
+      "summary": "・Aurzen ZIPは世界初の三つ折り構造を採用したポータブルプロジェクターで、ポケットに収まるほどのコンパクトサイズを実現している。\n・折りたたみ機構により携帯性と投影角度の柔軟性を両立しているが、小型化に伴う光量・画質のトレードオフが技術的な課題となっている。\n・超小型プロジェクター開発においては、折りたたみ光学系の精度維持と放熱設計が実装上の重要なポイントとなることを示唆している。",
+      "category": null,
+      "source": "ShortCircuit",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Why aren’t they all this size - Colorful iGame RTX 5070 Mini",
+      "url": "https://www.youtube.com/watch?v=pQ0MsGP1nK4",
+      "summary": "・ColorfulのiGame RTX 5070 Miniは、現在主流となっている大型GPUとは対照的に、コンパクトなサイズを実現した小型ゲーミングPC向けのグラフィックスカードである。\n・小型PCの構築は容易だが、小型ゲーミングPCの構築は大型GPUが主流となっているため難しく、このGPUはその課題に対する有力な解決策となり得る。\n・開発者や自作PCユーザーにとって、このような小型ハイエンドGPUの存在は、省スペースかつ高性能なシステム設計の選択肢を広げる重要な示唆を持つ。",
+      "category": null,
+      "source": "ShortCircuit",
+      "source_type": "youtube"
+    },
+    {
+      "title": "React2Shell on TanStack Start?!?",
+      "url": "https://www.youtube.com/watch?v=-dbvAMsRKi0",
+      "summary": "・React2Shell（R2S）はReact Server Componentsの脆弱性を突く攻撃手法であり、サーバー側でのコンポーネント実行を悪用してシェルアクセスを試みる仕組みとなっている。\n・TanStack StartはRSCをサポートしているものの、そのアーキテクチャ設計上の違いによりR2S攻撃の影響を受けない免疫性を持っている。\n・RSC対応フレームワークを採用する開発者は脆弱性の有無をアーキテクチャレベルで把握することが重要であり、TanStack Startはセキュリティ面でも選択肢として検討できる。",
+      "category": null,
+      "source": "Jack Herrington",
+      "source_type": "youtube"
+    },
+    {
+      "title": "#ad Lenovo Yoga 9i 2-in-1 Aura Edition - imagined with Intel",
+      "url": "https://www.youtube.com/watch?v=K3SRrTaQgz0",
+      "summary": "申し訳ありませんが、提供された情報（タイトルと説明文のみ）では、動画の具体的な技術的内容を正確に把握することができません。\n\n以下は、タイトルから推測できる範囲での要約となります：\n\n・Lenovo Yoga 9i 2-in-1 Aura EditionはIntelとの協力で設計された2-in-1コンバーチブルノートPCであり、Intel技術との深い統合が特徴と考えられる。\n・「Aura Edition」はIntelのAura対応機能（照明・センサー連携など）を活用したプラットフォーム最適化を示唆しており、ハードウェアレベルのAPI連携が開発者に関連する可能性がある。\n・開発者視点では、Intel統合プラットフォーム向けのソフトウェア最適化やAI・センサー機能の活用が、このクラスのデバイス開発における重要な検討事項となる。\n\n⚠️ **注意**: 動画の実際の内容（トランスクリプト）が提供されていないため、上記は推測に基づく要約です。正確な要約には動画視聴が必要です。",
+      "category": null,
+      "source": "Dave2D",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Guess these Superheroes in Google AI Search - Win $100",
+      "url": "https://www.youtube.com/watch?v=Baa9YmKoZEA",
+      "summary": "申し訳ありませんが、提供された情報（タイトルと短い説明文のみ）では、動画の具体的な技術的内容や実装の詳細を正確に把握することができません。\n\n動画の実際の内容（トランスクリプトやキャプションなど）が提供されていないため、正確な要約を生成することが難しい状況です。\n\nもし動画の**文字起こし（トランスクリプト）**や**詳細な説明文**をご提供いただければ、より正確で有益な技術的要約を作成いたします。\n\n---\n\nタイトルから推測できる範囲での概要（不確実）：\n\n・Google AIによる検索機能（AI Overview等）がスーパーヒーローの画像認識にどの程度対応しているかをテストするコンテンツと思われる。\n・SEOツール「Ahrefs」や「Brand Radar」との関連から、AIサーチにおけるブランド認識・視覚検索の精度検証が主題である可能性がある。\n・開発者への示唆としては、Google AIサーチの画像認識精度がSEOやブランド戦略に与える影響を把握することが重要と考えられる。\n\n※上記はタイトルからの**推測**であり、正確性は保証できません。",
+      "category": null,
+      "source": "Ahrefs",
+      "source_type": "youtube"
+    },
+    {
+      "title": "80,000 people sang every word to the most hated man in music.",
+      "url": "https://www.youtube.com/watch?v=D6CRRMMvRZ8",
+      "summary": "・製品やモデルそのものの質が圧倒的に高ければ、マーケティングやDevRelの弱さといった周辺要素の不足を補って余りある。\n・AnthropicはDevRelでCodexに大きく劣るとされているにもかかわらず、開発者は日常的にClaude（Opus 4.6）を使い続けており、モデルの実力が採用の決定打になっている。\n・開発者への示唆として、ブランディングや広報活動に過剰投資するより、コア技術・プロダクト品質の向上を最優先することが長期的な競争優位につながる。",
+      "category": null,
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    }
+  ]
+}

--- a/web/src/content/editions/0002.json
+++ b/web/src/content/editions/0002.json
@@ -1,0 +1,89 @@
+{
+  "issue_no": 2,
+  "date": "2026-04-19",
+  "standfirst": null,
+  "daily_title": null,
+  "sources_scanned": null,
+  "articles": [
+    {
+      "title": "Only Bieber could pull off watching YouTube on stage at Coachella.",
+      "url": "https://www.youtube.com/watch?v=isnhu6_jRzs",
+      "summary": "・ビーバーがコーチェラのステージ上でYouTube動画を再生するという異色のパフォーマンスを披露し、一部では「手抜き」との批判もあった。\n・このパフォーマンスが成立するのは、ビーバーがYouTube出身のオリジナルクリエイターであるという背景があるからこそだとJasonは分析している。\n・ステージ全体が彼のキャリアへのメタ的なコメンタリーとなっており、ファンにとってはノスタルジックな体験として機能した。",
+      "category": null,
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Nothing Headphone (a) are almost perfect...",
+      "url": "https://www.youtube.com/watch?v=a5bFJPwCmKs",
+      "summary": "・Nothing の Headphone (a) はフルパラメトリック EQ を搭載しており、ユーザーが音質を細かくカスタマイズできる点が技術的な強みとなっている。\n・物理ボタンを採用することでタッチ操作の誤作動を排除し、ハードウェア設計として実用性を重視したアプローチが取られている。\n・「ほぼ完璧」というタイトルの示す通り、音質面でわずかな課題が残るものの、価格帯を考慮すれば競争力の高いコストパフォーマンスを持つデバイスと評価されている。",
+      "category": null,
+      "source": "ShortCircuit",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Bittensor’s (alleged) $10M rug pull (feat. Mark Jeffrey) | E2275",
+      "url": "https://www.youtube.com/watch?v=sdhuUZbx5Sk",
+      "summary": "・BittensorのサブネットオペレーターであるCovenant AIの創設者が約1,000万ドル相当のTAOトークンを売却して離脱したとされる「ラグプル疑惑」が発生し、エコシステム全体の信頼性と統治構造に深刻な問題を投げかけた。\n・BitMindやMacroCosmos等の実際に稼働するサブネット運営者の事例から、トークンvs.エクイティの投資設計やサブネットオーナーシップの在り方など、Bittensorエコシステムにおける実装・資金調達モデルの具体的な考え方が議論された。\n・開発者・投資家へのインプリケーションとして、サブネットオーナーへの権限集中リスクを軽減するガバナンス改善（ロックアップ期間の設定や意思決定の分散化等）が急務であり、エコシステムへの参加には技術的実績とトークノミクス設計の両立が不可欠であることが示された。",
+      "category": null,
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    },
+    {
+      "title": "How To Learn AI In A Weekend",
+      "url": "https://www.youtube.com/watch?v=qLMYOhaKcZs",
+      "summary": "・Claude Codeを中心とした「AIフライホイール」として、AIに自分の業務をインタビューさせ→作るべきツールを特定し→実際に構築しながら学ぶという学習サイクルを紹介している。\n・コーディング経験不要でClaude Codeをインストールし、YouTube APIキーの取得やVercel・GitHubと連携しながらYouTube競合トラッカーのダッシュボードを実際に構築する具体的な手順をデモしている。\n・ZapierやMake.com、N8N、MCPサーバーなどの自動化ツールと組み合わせることで、開発者でなくても実務に直結するAIツールを週末レベルの時間投資で構築・運用できることを示唆している。",
+      "category": null,
+      "source": "Ali Abdaal",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Root Cause, Two Decades of Backend Bugs",
+      "url": "https://www.youtube.com/watch?v=Jx_4kfrQsiA",
+      "summary": "・著者Hussein Nasserが20年のバックエンドエンジニアリング経験をもとに、パフォーマンスボトルネック・競合状態・データ不整合など実際の本番バグ事例を15章にまとめた書籍「Root Cause」を出版した。\n・本書はネットワークプロトコルからデータベースエンジン内部・OSカーネルのデータ構造に至るまで、リクエストの全経路を深く追跡することでバグの根本原因を解明するアプローチを解説している。\n・中〜上級のバックエンド開発者がソースコード非公開の環境でも本番システムのデバッグ力を高めるための実践的な知識・思考法を身につけるのに適した一冊である。",
+      "category": null,
+      "source": "Hussein Nasser",
+      "source_type": "youtube"
+    },
+    {
+      "title": "100% Test Coverage is a LIE, Here’s Why...",
+      "url": "https://www.youtube.com/watch?v=p1xZ-Ni2t8Q",
+      "summary": "・テストカバレッジ100%は品質を保証しない——銀行システムの実例として、カバレッジ100%でもアサーションがゼロであれば欠陥を検出できないという「100%の罠」が存在する。\n・カバレッジはコードの実行行数を追跡する指標に過ぎず、ミューテーションテストやプロパティベーステストなどの高度な手法を組み合わせることで初めて実質的な品質担保が可能になる。\n・開発者はカバレッジを厳格な達成目標ではなくトレンド指標として活用し、高速なフィードバックループを最優先に設計することが現代のソフトウェアエンジニアリングにおける本質的な戦略である。",
+      "category": null,
+      "source": "Modern Software Engineering",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Oh Snap, Snapdragon Can Game Now - ASUS Zenbook A16",
+      "url": "https://www.youtube.com/watch?v=-8uDibZjHJI",
+      "summary": "・ASUS Zenbook A16はSnapdragon X2 Elite Extremeを搭載した約16インチの超薄型・軽量ノートPCで、バッテリー駆動時間と性能の両立を目指したARM系Windowsデバイスである。\n・ゲーミング性能や生産性ベンチマークが検証されており、Snapdragon XシリーズのARMアーキテクチャによるx86アプリのエミュレーション互換性（Compatibility）が依然として開発者にとって重要な課題として取り上げられている。\n・ARM向けネイティブビルドへの対応やエミュレーション層での動作確認が求められるため、Windowsアプリ・ゲーム開発者はSnapdragon X世代を視野に入れたARM64ネイティブ対応を優先すべき段階に来ている。",
+      "category": null,
+      "source": "ShortCircuit",
+      "source_type": "youtube"
+    },
+    {
+      "title": "My God, the Colors… - Lenovo Yoga Slim 7i Aura Edition",
+      "url": "https://www.youtube.com/watch?v=GWexV8ii2mQ",
+      "summary": "・Lenovo Yoga Slim 7i Aura Editionは、IntelのPanther Lake CPUを搭載した日常業務向けラップトップで、優れたディスプレイと高いコストパフォーマンスを特徴としている。\n・LTT Labsのテスト結果やウェブカメラ性能も検証されており、実用的なスペックの裏付けがデータとともに示されている。\n・価格対性能比を重視する開発者や一般ユーザーにとって有力な選択肢となり得る製品として紹介されている。",
+      "category": null,
+      "source": "ShortCircuit",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Do we still need PMs?",
+      "url": "https://www.youtube.com/watch?v=Vr5DvEp8sDI",
+      "summary": "申し訳ありませんが、提供いただいた情報はYouTube動画のタイトルとハッシュタグのみであり、動画の実際のコンテンツ（トランスクリプトや詳細な説明文）にはアクセスできないため、正確な要約をお届けすることができません。\n\nもし要約をご希望の場合は、以下をご提供いただけますでしょうか：\n\n1. **動画のトランスクリプト（字幕テキスト）**\n2. **動画の詳細な説明文**\n3. **動画の主要な内容のメモ**\n\nそれらをもとに、技術的な要点を中心とした3行要約を作成いたします。",
+      "category": null,
+      "source": "Lenny's Podcast",
+      "source_type": "youtube"
+    },
+    {
+      "title": "UBI isn’t the solution to AI job loss",
+      "url": "https://www.youtube.com/watch?v=7iNK_VedSWc",
+      "summary": "・AIによる雇用喪失への対策としてUBI（ユニバーサル・ベーシック・インカム）が議論されているが、仕事は単なる収入源ではなくアイデンティティや目的意識の源泉でもあるため、金銭的補償だけでは不十分である。\n・産業革命の歴史が示すように、技術変化後の労働市場の姿を正確に予測することは極めて困難であり、開発者はAI実装の社会的影響を謙虚に見積もる必要がある。\n・AIシステムを設計・開発する際には、人間の仕事を単純に代替するのではなく、人々の目的意識や社会的役割を維持・拡張できるような設計思想を優先することが重要な示唆となる。",
+      "category": null,
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    }
+  ]
+}

--- a/web/src/content/editions/0003.json
+++ b/web/src/content/editions/0003.json
@@ -1,0 +1,89 @@
+{
+  "issue_no": 3,
+  "date": "2026-04-20",
+  "standfirst": null,
+  "daily_title": null,
+  "sources_scanned": null,
+  "articles": [
+    {
+      "title": "The GPT Moment for Robotics Is Here",
+      "url": "https://www.youtube.com/watch?v=4EsUaur0nsQ",
+      "summary": "・Physical IntelligenceはOpenXなどのクロスエンボディメントアプローチで複数ロボットプラットフォームを横断学習するファウンデーションモデルを構築しており、昨年は数百時間のデータ収集を要したタスクがゼロショットで実行可能になるロボティクスの「GPT-1モーメント」に到達しつつある。\n・モデルはオンデバイスではなくクラウドで実行するアーキテクチャを採用しており、これによりロボット側のハードウェア制約を緩和し、大規模モデルの即時アップデートと展開が可能になるという重要な技術的ブレークスルーを実現している。\n・開発者・スタートアップへの示唆として、ロボティクスはデータ収集と運用(Ops)の問題に変質しており、今後は垂直特化型ロボティクス企業のカンブリア爆発が起きると予測されるため、特定ドメインのデータパイプラインと運用基盤の構築が競争優位の核心となる。",
+      "category": null,
+      "source": "Y Combinator",
+      "source_type": "youtube"
+    },
+    {
+      "title": "A little EQ is all you need - Nothing Headphone (a)",
+      "url": "https://www.youtube.com/watch?v=-oV43yNHaxI",
+      "summary": "・Nothing Headphone (a)はカラフルなデザインと優れたANCを備えた低価格帯のヘッドフォンで、上位モデルのHeadphone (1)の外観的な魅力を一部継承している。\n・専用アプリのEQ機能を活用することでデフォルトのサウンドチューニングを大幅に改善でき、レビュアーのAdamもカスタムEQ設定によって音質を好みに合わせた。\n・ラボテストの結果も踏まえるとコストパフォーマンスは高いが、ANCや音質の完成度は上位モデルには及ばず、価格帯相応の製品と結論付けられている。",
+      "category": null,
+      "source": "ShortCircuit",
+      "source_type": "youtube"
+    },
+    {
+      "title": "How to Generate the Best Keywords Using AI",
+      "url": "https://www.youtube.com/watch?v=bDEO7SX1UTM",
+      "summary": "申し訳ありませんが、提供された情報（タイトルと短い説明文「#ahrefs」のみ）では、動画の具体的な内容を把握することができません。\n\nより正確な要約を提供するために、以下のいずれかをご提供いただけますでしょうか：\n\n- **動画のトランスクリプト（字幕テキスト）**\n- **動画の詳細な説明文**\n- **動画のURL**（ただし、私はリアルタイムでWebにアクセスする機能を持っていないため、内容を直接取得することはできません）\n\n---\n\nもし一般的な知識に基づいた推測での要約でよければ、以下のように作成できます（**推測ベース**）：\n\n・AIツール（ChatGPTやAhrefsのAI機能など）を活用することで、従来の手動リサーチより効率的にターゲットキーワードを生成・選定できる。\n・検索意図（Search Intent）や競合分析をAIに組み合わせることで、コンバージョンに繋がりやすいロングテールキーワードを特定しやすくなる。\n・開発者やSEO担当者はAhrefsのAPIやAIプロンプト設計を活用し、キーワード生成プロセスを自動化・スケールさせることが推奨される。\n\n※上記は推測に基づくため、正確性は保証できません。",
+      "category": null,
+      "source": "Ahrefs",
+      "source_type": "youtube"
+    },
+    {
+      "title": "No power? No problem! - Tapo C675D home security camera KIT",
+      "url": "https://www.youtube.com/watch?v=oDCZkbJUJyA",
+      "summary": "・Tapo C675D は169°デュアル4Kレンズ・11.8倍ズーム・マイクロSDスロットを備えたソーラー駆動のパン/チルトカメラで、配線不要で設置できる点が最大の技術的特徴である。\n・10,000mAhバッテリーを搭載し90分の充電で1日稼働、双方向音声・スマートトラッキング・手動追尾制御などをTapoアプリから一元管理できる実用的な実装がなされている。\n・サブスクリプション不要でローカル録画（microSD）に対応しており、クラウド依存を避けたいプライバシー重視のユーザーや開発者にとってオフライン運用可能なセキュリティシステム構築の参考になる。",
+      "category": null,
+      "source": "ShortCircuit",
+      "source_type": "youtube"
+    },
+    {
+      "title": "BillionToOne Is Solving One of Biotech’s Hardest Problems",
+      "url": "https://www.youtube.com/watch?v=kkv5rZhrLkc",
+      "summary": "・BillionToOneは母体血液中の微量な胎児DNAを検出する技術（液体生検）を開発し、米国で最も広く使われる出生前遺伝子検査の一つを実現して企業評価額40億ドルに成長した。\n・数十億の分子の中から1つの変異を特定するという極めて高感度なDNA定量・解析技術がコアであり、ラボの半ブースから始めたスクラッチ開発と単一顧客からの販売拡大という実践的なゼロイチ経験が事業基盤を形成している。\n・同技術は出生前診断にとどまらず血液一滴による早期がん検出への応用を目指しており、微量シグナルの検出精度向上と偽陽性率の抑制が次の技術的課題として開発者に示唆を与えている。",
+      "category": null,
+      "source": "Y Combinator",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Why half of product managers are in trouble | Nikhyl Singhal (Meta, Google)",
+      "url": "https://www.youtube.com/watch?v=yUohoaC8_Hs",
+      "summary": "・AIの台頭により今後2年間でPMの約半数が淘汰されるリスクがあり、企業は3万人を削減して8,000人のAIファースト人材を採用し直すという大規模な構造転換が予測されている。\n・生き残るPMに求められるのは「情報の仲介者」ではなく「実際にプロダクトを作れるビルダー」としての能力であり、AIツール（Claude Code・Lovableなど）を活用して自ら手を動かすスキルが不可欠になっている。\n・開発者・PM問わず重要な示唆は「AIで喜びを感じる瞬間（moment of joy）」を意図的に見つけ、心理的障壁を乗り越えて自己変革を続けることが、AI時代のキャリア生存戦略の核心となるという点である。",
+      "category": null,
+      "source": "Lenny's Podcast",
+      "source_type": "youtube"
+    },
+    {
+      "title": "The Silent Killer of Your Software 🤫",
+      "url": "https://www.youtube.com/watch?v=mLinl_fWbzw",
+      "summary": "・技術的負債とは、より良いアプローチではなく短期的に簡単な解決策を選択することで生じる将来の手戻りコストのことである。\n・蓄積された技術的負債は時間とともに変更実装の難易度を高め、金融における負債と同様に開発を圧迫する深刻なリスクをもたらす。\n・開発者は将来の開発を麻痺させないよう、質の低いコードに早期に対処し、技術的負債を意識的にコントロールすることが重要である。",
+      "category": null,
+      "source": "Modern Software Engineering",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Anthropic's exponential mindset",
+      "url": "https://www.youtube.com/watch?v=7pI0pHq5P0Y",
+      "summary": "申し訳ありませんが、提供された情報（タイトルと短い説明文のハッシュタグのみ）からは、動画の具体的な技術的内容を把握することができません。\n\n正確な要約をお届けするために、以下のいずれかをご提供いただけますか？\n\n- **動画の文字起こし（トランスクリプト）**\n- **動画の詳細な説明文**\n- **動画のURL**（ただし私はリアルタイムでURLにアクセスする機能は持っていません）\n\nいただいた情報をもとに、技術的な要点・実装ヒント・開発者への示唆を優先した3行要約を作成いたします。",
+      "category": null,
+      "source": "Lenny's Podcast",
+      "source_type": "youtube"
+    },
+    {
+      "title": "The AI Challenger disaster prediction",
+      "url": "https://www.youtube.com/watch?v=iVOJEcV5lBg",
+      "summary": "申し訳ありませんが、提供された情報（タイトルと説明文のみ）では、動画の具体的な内容を把握することができません。\n\nYouTubeの動画URLや、動画のトランスクリプト・字幕テキストを共有していただければ、正確な要約が可能です。\n\n---\n\n**タイトルと説明文から推測できる範囲での暫定的な要約：**\n\n・AIツール（OpenAIやClaude Code）を使用して、チャレンジャー号爆発事故に関連するデータ分析や災害予測を実装するデモと思われる。\n・歴史的な工学データをAIに解析させることで、当時見落とされたリスク予測パターンを再現・可視化する試みが紹介されている可能性がある。\n・開発者にとっては、Claude CodeやOpenAI APIを実データ分析に活用する具体的なユースケースとして参考になると考えられる。\n\n> ⚠️ **注意：上記は推測に基づくものです。正確な要約には動画の実際のコンテンツが必要です。**",
+      "category": null,
+      "source": "Lenny's Podcast",
+      "source_type": "youtube"
+    },
+    {
+      "title": "This 22-Year-Old Built TikTok for Mobile Games, and It’s Growing Fast | E2276",
+      "url": "https://www.youtube.com/watch?v=O2zIQW6gnlc",
+      "summary": "・22歳のCEO Albert と24歳のCTO Boris が開発した「Nanogram」は、Google Gemini を活用して90秒でAI生成ゲームを作成・共有できるTikTok型モバイルゲームプラットフォームで、すでに10万人以上のユーザーがパワーユーザー1セッション25ゲーム以上プレイしている。\n・ゲームフィードへの広告統合を将来の収益モデルとして検討しており、RobloxやWorld of Warcraftのようなゲームプラットフォームとの差別化としてAI生成コンテンツの即時性とSNS的な拡散性を軸に成長戦略を描いている。\n・後半では1X TechnologiesのヒューマノイドロボットNEOを取り上げ、家庭環境は工場より複雑なナビゲーションが求められるため安全最優先設計と「ワールドモデル」による物理世界の学習が汎用ロボット開発の鍵であると強調されている。",
+      "category": null,
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    }
+  ]
+}

--- a/web/src/content/editions/0004.json
+++ b/web/src/content/editions/0004.json
@@ -1,0 +1,89 @@
+{
+  "issue_no": 4,
+  "date": "2026-04-21",
+  "standfirst": null,
+  "daily_title": null,
+  "sources_scanned": null,
+  "articles": [
+    {
+      "title": "You shouldn't talk to customers",
+      "url": "https://www.youtube.com/watch?v=m6B95EUX7-0",
+      "summary": "申し訳ありませんが、提供いただいた情報（タイトルと短いハッシュタグのみの説明文）だけでは、動画の具体的な内容を正確に把握することができません。\n\nYouTubeの動画内容そのものを直接読み取る機能も持っていないため、正確な要約をお届けすることが難しい状況です。\n\n---\n\n**より良い要約のために、以下をご提供いただけますか？**\n\n- 動画の**字幕・トランスクリプト**\n- 動画の**詳細な説明文**\n- 動画内で話されている**主なポイント**\n\nそれらをご共有いただければ、ご要望の形式で要約いたします！",
+      "category": null,
+      "source": "Lenny's Podcast",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Zuckerberg's the best at copying ideas and making them 10x better.",
+      "url": "https://www.youtube.com/watch?v=BeEN3sxN0oA",
+      "summary": "・MetaはAIインフラ強化のため独自カスタムチップ（ASIC）の開発を進めており、クラウド依存からの脱却と推論コストの削減を目指している。\n・ザッカーバーグの戦略は他社の革新的アイデアを迅速に模倣・改良してスケールさせることであり、開発者はMetaのオープンソース戦略（LLaMAなど）を自社プロダクトに活用できる点に注目すべきである。\n・AIをエンゲージメント最大化（いわゆるドゥームスクローリング）に組み込む設計思想は、開発者がUX設計においてユーザーの依存性と倫理的配慮のバランスを意識する必要性を示唆している。",
+      "category": null,
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    },
+    {
+      "title": "The State Pattern in Python - I Like How This Turned Out",
+      "url": "https://www.youtube.com/watch?v=OeirQdzYdnc",
+      "summary": "・従来のステートパターンはクラスと継承で実装されるが、この動画ではPythonのEnum・デコレータ・ジェネリクスを活用してデータ駆動型の汎用ステートマシンへとリファクタリングする手法を紹介している。\n・状態遷移をルックアップテーブルとして捉え直すことで、`StateMachine`クラスを汎用エンジンとして抽出し、デコレータで遷移を宣言的に定義できる設計を実現している。\n・この手法により業務ロジックを持つクラス（例：Payment）がシンプルになり、遷移の明示性・再利用性が高まるため、状態数が多く遷移ルールが複雑なシステムで特に有効な設計パターンである。",
+      "category": null,
+      "source": "ArjanCodes",
+      "source_type": "youtube"
+    },
+    {
+      "title": "If I Wanted to Make My First $100K in 2026, I’d Do This",
+      "url": "https://www.youtube.com/watch?v=XIhc7_Ptrpk",
+      "summary": "・$100Kビジネス構築の5フェーズロードマップ（アイデア出し→ニッチ選定→オファー設計→バリデーション→モメンタム）を軸に、製品を作る前に必ず検証することの重要性が強調されている。\n・「6つのP」フレームワークを使って魅力的なオファーを設計し、ディスカバリーコール（初回営業通話）を押し売り感なく進める具体的な手法が解説されている。\n・開発者・フリーランサーへの示唆として、自分の技術スキルをニッチと掛け合わせてサービス化し、小規模な顧客検証（Mom Test的アプローチ）から始めることが最短ルートとして提示されている。",
+      "category": null,
+      "source": "Ali Abdaal",
+      "source_type": "youtube"
+    },
+    {
+      "title": "I built a network with gachapon machines",
+      "url": "https://www.youtube.com/watch?v=3XkBH83P93s",
+      "summary": "・日本のガチャポンマシンをネットワーク機器として組み合わせるという独創的なホームラボプロジェクトを構築した。\n・ガチャポンの筐体やギミックをネットワーキングの物理的なビジュアライゼーションや構成要素として活用する実装アイデアが紹介されている。\n・開発者やネットワークエンジニアにとって、学習環境を楽しくユニークな形で構築することがモチベーション維持に有効であることを示唆している。",
+      "category": null,
+      "source": "NetworkChuck",
+      "source_type": "youtube"
+    },
+    {
+      "title": "This robot did something unexpected.",
+      "url": "https://www.youtube.com/watch?v=osHX-pgB9Z8",
+      "summary": "・1xのロボットが訓練データに含まれていない行動（壁の付箋を取って読み上げる）を自発的に実行し、汎用知能の片鱗を見せた。\n・しかし同じ行動を再現しようとすると失敗しており、ロボットの知的行動が確率的・非決定論的であることが示された。\n・開発者への示唆として、汎用AIロボットの評価には「再現性」が重要な課題であり、一度の成功をもって能力の証明とすることへの慎重さが求められる。",
+      "category": null,
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Can I Build This UI In 10 Minutes",
+      "url": "https://www.youtube.com/watch?v=vmzt6I1IZg8",
+      "summary": "・CSSデイリーチャレンジのUIを10分で再現する挑戦で、複雑なレイアウトをFlexboxやGrid、疑似要素などのCSSテクニックを駆使して実装している。\n・10分の制限時間を超えた部分はチャレンジ延長として継続し、最終的にAIの解答例との比較も行うことで、実装アプローチの違いや改善点を検証している。\n・短時間でUIを構築する実践的な訓練はCSSスキル向上に効果的であり、cssdaily.devのような課題サイトを活用することが開発者の技術習得に役立つことを示唆している。",
+      "category": null,
+      "source": "Web Dev Simplified",
+      "source_type": "youtube"
+    },
+    {
+      "title": "\"Have fun staying poor.\"",
+      "url": "https://www.youtube.com/watch?v=c3PDUe5bsho",
+      "summary": "・この動画はJasonという人物がCrypto Twitterのコミュニティから批判を受けている状況を描いており、技術的な実装内容よりも投資コミュニティ内の対立に焦点を当てている。\n・Jasonは「自分の資産は批判者全員を合わせた額より多い」と主張しており、SNS上での議論より実際の投資行動を重視する姿勢を示している。\n・開発者・投資家への示唆として、SNSでの発言より実際の行動（ベッティング＝実践）から学ぶことの重要性が強調されており、「議論より実装・実践」という教訓が込められている。",
+      "category": null,
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    },
+    {
+      "title": "This is not an ad. Just a fake \"paid partnership\" tattoo",
+      "url": "https://www.youtube.com/watch?v=9KVxpLDfEV4",
+      "summary": "・Nick O'NeillはHiggsfield（AIツール）の未開示広告をしているとユーザーから疑われた。\n・彼はその疑惑への反論として、額に「Paid Partnership with Higgsfield」と書いた偽タトゥーを貼るというユーモラスな動画で応じた。\n・開発者・クリエイターにとって、製品への純粋なファン発信の推薦でも広告と誤解されうる時代において、透明性の示し方が重要な課題となっていることを示唆している。",
+      "category": null,
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    },
+    {
+      "title": "5 Ways To SSR/RSC on TanStack Start",
+      "url": "https://www.youtube.com/watch?v=PX3QlADinIE",
+      "summary": "・TanStack Startには「クライアントサイドレンダリング」「サーバーサイドレンダリング」「データのみのSSR」「RSC低レベルAPI」「コンポジットコンポーネント」の5つのSSR/RSC実装方式が存在する。\n・RSC低レベルAPIを使うことでサーバーコンポーネントを細かく制御できるが、コンポジットコンポーネントはサーバーとクライアントの処理を組み合わせたより実践的なアプローチを提供する。\n・開発者はユースケースに応じてこれら5つの方式を使い分けることが重要で、公式GitHubリポジトリにサンプルコードが公開されているため実装の参考にできる。",
+      "category": null,
+      "source": "Jack Herrington",
+      "source_type": "youtube"
+    }
+  ]
+}

--- a/web/src/content/editions/0005.json
+++ b/web/src/content/editions/0005.json
@@ -1,0 +1,169 @@
+{
+  "issue_no": 5,
+  "date": "2026-04-22",
+  "standfirst": null,
+  "daily_title": null,
+  "sources_scanned": null,
+  "articles": [
+    {
+      "title": "Introducing TanStack AI Code Mode",
+      "url": "https://www.youtube.com/watch?v=s9Cs_RmkVPg",
+      "summary": "・TanStack AI の「Code Mode」は、LLMがツールを呼び出す際に従来の関数呼び出し方式の代わりにコードを生成・実行するアプローチを採用し、処理速度と精度を向上させる新機能である。\n・Code Modeはコンテキスト消費量を削減しながらより正確なツール利用を実現するため、LLMを活用したアプリ開発においてコストとパフォーマンスの両面で恩恵をもたらす。\n・TanStack AIはオープンソースのモノレポとして公開されており、開発者はGitHubリポジトリやブログ記事を参照することで実装の詳細や導入方法を確認できる。",
+      "category": null,
+      "source": "Jack Herrington",
+      "source_type": "youtube"
+    },
+    {
+      "title": "They remade the best selling computer ever - Commodore 64 Ultimate",
+      "url": "https://www.youtube.com/watch?v=EGv5Ps-DuOM",
+      "summary": "・Commodore 64 Ultimateは伝説的なホームコンピュータ「コモドール64」を現代に復刻した製品で、オリジナルのキーボード一体型デザインや基本的なBASIC環境を忠実に再現している。\n・カセットテープによるデータ読み込みなど当時のインターフェースも継承しており、レトロなハードウェアの仕組みや8ビット時代のプログラミング体験を実機で学ぶことができる。\n・開発者視点では、往年のBASICプログラミングやシンプルなグラフィック処理の実装を体験できる教育的ツールとして、レトロコンピューティングやエミュレーション技術への理解を深める素材として活用できる。",
+      "category": null,
+      "source": "ShortCircuit",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Do we still need PMs?",
+      "url": "https://www.youtube.com/watch?v=Z_AoFoWkROg",
+      "summary": "動画の実際の内容（字幕・音声）にアクセスできないため、タイトルと説明文のみから推測した要約となりますが、以下のように整理できます：\n\n・AIコーディングツール（Claude CodeやChatGPTなど）の台頭により、従来PMが担っていた要件定義や仕様整理の一部が自動化・代替されつつある。\n・開発者自身がAIを活用してプロダクト判断や実装を直接行えるようになり、PM・エンジニア間の役割境界が再定義されている。\n・AIが普及する開発現場においても、ビジネス文脈の判断・ステークホルダー調整・優先順位づけなどPMの本質的価値は残るという示唆が含まれると考えられる。\n\n---\n⚠️ **注意：** YouTubeの動画内容（音声・字幕）には直接アクセスできないため、上記はタイトルと説明文からの**推測**です。正確な要約が必要な場合は、動画のトランスクリプトや字幕テキストをこちらに貼り付けていただければ、より精度の高い要約が可能です。",
+      "category": null,
+      "source": "Lenny's Podcast",
+      "source_type": "youtube"
+    },
+    {
+      "title": "i didn't want to like this....",
+      "url": "https://www.youtube.com/watch?v=G3jvn7n-68Y",
+      "summary": "・Perplexity Computerは19のAIモデルを搭載し、Firecracker MicroVMによる隔離されたクラウド実行環境でオーケストレーターモデル（Claude Opus等）がタスクを分解・委任するアーキテクチャを採用している。\n・ツール構築不要でスケジュール実行やマルチエージェント連携が即座に使える反面、10,000クレジット付きの月200ドルプランはヘビーユースで短期間に消費し切るほどコストが高い。\n・開発者にとっての示唆は「ツール整備（斧磨き）に創造的エネルギーを使い切ってしまう罠」であり、制約されたボックス型環境の方がアイデア創出に集中できるというビルド戦略の再考を促している。",
+      "category": null,
+      "source": "NetworkChuck",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Bittensor Drama! TAO down 15%! | E2274",
+      "url": "https://www.youtube.com/watch?v=BaGVZI-sMK0",
+      "summary": "・Bittensor（TAO）のサブネット上でCovenantAIを運営していたSamが、自身のウォレットからTAOトークンを売却・持ち出したとされる行為（いわゆるラグプル疑惑）が発覚し、TAOの価格が約20%下落した。\n・この問題の根本原因はサブネットのガバナンス設計の未熟さにあり、今後はサブネット開設時のTAOステーキング要件強化やコミュニティによるガバナンス権限の整備が技術的課題として浮き彫りになった。\n・一方で128あるサブネットの一例として紹介されたビデオサブネット85（Vidio）は、AIエージェントがAmazon S3等のストレージを解析し、ストリーミング・アーカイブ・セキュリティ用途向けに動画を最適化・アップスケールする分散型ビデオ処理インフラを構築しており、Bittensorの実用的な応用例を示している。",
+      "category": null,
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Are tech jobs safe in 2026?",
+      "url": "https://www.youtube.com/watch?v=TqQniw2xgck",
+      "summary": "申し訳ありませんが、提供された情報（タイトルと短い説明文のハッシュタグのみ）では、動画の具体的な内容を把握することができません。\n\n動画のトランスクリプト（字幕・文字起こし）や詳細な説明文をご提供いただければ、正確に要約いたします。\n\n---\n\n**提供いただける情報の例：**\n- 動画の字幕テキスト\n- 詳細な説明文\n- 動画内の主要なポイント\n\nご協力をお願いいたします！",
+      "category": null,
+      "source": "Lenny's Podcast",
+      "source_type": "youtube"
+    },
+    {
+      "title": "A smart move - Nothing Phone 4a Pro",
+      "url": "https://www.youtube.com/watch?v=R5TMLziDjtA",
+      "summary": "・Nothing Phone 4a Proはフラッグシップではないものの、価格帯に対してカメラ・ディスプレイ・バッテリーのバランスが良く、妥協点が少ない実用的なミッドレンジ端末である。\n・ハードウェアツアーやカメラテストなどの実機検証を通じて、日常使いに十分なパフォーマンスと独自の「Essentialボタン」など差別化機能が確認されている。\n・OnePlusの共同創業者Carl Pei率いるNothingが着実にブランドを成長させており、コストパフォーマンス重視のAndroid開発・検証端末として開発者にも注目に値する選択肢となりうる。",
+      "category": null,
+      "source": "ShortCircuit",
+      "source_type": "youtube"
+    },
+    {
+      "title": "3D-Printed Homes for $99K: ICON’s Jason Ballard on the future of housing | E2277",
+      "url": "https://www.youtube.com/watch?v=AOVMBfbk9KA",
+      "summary": "・ICONは独自の3Dプリンティング技術（Titanプリンター）を用いてコンクリート住宅を従来の半額・短期間で建設しており、Fort Blissでは6ヶ月で10棟の兵舎を納入し耐爆・防弾性能も実証している。\n・チャンネルパートナー制度を通じてスケール展開を図っており、配管・電気配線との統合や耐久性（ひび割れ対策）が主要な技術課題として開発者・建設業者向けに共有された。\n・Resi LabsはBitTensor（サブネット46）上に構築した分散型AIで不動産価格を98%の精度で推定するエンジンをデモし、推論コストが1件あたり数分の1セントという超低コスト実装モデルを示した。",
+      "category": null,
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Hire barrels, not ammunition",
+      "url": "https://www.youtube.com/watch?v=pZqVAvFg0UQ",
+      "summary": "・多くの企業が採用を増やしても成果が上がらない根本原因は、「バレル（構想から成功まで独立して推進できる人材）」の数が増えないまま人員だけ積み上げているためである。\n・バレルでない人材をいくら追加しても、同じ取り組みに人が重なるだけでコラボレーションコストが増大し、時間とエネルギーが無駄になる。\n・採用・組織拡大を検討する際は人数ではなく「アイデアを自力で実現まで導けるバレルの数」を増やすことを優先すべきであり、それが真のスケールの鍵となる。",
+      "category": null,
+      "source": "Lenny's Podcast",
+      "source_type": "youtube"
+    },
+    {
+      "title": "What Most Python Developers Miss About Generators",
+      "url": "https://www.youtube.com/watch?v=5VN-3rIUPZ8",
+      "summary": "・Pythonのジェネレーターは`yield`で処理を一時停止・再開し、データを必要な時だけ生成する遅延評価により、大きな中間データ構造を持たずメモリ効率の高いストリーム処理を実現できる。\n・入力に`Iterable`・出力に`Generator`を統一したパイプライン設計と`functools.reduce`を使った関数合成により、ログのパース・フィルタリング・正規化などの処理ステージを疎結合かつ宣言的に組み合わせられる。\n・`send()`を使った双方向通信でジェネレーターを小さなステートフルコンポーネントとして活用でき、また消費者側がペースを制御するバックプレッシャーの仕組みにより、過剰生産やメモリ問題を自然に防止できる。",
+      "category": null,
+      "source": "ArjanCodes",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Competition beats corporate building AI",
+      "url": "https://www.youtube.com/watch?v=-wgh2bKIT2I",
+      "summary": "・OpenAI・Google・AnthropicなどがAIを内部開発する従来モデルに対し、TAO（Bittensor）はオープンなコンペティション形式でAI開発を行い、最も優れたモデルが報酬を得る分散型アーキテクチャを採用している。\n・開発者は「サブネット」と呼ばれる専門化されたネットワークに参加・構築でき、中央集権的な組織に所属せずともAI開発に貢献できる実装の自由度が確保されている。\n・このモデルは競争原理によってモデル品質の向上を促すインセンティブ設計がなされており、個人ビルダーや独立開発者にとって従来の企業主導開発に対抗できる経済的機会を提供している。",
+      "category": null,
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    },
+    {
+      "title": "MacBook Touch Bars Are Back!",
+      "url": "https://www.youtube.com/watch?v=OkcRVZ14keo",
+      "summary": "・EnilinxのFlexbarはAppleのTouch Barに類似したMacBook向けのサードパーティ製アクセサリで、外付けで接続できる点が特徴である。\n・オリジナルのTouch Barと異なりソフトウェアのカスタマイズ性が高く、開発者はショートカットやマクロをより柔軟に設定・割り当てることができる可能性がある。\n・Apple純正ではないサードパーティ製品であるため、macOSのアップデートや互換性への継続的な対応状況を開発者は導入前に確認すべきである。",
+      "category": null,
+      "source": "ShortCircuit",
+      "source_type": "youtube"
+    },
+    {
+      "title": "You Need To Use This TSConfig Setting",
+      "url": "https://www.youtube.com/watch?v=h1ZPBYhTT1k",
+      "summary": "動画の具体的な内容（字幕・音声）にアクセスできないため、タイトルと説明文のみを基に以下のように推察した要約となります。正確な内容は動画本編でご確認ください。\n\n・TypeScriptの`tsconfig.json`には見落とされがちながら重要な設定項目が存在し、開発効率や型安全性の向上に直結する。\n・特定のTSConfig設定を有効化することで、コンパイル時のエラー検出が強化され、潜在的なバグを早期に防ぐことができる。\n・プロジェクト初期のtsconfig設定を見直し、推奨オプションを適切に有効化することが、堅牢なTypeScript開発の基盤となる。",
+      "category": null,
+      "source": "Web Dev Simplified",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Top AI Trends From 100 Interviews | AI Briefings: nWave",
+      "url": "https://www.youtube.com/watch?v=8WJ1XVBh8NA",
+      "summary": "・「バイブコーディング」は大規模システムでは失敗しやすく、AIツールを単なるコード生成器として使うのではなく、SOLID原則・ヘキサゴナルアーキテクチャ・TDDといったソフトウェアエンジニアリングの規律を維持することが不可欠である。\n・nWaveは23以上の専門AIエージェントを「意見を持つチームメンバー」として扱い、Claude Codeを活用して実装フェーズを自動化しつつ、人間が問題定義・設計の中心に留まる「細粒度の反復的仕様化」アプローチを採用している。\n・AIと協働する開発においては、人間が問題空間の主導権を握り小さなステップで進めることがこれまで以上に重要であり、AIを「ツール」ではなく「エンジニアリングパートナー」として統制できるかどうかがチームの競争力を左右する。",
+      "category": null,
+      "source": "Modern Software Engineering",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Vikings, Ragnar, Berserkers, Valhalla & the Warriors of the Viking Age | Lex Fridman Podcast #495",
+      "url": "https://www.youtube.com/watch?v=iKx3gAODybU",
+      "summary": "・この動画はヴァイキング史研究者のLars Brownworthが、ヴァイキング時代の始まり・軍事戦略・ラグナル・ロズブロークなどの歴史的事実をLex Fridmanと深く掘り下げたポッドキャストである。\n・ヴァイキングの船舶技術・戦術・北米や東方への探検ルートなど、歴史的な「実装」の詳細が具体的に語られており、歴史をシステム的・構造的に捉える視点が随所に示されている。\n・人間の本質と歴史の関係性にも言及されており、AIや技術開発に携わる開発者にとっても「過去の意思決定パターンから学ぶ」という示唆が得られる内容となっている。",
+      "category": null,
+      "source": "Lex Fridman",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Do you need a Studio Display, or the XDR version  - Apple Studio Display and XDR (2026)",
+      "url": "https://www.youtube.com/watch?v=QY6wrULPZmM",
+      "summary": "以下はタイトルと説明文から推察できる内容に基づいた要約です（実際の動画視聴はしていません）。\n\n・Apple Studio DisplayとStudio Display XDRはI/Oやスペックなどのハードウェア仕様に明確な差異があり、用途に応じた選択が重要となる。\n・リフレッシュレートや色精度、ゲーミング性能などの観点で両モデルを実機比較しており、XDRは上位の映像品質を提供するがその分価格差も大きい。\n・開発者や映像制作者にとっては色精度やディスプレイ性能が作業品質に直結するため、用途と予算のバランスを踏まえてどちらのモデルが費用対効果に優れるかを見極めることが示唆される。",
+      "category": null,
+      "source": "ShortCircuit",
+      "source_type": "youtube"
+    },
+    {
+      "title": "The biggest myth in business",
+      "url": "https://www.youtube.com/watch?v=f1rK6WfCjCQ",
+      "summary": "申し訳ありませんが、提供された情報（タイトルと説明文のみ）では、動画の具体的な内容を把握することができません。\n\nURLや説明文からわかる範囲でお伝えすると：\n\n・「ビジネスにおける最大の神話」というタイトルから、一般的なビジネス常識への反論や新たな視点を提示する内容と推測される。\n・説明文のリンクは「経済的自由」に関するワークショップへの誘導であり、ライフスタイルビジネスや収益化戦略に関連するコンテンツである可能性が高い。\n・技術的・開発者向けの具体的な実装ヒントを抽出するには、動画の実際のトランスクリプトや詳細な内容が必要です。\n\n---\n**動画の字幕・トランスクリプト、または詳細な内容をご提供いただければ、より正確な要約が可能です。**",
+      "category": null,
+      "source": "Ali Abdaal",
+      "source_type": "youtube"
+    },
+    {
+      "title": "How to Pick a Niche(SEO)",
+      "url": "https://www.youtube.com/watch?v=6sP6wMOb48A",
+      "summary": "申し訳ありませんが、提供された情報（タイトルと短い説明文のみ）からは、動画の具体的な内容を正確に把握することができません。\n\n動画の**文字起こし（トランスクリプト）や詳細な説明文**をご提供いただけると、正確な要約が可能です。\n\n---\n\nタイトルと`#ahrefs`タグから推測できる一般的な内容でよければ、以下のような要約になります（**推測ベース**）：\n\n・SEOにおけるニッチ選定では、検索ボリュームと競合難易度（KD）のバランスを評価し、参入可能なキーワード空間を特定することが重要である。\n・Ahrefsなどのツールを活用して、ターゲットニッチの上位サイトのドメイン権威（DR）や被リンク構造を分析し、現実的な勝算を見極めるべきである。\n・収益性・検索需要・専門性の三要素が揃うニッチを選ぶことで、コンテンツ投資対効果を最大化できる。\n\n正確な要約のために、ぜひ動画の内容をご共有ください。",
+      "category": null,
+      "source": "Ahrefs",
+      "source_type": "youtube"
+    },
+    {
+      "title": "They shot an entire $70M movie on a gray screen.",
+      "url": "https://www.youtube.com/watch?v=295kcwiTaco",
+      "summary": "・7000万ドル規模の映画をグレーのスクリーンのみで撮影し、背景はすべてAI生成で制作するという手法が採用された。\n・俳優（ガル・ガドット含む）はセットなしで演技に集中でき、AIが背景を後から生成することでプロダクション工程が大幅に効率化される。\n・この技術により映画制作のコストと物理的制約が削減され、今後はより多くの作品が制作可能になるという示唆がある。",
+      "category": null,
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    },
+    {
+      "title": "SpaceX and Cursor team up to topple Claude Code | E2279",
+      "url": "https://www.youtube.com/watch?v=Xhl8gVk3yrc",
+      "summary": "・SpaceXとxAIがAIコーディングツールCursorと提携し、SpaceXが計算資源を提供しCursorが独自のコーディングモデルを訓練する構造で、総額最大600億ドル規模の買収オプション付き大型ディールが成立した。\n・BittensorのサブネットをKickstarter的に支援するBitstarter、および分散型コンペティションでエージェント向け「スキル（マークダウンファイル）」を設計・改善するTrajectoryRL（サブネット11）など、分散型AIインフラの実装事例が紹介された。\n・エージェント時代においてスキルファイルの生成・管理自体にエージェントが必要になるという再帰的な複雑化が進んでおり、AIコーディングモデルがxAIの能力向上に再帰的に貢献するループ構造が開発者にとって重要な示唆となっている。",
+      "category": null,
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    }
+  ]
+}

--- a/web/src/content/editions/0006.json
+++ b/web/src/content/editions/0006.json
@@ -1,0 +1,169 @@
+{
+  "issue_no": 6,
+  "date": "2026-04-23",
+  "standfirst": null,
+  "daily_title": null,
+  "sources_scanned": null,
+  "articles": [
+    {
+      "title": "How I’d Use YouTube SEO to Get Millions of Views if I Had to Start Over",
+      "url": "https://www.youtube.com/watch?v=lgUrHqaPrhU",
+      "summary": "・YouTubeアルゴリズムではなくGoogle検索を狙い、毎月一定数検索されるキーワードをAhrefs Site Explorerで特定してトピックを選ぶことが、再現性ある安定した流入の基盤となる。\n・ランキングチェックリストとして、タイトルに検索キーワードをそのまま含め、説明文の冒頭にもキーワードを置き、チャプター用タイムスタンプを追加し、動画内で口頭でもキーワードと関連語を網羅的に語ることがGoogleとYouTubeの評価を高める。\n・AIオーバービューやAIモードでのYouTube引用が急増しており、Ahrefs Brand Radarで競合チャンネルがどのAI検索クエリに表示されているかを調べ、その話題で網羅的な動画を制作することが現時点での最大の成長機会となっている。",
+      "category": null,
+      "source": "Ahrefs",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Why Your Company Should Own Its AI Model | E2278",
+      "url": "https://www.youtube.com/watch?v=xFJceTJrbWo",
+      "summary": "・AragonはRL（強化学習）を用いて企業のSlack・メール・各種データをKimiなどのベースモデルに継続的にポストトレーニングし、企業専用の「カンパニーワールドモデル」として重みに埋め込む仕組みを構築している。\n・データ取得はCronジョブで約15分ごとにSlack等からデータを収集しChromaDB＋Ollamaで知識ベースを構築し、コンテキストウィンドウに詰め込む従来手法より低コスト・高精度なエージェント実行を実現している。\n・エージェントはカレンダー・メール・Slack・請求書支払いなど複数サービスに接続し、「Joshに送って」のような曖昧な指示でも社内データから文脈を推論して自律実行できる点が差別化ポイントとなっている。",
+      "category": null,
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Stop Using Context in React - Use This Instead",
+      "url": "https://www.youtube.com/watch?v=ULS7LHNScHc",
+      "summary": "・ZustandはReactのContextと異なりコンポーネントが使用する値のみをセレクター関数で抽出することで不要な再レンダリングを防止でき、`useCounterStore(state => state.count)`のように記述するだけでパフォーマンスが向上する。\n・オブジェクトをまとめて返す場合は参照比較による無限ループを避けるため`useShallow`でラップするシャロー比較を用いる必要がある。\n・Zustandのストアは`useCounterStore.getState()`や`useCounterStore.setState()`でReactコンポーネント外からも直接アクセスできるため、イベントリスナーや非Reactコードとの統合が容易になる。",
+      "category": null,
+      "source": "Web Dev Simplified",
+      "source_type": "youtube"
+    },
+    {
+      "title": "The current state of the PM industry",
+      "url": "https://www.youtube.com/watch?v=vR3tw1_v-js",
+      "summary": "・3年前のプロダクトリーダーは情報伝達に終始し権限なき責任を担わされていたが、AI活用により自らアイデアを検証・実装できるようになり業界はルネッサンスを迎えている。\n・一方で変化のスピードが速く常に緊張状態が続くことで業界全体が極度の疲弊状態にあり、これほど疲れ切った業界は見たことがないと指摘されている。\n・大手企業が数万人単位でレイオフを行いながら同時に高待遇で採用も進めるという矛盾した状況が生じており、PMはポジションによって恩恵と打撃の両方を受け得る二極化が進んでいる。",
+      "category": null,
+      "source": "Lenny's Podcast",
+      "source_type": "youtube"
+    },
+    {
+      "title": "How We Built a $1.5M ARR SaaS With 3 People and $0 in Ad Spend",
+      "url": "https://www.youtube.com/watch?v=Dt6HAEuwEug",
+      "summary": "・TallyはNotion風のブロック挿入UIを採用したフォームビルダーで、無制限フォーム・無制限回答を無料提供するという差別化した価格モデルを初期から採用した。\n・初期ユーザー獲得はProduct Huntのアップボーター向け手動コールドDM・Slackグループへの参加・ソーシャルモニタリングによるピッチという予算ゼロの地道な手法で行い、約15〜20%の返信率を得た。\n・「Building in Public」としてブログに収益・コスト・ロードマップを全公開する戦略がファウンダー層へのリーチとユーザー獲得に有効に機能し、3名チームで150k MRR（約1.5M ARR）を達成した。",
+      "category": null,
+      "source": "MicroConf",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Apple fixes bug that cops used to extract deleted chat messages from iPhones",
+      "url": "https://techcrunch.com/2026/04/22/apple-fixes-bug-that-cops-used-to-extract-deleted-chat-messages-from-iphones/",
+      "summary": "概要\nAppleは、削除済みまたは自動消去されたメッセージの内容を法執行機関が復元できてしまうバグを修正するアップデートをリリースした。通知としてキャッシュされたメッセージ内容がデバイス上に最大1ヶ月間保持されており、FBIがフォレンジックツールを使ってSignalの削除済みメッセージを抽出できることが404 Mediaの報道で明らかになっていた。Appleは旧バージョンのiOS 18向けにも修正をバックポートした。\n\n学べること\nアプリレベルでメッセージを削除しても、OS側の通知データベースに内容が残存するという「レイヤーをまたいだデータ漏洩リスク」が存在することが改めて示された。プライバシー機能は単一のアプリや単一のレイヤーだけでは完結せず、OSおよびシステム全体の挙動を把握しなければ真の安全性は担保できない。\n\n実践的な応用\niOSおよびiPadOSを最新バージョンへ即時アップデートし、通知キャッシュのリスクを解消することが最優先アクションとなる。プライバシーに配慮したアプリを開発・運用する際は、通知ペイロードに機密コンテンツを含めない設計（空の通知＋アプリ内取得方式）を採用することを検討すべきだ。Signal等の自動削除機能に頼るだけでなく、通知表示設定をロック画面で非表示にするなど多層的な対策を組み合わせることも有効である。",
+      "category": null,
+      "source": "Hacker News (Front Page)",
+      "source_type": "rss"
+    },
+    {
+      "title": "How Stripe Built Their New Website",
+      "url": "https://www.youtube.com/watch?v=ypzNhwpmOD4",
+      "summary": "・Stripeの新ホームページは「ベントーボックス」レイアウトを採用し、決済・請求・AIなど複数プロダクトをモーダルによるプログレッシブ・ディスクロージャーで表現することで、ページ離脱を防ぎながら情報を段階的に提供する設計を実現した。\n・アニメーションは「多すぎず少なすぎず」の調整を繰り返すプロトタイピングで精緻化され、インタラクションへの応答性をクリック可能の視覚的フィードバックとして機能させている。\n・サイトはビジネスの進化（グローバルGDPカウンターや企業ロゴのスクロール表示など）に合わせて「マニフェスト」として設計し、デザインの細部へのこだわりがプロダクト品質への信頼に直結するという思想で構築された。",
+      "category": null,
+      "source": "Y Combinator",
+      "source_type": "youtube"
+    },
+    {
+      "title": "How Push Notifications Can Betray Your Privacy (and What to Do About It)",
+      "url": "https://www.eff.org/deeplinks/2026/04/how-push-notifications-can-betray-your-privacy-and-what-do-about-it",
+      "summary": "概要\nスマートフォンのプッシュ通知は、AppleやGoogleのサーバーを経由して配信されるため、内容やメタデータが第三者に把握される可能性がある。法執行機関向けのフォレンジックツールを使えば、Signalなどのセキュアなメッセージングアプリの削除済み通知テキストすら復元できることが404 Mediaの報告で明らかになった。Appleは2026年4月のiOS更新で削除済み通知のデータベース保存を停止する対応を行った。\n\n学べること\n通知のプライバシーリスクは「クラウド経由の送信時」と「端末上への保存時」の2段階で発生しており、どちらも独立した対策が必要となる。Signalはサーバーを経由せず端末上で通知を処理する設計を採用しており、通知プライバシーの実装水準として他アプリの参考モデルになる。アプリを削除した後も通知データがOSに残留し得るという事実は、開発者がデータ削除の完全性を設計段階から考慮すべきことを示している。\n\n実践的な応用\nSignalはiOS・Android両方で通知表示を「送信者名のみ」または「内容なし」に制限できるため、セキュリティを重視するユーザーは即座に設定変更を検討すべきだ。iOSでは「設定→通知→プレビューを表示」をロック解除時または非表示に変更し、Androidでは「ロック画面上の機密コンテンツ」を無効化することでリスクを軽減できる。開発者はSignalの通知設計を参考に、コンテンツをサーバーに送らず「ping」で起動する方式を採用し、ユーザーに通知内容の粒度を選択させるUIを実装することが推奨される。",
+      "category": null,
+      "source": "EFF",
+      "source_type": "rss"
+    },
+    {
+      "title": "Hot Off the Press: EFF's Updated Guide to Tech at the US-Mexico Border",
+      "url": "https://www.eff.org/deeplinks/2026/04/hot-press-effs-updated-guide-tech-us-mexico-border",
+      "summary": "概要\nEFF（電子フロンティア財団）は、米国・メキシコ国境における監視技術を解説するガイドブック（zine）の大幅改訂版を公開した。40ページのフルカラー冊子には、新型監視タワー、軍事技術、偽装カメラや自動ナンバープレート読取装置のギャラリーが追加されている。英語版はEFFショップで購入またはCreative Commonsライセンスで無料ダウンロードが可能だ。\n\n学べること\n国境沿いでは監視機器が美術作品・携帯電話タワー・ゴミなどに偽装して設置されており、専門知識なしには識別が困難な実態がある。このガイドはジャーナリスト・人道支援者・移民擁護者など現場の人々が実際に活用しており、公開情報・衛星画像・見本市資料など多角的な調査手法によって裏付けられている。監視インフラの透明性確保には、市民による継続的なドキュメント化と情報共有が不可欠であることが示されている。\n\n実践的な応用\n開発者やindie hackerは、EFFが公開しているオープンな地図データや衛星画像の分析手法を参考に、監視インフラの可視化ツールや市民向けレポーティングアプリの開発を検討できる。Creative Commonsライセンスで提供されているガイドを活用し、同様の「テクノロジー×人権」分野のコンテンツ制作や啓発プロジェクトに応用することも有効だ。公開記録請求（FOIA）や衛星画像解析をデータソースとしたプロダクト開発のモデルケースとして研究する価値がある。",
+      "category": null,
+      "source": "EFF",
+      "source_type": "rss"
+    },
+    {
+      "title": "Scoring Show HN submissions for AI design patterns",
+      "url": "https://www.adriankrebs.ch/blog/design-slop/",
+      "summary": "概要\nClaude Codeの普及によりShow HN投稿数が急増し、モデレーターが新規アカウントの投稿を制限するほどになった。筆者はAI生成デザインの\"無機質な見た目\"を定量化するため、500件のShow HNページをPlaywrightで自動スキャンし、フォント・カラー・レイアウト・CSSの15パターンで採点した。その結果、多くのプロジェクトがshadcn/ui・VibeCode Purple・左カラーボーダーなど共通のAIデザインパターンを持つことが確認された。\n\n学べること\nLLMが出力するデフォルトデザインには「Inter一択」「グラデーション多用」「番号付きステップ」など再現性の高いパターンがあり、デザイナーには一目でAI生成と識別できるシグネチャーとなっている。ただし筆者が指摘するように、これは「悪い」というより「没個性」の問題であり、かつてBootstrapテンプレートが乱立した時代と構造的に同じ現象だ。決定論的なDOM・CSSチェックだけで5〜10%の誤検知率に抑えられたことは、LLMによる主観判定なしでもパターン検出が可能であることを示している。\n\n実践的な応用\n自分のランディングページが\"AIスロップ\"と見なされたくない場合、少なくとも上記15パターンのうち複数が重複しないよう意識的にデザインを上書きするだけで差別化になる。採点コードのオープンソース化も検討中とのことなので、自社サービスのページを自動スコアリングするCI組み込みを検討する価値がある。AIエージェントがWebの主要ユーザーになる未来では設計の優先順位が変わりうるため、\"人間に魅せるデザイン\"への投資対効果を今から再評価しておくべきだ。",
+      "category": null,
+      "source": "Hacker News (Front Page)",
+      "source_type": "rss"
+    },
+    {
+      "title": "Bring your own Agent to MS Teams",
+      "url": "https://microsoft.github.io/teams-sdk/blog/bring-your-agent-to-teams/",
+      "summary": "・Teams TypeScript SDKの`ExpressAdapter`を使えば、既存のExpressサーバーに`POST /api/messages`エンドポイントを追加するだけで、既存のSlackボット・LangChainチェーン・Azure AI Foundryエージェントをそのまま Teams に接続できる。\n・実装は「アダプターでサーバーをラップ→`TeamsApp`インスタンス生成→`message`イベントハンドラ登録」の3ステップで共通化されており、SlackとTeamsを同一プロセス・同一Expressアプリ上で並行稼働させることも可能。\n・ボット登録はCLI（`teams app create`）一コマンドでAADアプリ登録・シークレット生成・マニフェスト作成を自動化でき、ローカル開発にはDev TunnelsやngrokでHTTPS公開が必要。",
+      "category": null,
+      "source": "Hacker News (Front Page)",
+      "source_type": "rss"
+    },
+    {
+      "title": "Paying $500/month so your kids have clean socks.",
+      "url": "https://www.youtube.com/watch?v=stDA4c8Ntr0",
+      "summary": "・家庭用ロボット「Neo」は現在、安全性の観点から調理や熱い液体の扱いなど危険な作業を制限しているが、長期的にはAI側の改良により安全に対応できるようにする方針。\n・ユーザーは外出時にアプリで「離席」を設定するだけで、帰宅までにすべての日常作業が完了する自律動作モードを実用的に活用している。\n・月額500ドルという価格に対し、洗濯などの家事負担を解消する価値があるとユーザーは評価しており、家事支援ロボットの実用的な費用対効果が示されている。",
+      "category": null,
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Keep Pushing: We Get 10 More Days to Reform Section 702",
+      "url": "https://www.eff.org/deeplinks/2026/04/keep-pushing-we-get-10-more-days-reform-section-702",
+      "summary": "・セクション702はNSAが海外通信を大規模収集しFBIが令状なしに米国人の通信内容を閲覧できる問題のある監視法である。\n・超党派の議員グループが実質的改革なしの5年間再授権を否決し、FBIアクセスに令状要件を課す真の改革を求めて10日間の延長を勝ち取った。\n・ウォーデン上院議員は法律の秘密解釈や乱用疑惑を指摘しており、ジャーナリストや海外在住家族を持つ米国人を含む一般市民のプライバシー保護のため、議会への圧力継続が急務となっている。",
+      "category": null,
+      "source": "EFF",
+      "source_type": "rss"
+    },
+    {
+      "title": "Palantir Has a Human Rights Policy. Its ICE Work Tells a Different Story",
+      "url": "https://www.eff.org/deeplinks/2026/04/palantir-has-human-rights-policy-its-ice-work-tells-different-story",
+      "summary": "・PalantirはUN人権指導原則等を公式に支持しているが、EFFの質問状に対してICEとの契約における具体的な人権デューデリジェンスの内容を明示しなかった。\n・ICEのELITEツールはPalantirが主張する「特定対象の優先的執行」に留まらず、メディケイドデータを含む多様なソースを利用した大規模な一斉摘発に使用されているとの証言・文書が存在する。\n・EFFは「法令遵守」や「内部プロセスの存在」は人権基準の代替にならないとし、Palantirに対してICEおよび人権侵害が予見される全機関との契約終了を求めている。",
+      "category": null,
+      "source": "EFF",
+      "source_type": "rss"
+    },
+    {
+      "title": "📁 How ICE Got My Data | EFFector 38.8",
+      "url": "https://www.eff.org/deeplinks/2026/04/how-ice-got-my-data-effector-388",
+      "summary": "・GoogleがICEにユーザーデータを提供した事例をEFFが取り上げており、プライバシー保護の約束を破った企業責任が問われている。\n・EFFシニアスタッフ弁護士F. Mario Trujilloは、政府による標的捜査からユーザーを守れなかったGoogleを州司法長官が追及できる可能性について解説している。\n・NSA監視改革や3Dプリンティングの検閲問題など、テクノロジーと市民の自由に関わる法的課題が複数取り上げられており、開発者はユーザーデータの政府開示リスクを設計段階から考慮する必要性が示唆されている。",
+      "category": null,
+      "source": "EFF",
+      "source_type": "rss"
+    },
+    {
+      "title": "Writing a C Compiler, in Zig",
+      "url": "https://ar-ms.me/thoughts/c-compiler-1-zig/",
+      "summary": "本文が断片的・不十分なため、要約不可。",
+      "category": null,
+      "source": "Hacker News (Front Page)",
+      "source_type": "rss"
+    },
+    {
+      "title": "Show HN: Honker – Postgres NOTIFY/LISTEN Semantics for SQLite",
+      "url": "https://github.com/russellromney/honker",
+      "summary": "・HonkerはSQLiteのWALファイルをstat(2)で監視することでポーリングなし・シングルデジットmsのクロスプロセス通知を実現し、Rustコアの上にPython/Node/Go/Ruby等の薄いバインディングを提供するSQLite拡張機能である。\n・ビジネスロジックのINSERTとキューのenqueue/stream publishを同一トランザクション内で実行できるトランザクショナルアウトボックスパターンが中核設計であり、ロールバック時にジョブも自動的に破棄される原子性を保証する。\n・WALモード必須・単一ホスト前提・NFS非対応という制約があり、リトライ付きワークキュー・耐久性ストリーム・エフェメラルpub/subの3プリミティブを備えるが、タスクパイプラインやDAGワークフローは意図的に除外されている。",
+      "category": null,
+      "source": "Hacker News (Front Page)",
+      "source_type": "rss"
+    },
+    {
+      "title": "Arch Linux Now Has a Bit-for-Bit Reproducible Docker Image",
+      "url": "https://antiz.fr/blog/archlinux-now-has-a-reproducible-docker-image/",
+      "summary": "・Arch LinuxのDockerイメージがビット単位で完全再現可能となり、新たに`repro`タグとして配布されている。\n・再現性確保のためpacmanキーが除去されているため、利用前に`pacman-key --init && pacman-key --populate archlinux`の実行が必要となる。\n・再現性実現の技術的ポイントは、`SOURCE_DATE_EPOCH`の設定、`ldconfig`補助キャッシュの削除、`--rewrite-timestamp`オプションによるタイムスタンプ正規化の3点である。",
+      "category": null,
+      "source": "Hacker News (Front Page)",
+      "source_type": "rss"
+    },
+    {
+      "title": "Copyright and DMCA Best Practices for Fediverse Operators",
+      "url": "https://www.eff.org/deeplinks/2026/04/copyright-and-dmca-best-practices-fediverse-operators",
+      "summary": "・DMCAセーフハーバーを適用するには、著作権侵害通知を受け取る「指定代理人」を米国著作権局のディレクトリ（copyright.gov）に登録し、3年ごとに更新する必要がある。\n・侵害通知への迅速な対応、不審な通知の精査、カウンター通知の適切な転送・復元対応、リピート侵害者アカウントの停止ポリシーの明文化が実装上の必須要件となる。\n・ホストは能動的な侵害監視は不要だが、既知の侵害を放置したり、侵害を奨励するコンテンツを掲載したりするとセーフハーバーの保護を失うため、利用規約やDMCAページへの明記が重要。",
+      "category": null,
+      "source": "EFF",
+      "source_type": "rss"
+    },
+    {
+      "title": "EFF 🤝 HOPE: Join Us This August!",
+      "url": "https://www.eff.org/deeplinks/2026/04/eff-hope-join-us-august",
+      "summary": "・EFFはニューヨーク・マンハッタンで8月14〜16日に開催されるハッカーカンファレンス「HOPE 26」に参加し、4月中のチケット購入額の10%がEFFに還元される。\n・カンファレンスではEFFの技術者・弁護士・活動家による位置情報ブローカーの追跡技術、政府監視への対抗策、デジタル市民権などの講演が予定されている。\n・位置情報データの収集・販売エコシステムの技術的実態や、プライバシー保護のための具体的な対策についても詳しく解説される予定。",
+      "category": null,
+      "source": "EFF",
+      "source_type": "rss"
+    }
+  ]
+}

--- a/web/src/content/editions/0007.json
+++ b/web/src/content/editions/0007.json
@@ -1,0 +1,129 @@
+{
+  "issue_no": 7,
+  "date": "2026-04-25",
+  "standfirst": null,
+  "daily_title": null,
+  "sources_scanned": null,
+  "articles": [
+    {
+      "title": "California Coastal Community Must Reject CBP's AI-Powered Surveillance Tower",
+      "url": "https://www.eff.org/deeplinks/2026/04/california-coastal-community-must-reject-cbps-ai-powered-surveillance-tower",
+      "summary": "・CBPがカリフォルニア州サンクレメンテにAnduril製AIサーベイランスタワー「Sentry」の設置を申請しており、映像・レーダー・コンピュータビジョンを組み合わせたシステムが最大9マイル先まで常時スキャン・追跡を自動実行する。\n・同システムは最大30日の画像保持に加え、アルゴリズム学習用データは「削除不可」とされており、市民データがAndurilの製品開発に流用される構造になっている。\n・CBPは今後数年で1,500基以上の追加設置（維持費だけで4億ドル超）を計画しているが、20年以上にわたる政府報告書がタワー型監視システムの非効率性を指摘しており、地域コミュニティや市議会レベルでの設置拒否が重要な対抗手段となっている。",
+      "category": "tech-news",
+      "source": "EFF",
+      "source_type": "rss"
+    },
+    {
+      "title": "Context is EVERYTHING in Agile",
+      "url": "https://www.youtube.com/watch?v=xWr55A41C20",
+      "summary": "・レトロスペクティブは形式的な儀式ではなく、「なぜうまくいかないのか」「解決策は何か」を真剣に考える場として機能させることが重要。\n・デイリースタンドアップは管理強化が目的ではなく、チームメンバーが互いの進捗を把握し、衝突回避・協力・共同作業を促進する「チーム認識」のための実践である。\n・アジャイルの各プラクティスは固定された規則ではなく継続的な実験であり、状況に応じて採用・適応・廃棄すべきものであって、固定されたプラクティス群をアジャイルの全てと見なすこと自体がアジャイルではない。",
+      "category": "senior-engineer",
+      "source": "Modern Software Engineering",
+      "source_type": "youtube"
+    },
+    {
+      "title": "EFF Sues DHS and ICE For Records on Subpoenas Seeking to Unmask Online Critics",
+      "url": "https://www.eff.org/press/releases/eff-sues-dhs-and-ice-records-subpoenas-seeking-unmask-online-critics-0",
+      "summary": "・EFFはDHSとICEが裁判官の承認不要な行政召喚状を使い、ICE活動を記録・批判したオンラインユーザーの身元特定を試みているとして、関連公文書の開示を求めて提訴した。\n・これらの召喚状はテック企業に対してユーザーの氏名・住所・IPアドレス等の基本情報提供を求めるもので、ユーザーが法廷で異議申し立てると政府側は判決を待たず取り下げており、違法性を自ら示唆している。\n・EFFはAmazon・Google・Metaなど主要テック企業に対し召喚状への対応前に司法介入を求めるよう要請し、またGoogleがユーザーへの事前通知の約束を破ったとして州司法長官への調査要請も行っている。",
+      "category": "tech-news",
+      "source": "EFF",
+      "source_type": "rss"
+    },
+    {
+      "title": "Wireless HDMI???",
+      "url": "https://www.youtube.com/watch?v=M67s2YlLsck",
+      "summary": "・2つのドングルと電源ケーブルのみでHDMIケーブルを無線化するデバイスで、MacOS・Android・Windows対応、4K 30Hz・遅延100msをサポートする。\n・95Wパススルー充電に対応しUSBポートを犠牲にしない設計で、1つの受信機に最大5台の送信機をペアリングできるため複数ユーザーでの切り替えも容易。\n・プレゼンや動画用途には十分だがゲーミングには不向きで、実使用テストでは発熱やラグも確認されており、圧縮信号で130ドルの価値があるかは用途次第。",
+      "category": "gadget",
+      "source": "ShortCircuit",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Stop New York's Attack on 3D Printing",
+      "url": "https://www.eff.org/deeplinks/2026/04/stop-new-yorks-attack-3d-printing",
+      "summary": "・ニューヨーク州の2026-2027年度予算案には、州内で販売されるすべての3Dプリンターに印刷ブロック用監視ソフトウェアの搭載を義務付ける条項が含まれており、来週にも採決が行われる可能性がある。\n・技術的な問題として、設計ファイルは分割や改変によって容易にパターン検出を回避できるため、このアルゴリズムによる規制は実効性がなく、合法的な利用者への監視・検閲リスクだけが高まる。\n・ニューヨーク州は米国最大級の消費者市場であるため、この規制が成立すればメーカーは事実上グローバルスタンダードとして同仕様の製品を展開し、3Dプリント技術の革新やオープンソース製造に世界的な悪影響を及ぼす恐れがある。",
+      "category": "tech-news",
+      "source": "EFF",
+      "source_type": "rss"
+    },
+    {
+      "title": "The Defense Tech Startup YC Kicked Out of a Meeting is Now Arming America | E2280",
+      "url": "https://www.youtube.com/watch?v=RT09WX9_hqY",
+      "summary": "・MetaやKPMGなどの大企業がAIインフラ投資の資金を捻出するために人員削減を行っており、「AIが仕事を奪う」というより「AIへの投資費用を賄うために人を削る」構造が明確になっている。\n・スタートアップの機会として、大企業の売上の1%未満の市場（大企業が注力できない小規模領域）を狙うことが最も有効な戦略として提唱されている。\n・今後の技術トレンドとして、オープンソースモデルを基盤に自社データでファインチューニングしたローカル動作のSLM（小規模言語モデル）がスタートアップの主要アーキテクチャになると予測されている。",
+      "category": "startup",
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    },
+    {
+      "title": "People on remote islands in Ireland can't get basic goods delivered.",
+      "url": "https://www.youtube.com/watch?v=5FGoIt-k6Xs",
+      "summary": "・アイルランドの離島・遠隔地への配送に対応するため、航続距離60〜120マイル、積載量最大44ポンド（約20kg）の長距離ドローンを運用している。\n・1機で最大20個の荷物を搭載し、途中で個別に荷物を投下しながら複数箇所へ配送後、基地に帰還する独立ドロップ機能を実装している。\n・現地では日用品へのアクセスが深刻に不足しており、食料品から生活必需品まで幅広い物資の輸送ニーズに対応できる設計となっている。",
+      "category": "startup",
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    },
+    {
+      "title": "EFF Calls on Kuwait to Release Journalist Ahmed Shihab-Eldin",
+      "url": "https://www.eff.org/deeplinks/2026/04/eff-calls-kuwait-release-journalist-ahmed-shihab-eldin",
+      "summary": "・米クウェート二重国籍のジャーナリスト、アフメド・シハブ＝エルディン氏が2025年3月3日にクウェートで逮捕され、虚偽情報の拡散や国家安全保障の侵害等の疑いで起訴されたとされる。\n・同氏は米空軍F-15E戦闘機の墜落映像を投稿したことが逮捕の契機とみられ、クウェートは同日「ミサイルや関連施設の撮影・投稿禁止」を警告するなど軍関連報道への締め付けを強化している。\n・クウェートは歴史的に報道の自由が比較的認められてきたが、2016年のサイバー犯罪法など表現を制限する法律が存在し、EFFは即時釈放を求めている。",
+      "category": "tech-news",
+      "source": "EFF",
+      "source_type": "rss"
+    },
+    {
+      "title": "I Don’t Agree With the Controversy - Apple AirPod Max 2",
+      "url": "https://www.youtube.com/watch?v=soPjk9AaW5A",
+      "summary": "・AirPods Max 2はH2チップ搭載により業界最高水準のノイズキャンセリングと自然な透過モードを実現しているが、重量・付属品の貧弱さ・高価格といった5年前からの課題は未解決のまま。\n・音響測定によると低音過多・ボーカル帯域のディップ・高域の過剰なピークというVシェイプ傾向が確認され、周波数特性は初代Max とほぼ同一で実質的な改善は見られない。\n・ライブ翻訳・会話認識・アダプティブオーディオなどH2チップ由来の新機能はiPhone専用で提供され、非Apple端末では多くの機能が利用できないエコシステム制限が継続している。",
+      "category": "gadget",
+      "source": "ShortCircuit",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Is Quantum Computing An Engineering Reality Or Just Physics Hype?",
+      "url": "https://www.youtube.com/watch?v=sHDWnW1fXJw",
+      "summary": "・量子コンピュータはスーパーポジション（重ね合わせ）とエンタングルメント（量子もつれ）を利用し、キュービットが同時に複数の状態を持つことで、古典的なコンピュータでは不可能な規模の計算を50〜250マイクロ秒で実行できる。\n・現在の最大の工学的課題はデコヒーレンス（外部振動・熱・粒子などによる量子状態の崩壊）とエラー訂正であり、AWS・Googleなどでクラウドアクセスは可能だが、通常のWebアプリ等の汎用計算には不向きな専用ツールである。\n・RSAなどの素因数分解ベースの暗号は量子コンピュータによる総当たり攻撃で理論上解読可能なため、量子耐性暗号アルゴリズムへの移行が現実的な開発課題として浮上しており、国家レベルの脅威も懸念されている。",
+      "category": "senior-engineer",
+      "source": "Modern Software Engineering",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Speaking Freely: Lizzie O'Shea",
+      "url": "https://www.eff.org/deeplinks/2026/04/speaking-freely-lizzie-oshea",
+      "summary": "・オーストラリアのデジタル権利活動家リジー・オシェアは、16歳未満のSNS利用禁止法について、LGBTIQ・地理的孤立・家庭内問題を抱える脆弱な若者が支援コミュニティへのアクセスを失うなど、人権上の深刻なリスクがあると指摘する。\n・年齢確認の実装はサイバーセキュリティリスクやプライバシー侵害を伴い、技術的な実効性も低い一方、禁止下でもSNSを利用し続ける若者（約7割）がヘルプシーキング行動を萎縮させられる懸念がある。\n・同法は提案から成立まで数日という極めて短い審議期間で可決され、子どもの権利団体・研究者・専門家からの膨大な反対意見が政策プロセスに十分反映されなかった点が民主的観点からも問題視されている。",
+      "category": "tech-news",
+      "source": "EFF",
+      "source_type": "rss"
+    },
+    {
+      "title": "\"Plain text has been around for decades and it's here to stay.\" – Unsung",
+      "url": "https://unsung.aresluna.org/plain-text-has-been-around-for-decades-and-its-here-to-stay/",
+      "summary": "・MockdownやWiretextなどの「プレーンテキスト/ASCII」ダイアグラム・UIデザインツールは、ソースコード埋め込みや生成AIへの入力として活用されている。\n・これらのツールは1970〜80年代のTUI文化の現代的再解釈であり、マウス対応・Web対応など現代的な使い勝手を備えている。\n・AIの高性能化が進む中、意図的な制約を設けるプラクティスが重要性を増しており、モノスペースのプレーンテキストはファイルの可搬性と編集インターフェースの普遍性から長期的な価値を持つ。",
+      "category": "tech-news",
+      "source": "Hacker News (Front Page)",
+      "source_type": "rss"
+    },
+    {
+      "title": "EFF Challenges Secrecy In Eastern District of Texas Patent Case",
+      "url": "https://www.eff.org/deeplinks/2026/04/eff-challenges-secrecy-eastern-district-texas-patent-case",
+      "summary": "・EFFはテキサス州東部地区の特許訴訟（Wilus v. HP）において、Wi-Fi 6標準必須特許のFRAND条件や特許譲渡に関する重要な裁判所文書が正当な理由なく全面封印されていることを発見し、公開を求めた。\n・テキサス州東部地区では、個別文書ごとの具体的な封印理由の説明を求める「compelling reasons」基準が事実上機能しておらず、包括的な保護命令による広範な封印が常態化している。\n・EFFの介入により一部の文書は部分開示されたが、裁判所記録の公開はデフォルトであるべきであり、北カリフォルニア地区のように裁判所が自ら封印要求を厳格に審査する運用が求められる。",
+      "category": "tech-news",
+      "source": "EFF",
+      "source_type": "rss"
+    },
+    {
+      "title": "How To Build A Company With AI From The Ground Up",
+      "url": "https://www.youtube.com/watch?v=EN7frwQIbKc",
+      "summary": "・AIをツールとして使うのではなく「OSとして組織全体を動かす」という発想のもと、あらゆる業務プロセスをクローズドループ化し、会議録・チケット・顧客フィードバック等を全てAIが参照できる状態（queryable organization）にすることが重要。\n・エンジニアリングでは「スペックとテストを人間が定義し、コード実装はAIエージェントが担うソフトウェアファクトリー」モデルが台頭しており、手書きコードを持たないリポジトリも実現されている。\n・組織構造は「IC（実際に作る人）・DRI（成果責任者）・AIファウンダー型リーダー」の3アーキタイプに整理され、人員ではなくトークン使用量を最大化する「token maxing」が競争優位の鍵となる。",
+      "category": "startup",
+      "source": "Y Combinator",
+      "source_type": "youtube"
+    },
+    {
+      "title": "The PM job market has split",
+      "url": "https://www.youtube.com/watch?v=pqPgEOYzp9w",
+      "summary": "・プロダクトマネージャーの求人市場は二極化しており、「情報を整理・伝達する役割（情報ムーバー）」は時代遅れになりつつある。\n・現在採用されているのは「ものを作ることが好きなビルダー型」のPMであり、創業者マインドを持つ人材が強く求められている。\n・「ビルダー志向」はPMに限らずエンジニア・デザイナー・マーケターにも共通する重要資質となり、今後数年の採用トレンドを牽引すると示唆されている。",
+      "category": "podcast",
+      "source": "Lenny's Podcast",
+      "source_type": "youtube"
+    }
+  ]
+}

--- a/web/src/content/editions/0008.json
+++ b/web/src/content/editions/0008.json
@@ -1,0 +1,49 @@
+{
+  "issue_no": 8,
+  "date": "2026-05-03",
+  "standfirst": null,
+  "daily_title": null,
+  "sources_scanned": null,
+  "articles": [
+    {
+      "title": "The Only Investing Video You’ll Ever Need (Start With $0)",
+      "url": "https://www.youtube.com/watch?v=bfENsVP77VQ",
+      "summary": "・インフレに対抗し資産を増やす手段として株式投資が推奨されており、特に初心者には個別銘柄のピッキングではなくS&P500などのインデックスファンドへの投資が最適とされている。\n・インデックスファンドは上位500社に自動分散投資される仕組みで、歴史的に年平均7〜9%のリターンをもたらし、少額から始められ専門知識も不要という実用的メリットがある。\n・個別銘柄選定はプロのファンドマネージャーでさえ長期的にS&P500を上回れないケースが多く、調査に膨大な時間コストがかかる点でも非効率であり、「セットして放置」戦略が合理的である。",
+      "category": "productivity",
+      "source": "Ali Abdaal",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Steam Controller Review - This Was a Triumph!",
+      "url": "https://www.youtube.com/watch?v=0idmNj1syPs",
+      "summary": "・新しいSteam ControllerはTMRスティック（Hall効果より低消費電力・高耐久）、高精度ジャイロ、触覚フィードバック付きタッチパッドを搭載し、従来のコントローラーの欠点であったレート入力問題をポジション入力で補完する設計となっている。\n・Steam Deckと同一のボタンレイアウトを採用したことで、既存の800万ユーザーが構築したコミュニティプロファイルをそのまま流用でき、開発者側のゲーム最適化も充実しているため、箱出し即時の高いゲーム互換性を実現している。\n・2.4GHz専用ドングルによる超低遅延接続（最大4台同時接続でも遅延増加なし）、約30〜35時間のバッテリー持続、容易なバッテリー交換設計など実用面も優れるが、旧モデルにあった2段階トリガーは廃止され価格は$99と高めの設定となっている。",
+      "category": "gadget",
+      "source": "Dave2D",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Nintendo is going to sue  - Anbernic RG DS",
+      "url": "https://www.youtube.com/watch?v=x5sbGCcQwQI",
+      "summary": "・Anbernic RG DSは95ドル以下で購入できるDS型Androidエミュレーター端末で、クアッドコアCortexプロセッサ・3GB RAM・デュアル480p IPSタッチスクリーンを搭載し、DS・GBA・PS1など複数ハードのエミュレーションに対応する。\n・RGランチャーとAndroid標準OSの二重構造により、ROMをデフォルトのエミュレーターに追加してもランチャー上に表示されないなど設定の落とし穴があり、デュアルスクリーンの正常動作には「下画面でアプリを開く」などの非直感的な手順が必要。\n・入力遅延はメニュー操作時に顕著で2Dアクションやリズムゲームには厳しいが、RPGやゼルダ系なら許容範囲内であり、UIの完成度や耐久性の低さを考慮すると「100ドル以下で手軽にDSゲームを遊びたいユーザー向け」の割り切った選択肢と評価できる。",
+      "category": "gadget",
+      "source": "ShortCircuit",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Don’t Use Boolean Flags in Python, Use Policies Instead",
+      "url": "https://www.youtube.com/watch?v=wYeDGkdMi3g",
+      "summary": "・Pythonでのブール型フラグや条件分岐の肥大化を防ぐため、各ルールを単一責任の「ポリシー」関数として分離し、`functools.reduce`を使ったパイプラインで合成する設計パターンを紹介している。\n・ポリシー関数をレジストリ（辞書）に登録し、Pydantic Settingsと`.env`ファイルで有効なポリシーを外部から制御することで、コードを変更せずに機能のオン/オフが可能なデータ駆動型の実装が実現できる。\n・コード量は増えるトレードオフがあるものの、各ポリシーが独立してテスト・再利用可能になり、条件分岐の爆発を防ぎながら本番システムに必要な柔軟性と保守性を両立できる。",
+      "category": "senior-engineer",
+      "source": "ArjanCodes",
+      "source_type": "youtube"
+    },
+    {
+      "title": "It's finally time for Wi-Fi 7 - TP Link Deco 7 Pro",
+      "url": "https://www.youtube.com/watch?v=I5jGzFP0g8Y",
+      "summary": "・TP-Link Deco BE673はWi-Fi 7対応メッシュルーターで、最大14Gbpsの速度よりも6GHz帯（最大320MHz幅）のサポートが実用面での最大の利点であり、混雑した環境での速度・レイテンシ改善に効果的。\n・ハードウェア面では10Gbps/2.5Gbps/1GbpsのEthernetポートを搭載し、バックホール接続やハイスピードスイッチとの組み合わせなど柔軟なネットワーク構成が可能。\n・MLO（マルチリンクオペレーション）や seamlessなAP間ローミング、ホーム全体へのVPN適用、世代間互換性など開発・運用面で有用な機能を備えており、アプリのセットアップも改善されている。",
+      "category": "gadget",
+      "source": "ShortCircuit",
+      "source_type": "youtube"
+    }
+  ]
+}

--- a/web/src/content/editions/0009.json
+++ b/web/src/content/editions/0009.json
@@ -1,0 +1,49 @@
+{
+  "issue_no": 9,
+  "date": "2026-05-04",
+  "standfirst": null,
+  "daily_title": null,
+  "sources_scanned": null,
+  "articles": [
+    {
+      "title": "The Open Social Web Needs Section 230 to Survive",
+      "url": "https://www.eff.org/deeplinks/2026/04/open-social-web-needs-section-230-survive",
+      "summary": "・セクション230は「コンテンツの発信者はホスト側ではなくユーザー自身」という原則を定めた法律で、小規模なサーバー運営者を法的リスクから守る重要な盾となっている。\n・MastodonやBlueskyなどの分散型オープンソーシャルウェブは多数の小規模ホストが協調して成立するアーキテクチャであり、セクション230が弱体化すれば訴訟リスクに耐えられる大企業だけが生き残る構造になる。\n・投稿のブースト・共有といったユーザー行為もセクション230の保護対象であるため、開発者・運営者だけでなくユーザーレベルでもこの法的保護の維持が分散型SNS存続の前提条件となる。",
+      "category": "tech-news",
+      "source": "EFF",
+      "source_type": "rss"
+    },
+    {
+      "title": "Talking to 35 Strangers at the Gym",
+      "url": "https://thienantran.com/talking-to-35-strangers-at-the-gym/",
+      "summary": "・著者は大学卒業後の孤独を解消するため、1ヶ月間ジムで35人の見知らぬ人に話しかけるという実験を行い、最初の数日は逃げ出しそうになったが「素早くアプローチする」ことで恐怖を克服した。\n・会話の開始フレーズは最初「よく見かけますね、すごく強いですね、どんなトレーニングをしていますか？」と統一していたが、後に相手の特徴（帽子・外見など）に合わせてカスタマイズする方が効果的だった。\n・Week4以降は新規開拓より既存の5〜6人との関係を深める戦略に切り替え、結果として一緒に食事や映画鑑賞をする友人を複数獲得し、「大学後の友達作り」という問題を実験的アプローチで解決した。",
+      "category": "tech-news",
+      "source": "Hacker News (Front Page)",
+      "source_type": "rss"
+    },
+    {
+      "title": "Partial Page Caching Using React Server Components",
+      "url": "https://www.youtube.com/watch?v=t9xB8xvySyo",
+      "summary": "・TanStack StartのRSCサポートを活用し、CDNキャッシュをページ単位ではなくコンポーネント単位（トレンド欄など更新頻度の異なる部分）で制御する「部分的ページキャッシュ」を実装できる。\n・`renderServerComponent`というLow Level APIを使ってRSCのflightデータをGETリクエストのサーバー関数として返すことで、CDNがそのRSCペイロードをキャッシュ・キャッシュバストできる仕組みを構築している。\n・JSONをクライアントでレンダリングする従来手法と比べ、RSCはVDOMが事前構築済みで高速なうえ、`use client`指定のインタラクティブコンポーネントのJSコードも必要時のみ動的ロードされるため、バンドルサイズの肥大化を防げる。",
+      "category": "dev-for-startup",
+      "source": "Jack Herrington",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Google Doesn't Care About Quality Content",
+      "url": "https://www.youtube.com/watch?v=fKd1zHxZryI",
+      "summary": "・Googleが評価するのは「コンテンツの質」そのものではなく、検索ユーザーが求める体験（UX）を満たしているかどうかである。\n・「ベストジムシューズ」のような検索では、1〜2択しか示さないレビューより、複数の選択肢を提示するページの方がユーザーニーズに合致していると評価される。\n・価格・カラー・サイズ・在庫情報をAPIで一元表示するアフィリエイトサイトのようなエンドツーエンドのショッピング体験が、SEO上も技術実装の観点からも有効な戦略となる。",
+      "category": "marketing",
+      "source": "Ahrefs",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Affiliate Programs for SaaS: Build a Referral Engine That Grows With Your Product",
+      "url": "https://www.youtube.com/watch?v=4Qb9bElIymo",
+      "summary": "・アフィリエイトプログラムは「販売チャネル」ではなく、ブランド認知・見込み客獲得・紹介売上の3つの価値を生む「借りたオーディエンス活用戦略」として捉えるべきである。\n・効果的なパートナーには大手補完的プレイヤー（Keystoneパートナー）と既存顧客群（Pollinatorパートナー）の2種類があり、特にKeystoneパートナーとは無料ウェビナー＋デモ形式のコンテンツ提供が高いROIをもたらす（ConvertKitが$1M→$10M ARRに活用した実績あり）。\n・実装の鍵は「パートナーが簡単に動けるようにすること」で、ランディングページや招待メール3〜5本を事前に用意し、リスト共有・フォローアップ・コミッション支払い・次回予約までを一連のフライホイールとして仕組み化することが重要である。",
+      "category": "indie-hacker",
+      "source": "MicroConf",
+      "source_type": "youtube"
+    }
+  ]
+}

--- a/web/src/content/editions/0010.json
+++ b/web/src/content/editions/0010.json
@@ -1,0 +1,49 @@
+{
+  "issue_no": 10,
+  "date": "2026-05-05",
+  "standfirst": null,
+  "daily_title": null,
+  "sources_scanned": null,
+  "articles": [
+    {
+      "title": "Highlight Reel Camera!",
+      "url": "https://www.youtube.com/watch?v=6l7jf0ZrcAI",
+      "summary": "・このカメラは一日中自動で断続的に録画し、AIを使ってハイライトリールを生成するほか、「鍵をどこに置いたか」など過去の行動を検索・確認できる機能を持つ。\n・バッテリーは最大13時間持続し軽量だが、カメラ画質は低光量環境で著しく低下するという技術的な制約がある。\n・録画データはデバイス上にローカル保存され、AWSへのアップロードは任意かつ暗号化されるが、価格は200ドルと高く、常時装着型である点でプライバシーや社会的受容性の課題が残る。",
+      "category": "gadget",
+      "source": "ShortCircuit",
+      "source_type": "youtube"
+    },
+    {
+      "title": "The $10M+ Bet on a Beanie That Reads Your Brain | Sabi & the Future of BCI | E2282",
+      "url": "https://www.youtube.com/watch?v=_tIHicFHtXE",
+      "summary": "・Sabi社はfMRI研究（2023年の論文）をベースに、頭蓋骨への手術不要な非侵襲型BCI（脳コンピュータインターフェース）をビーニー型ウェアラブルデバイスとして実装し、脳の電気的活動をバイオポテンシャルセンサーで外部計測することで思考をテキストに変換する。\n・深層学習ベースの「ブレインファンデーションモデル」と多数のセンサーを組み合わせることで、大型病院機器（fMRI）から小型ウェアラブルへの技術移行を実現しており、エンジニアリング上の最大の課題はセンサーとモデルの小型化・精度両立だった。\n・現時点では単語単位で意図的に思考する必要があるなど制約があるが、侵襲手術不要なBCIの実用化に向けた$10M超の投資を受けたスタートアップとして、開発者にとってはエッジAIモデルと生体信号処理の組み合わせが次世代UIの有力な実装アプローチとして注目される。",
+      "category": "startup",
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    },
+    {
+      "title": "ChatGPT thinks palm reading is real. And it's your fault.",
+      "url": "https://www.youtube.com/watch?v=jZwQfLVyUMo",
+      "summary": "・大規模言語モデルは手相占いや占星術などの疑似科学コンテンツをWebクロールで大量に学習しており、それらを「知識」として習得してしまっている。\n・学習データにはそれらを信じるコミュニティ（Redditスレッド等）の投稿が含まれており、トレーニング時に「これは疑似科学である」という明示的な否定ラベルが付与されていないことが問題の核心。\n・ChatGPTに指紋などの生体情報を提供することはプライバシーリスクの観点から強く推奨されないと出演者全員が警告している。",
+      "category": "startup",
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    },
+    {
+      "title": "My simple path to getting rich",
+      "url": "https://www.youtube.com/watch?v=jCyhEO3h-Ik",
+      "summary": "・ケニアなど低所得国でネットを使って収入を得るには、YouTubeチャンネルよりも米国企業向けのサービスビジネス（Web制作・SNS広告・AIオートメーションなど）を始める方が効果的である。\n・必要なスキルはYouTubeの無料動画で習得でき、有料コースは不要であり、まずはスマホではなくPCやネットカフェを活用して本格的な作業環境を確保することが優先される。\n・「富裕層にサービスを提供し、彼らがさらに稼げるよう助ける」ことが最短で収入を得る本質的な戦略であり、米国企業を顧客にすることで通貨差益も活かせる。",
+      "category": "productivity",
+      "source": "Ali Abdaal",
+      "source_type": "youtube"
+    },
+    {
+      "title": "The \"Perfect Code\" Myth",
+      "url": "https://www.youtube.com/watch?v=XLIr1f2-wFE",
+      "summary": "・プログラミングの習熟には「唯一の正解を見つけなければ」というプレッシャーから解放され、複数のアプローチが同じ結果に至り得ると認識するステージがある。\n・ゴールが不明確でも、フィットネス関数（目的地への近さの指標）を定めながら反復・実験することで前進できるという考え方が重要な実装指針となる。\n・小さな単位での進捗（イテレーション）を積み重ねる姿勢こそが、不確実な開発環境においてエンジニアが自信を持って着手するための実践的な手法である。",
+      "category": "senior-engineer",
+      "source": "Modern Software Engineering",
+      "source_type": "youtube"
+    }
+  ]
+}

--- a/web/src/content/editions/0011.json
+++ b/web/src/content/editions/0011.json
@@ -1,0 +1,49 @@
+{
+  "issue_no": 11,
+  "date": "2026-05-06",
+  "standfirst": null,
+  "daily_title": null,
+  "sources_scanned": null,
+  "articles": [
+    {
+      "title": "Shut Down Turnkey Totalitarianism",
+      "url": "https://www.eff.org/deeplinks/2026/04/claw-back",
+      "summary": "・EFF（電子フロンティア財団）は、NSA内部告発者が警告した「ターンキー全体主義国家」に対抗するため、無令状のナンバープレート追跡訴訟やオープンソースの監視機器検出ツール「Rayhunter」のリリースなど具体的な技術的施策を展開している。\n・現在、米国議会で大規模国際監視プログラム「Section 702」の更新が審議されており、EFFは一般市民がこの監視体制を阻止できるよう政治的働きかけを強化している。\n・開発者向けには、ウェブ上の追跡スクリプトやCookieをブロックするフリーツール「Privacy Badger」が提供されており、オープンソースの監視対策ツール開発への参加・支援が呼びかけられている。",
+      "category": "tech-news",
+      "source": "EFF",
+      "source_type": "rss"
+    },
+    {
+      "title": "Open Records Laws Reveal ALPRs’ Sprawling Surveillance. Now States Want to Block What the Public Sees.",
+      "url": "https://www.eff.org/deeplinks/2026/04/open-records-laws-reveal-alprs-sprawling-surveillance-now-states-want-block-what",
+      "summary": "・米国の複数州（コネチカット、アリゾナ、ワシントン、イリノイ、ジョージアなど）でALPR（自動ナンバープレート読み取り装置）データを公開記録法の対象外とする立法が相次いでおり、EFFはこの傾向を「監視技術への市民監視を阻害する」として強く反対している。\n・EFFは完全な情報公開も完全な非公開も支持せず、個人を特定できる生データは保護しつつ、集計・匿名化されたデータ（スキャン件数、エラー率、データ共有状況など）は公開すべきという「プライバシーと透明性のバランス型アプローチ」を提唱している。\n・開発者・政策立案者向けの示唆として、公開記録法にはケースバイケースのプライバシー衡量規定を設け、個人識別情報はリダクション（墨消し）で保護しながら非個人情報は開示可能にする設計が技術的・法的に最善とされている。",
+      "category": "tech-news",
+      "source": "EFF",
+      "source_type": "rss"
+    },
+    {
+      "title": "Google's Algorithm Crushed This Business",
+      "url": "https://www.youtube.com/watch?v=BRN-LnrSdG0",
+      "summary": "・GoogleにクリエイターSuccess Storyとして紹介された翌日、2023年9月の「Helpful Content Update」によりサイトトラフィックが75〜80%激減し、収益も同率で消失した。\n・トラフィック喪失はデジタル製品販売・ブランドスポンサー契約など収益源全体に連鎖的ダメージを与え、「分散化されたビジネス」という認識が実態と乖離していたことが露呈した。\n・AI Overviewsや検索結果の多様化により青リンクへの到達が困難になった現状は、Google検索への依存度が高いサイト運営者にとってトラフィック回復が構造的に困難であることを示唆している。",
+      "category": "marketing",
+      "source": "Ahrefs",
+      "source_type": "youtube"
+    },
+    {
+      "title": "3 Paths to a Rich Retirement",
+      "url": "https://www.youtube.com/watch?v=Or6yvefovGU",
+      "summary": "・50代以降の充実した退職後の生活には「心の成長」「身体の健康」「社会への貢献」の3つの柱が重要とされている。\n・身体面ではハイキングやピックルボール・セーリングなど、頭脳面では新しいスキル習得など、具体的な活動への参加が推奨されている。\n・貢献欲求を満たす手段として、ビジネス起業・ワークショップ開催・SNS発信・書籍執筆など多様な選択肢が示されており、金銭的必要がなくても取り組む価値がある。",
+      "category": "productivity",
+      "source": "Ali Abdaal",
+      "source_type": "youtube"
+    },
+    {
+      "title": "SaaS Challengers",
+      "url": "https://www.youtube.com/watch?v=DhYJ1GENLoQ",
+      "summary": "・AIによるソフトウェア開発コストの100倍以上の削減により、数十年かけて構築された大規模コードベースという既存SaaSの護城河（モート）が消滅しつつある。\n・既存製品の低価格クローン、AIネイティブ製品、複数SaaSの統合スイート、OSSへの置き換えとサービス収益化など、複数の攻略アプローチが有効とされている。\n・ERPやチップ設計ソフト、産業制御システムなど従来「難攻不落」とされてきた巨大レガシーSaaSこそを狙うべきであり、クラウドがオンプレを置き換えたように次世代はAIネイティブがレガシーSaaSを置き換える。",
+      "category": "startup",
+      "source": "Y Combinator",
+      "source_type": "youtube"
+    }
+  ]
+}

--- a/web/src/content/editions/0012.json
+++ b/web/src/content/editions/0012.json
@@ -1,0 +1,49 @@
+{
+  "issue_no": 12,
+  "date": "2026-05-07",
+  "standfirst": null,
+  "daily_title": null,
+  "sources_scanned": null,
+  "articles": [
+    {
+      "title": "Your AI shouldn't have to Google your own company's history",
+      "url": "https://www.youtube.com/watch?v=OQbQa-XEpho",
+      "summary": "・自社の過去データ（業績推移など）をRAGやWeb検索で毎回取得すると処理時間・コストが大きくなるため、静的な社内情報はモデルの重みに学習させておくべきである。\n・Web検索などのツールコールは重みに存在しない最新情報の取得に限定することで、トークン消費を抑えつつ効率的なハイブリッド構成が実現できる。\n・企業が自社インテリジェンスを真に「資産」として所有するには、独自データでファインチューニングしたモデルの重みを自社で保持することが唯一の方法である。",
+      "category": "startup",
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    },
+    {
+      "title": "👎 California's Terrible, No Good, Very Bad Social Media Ban | EFFector 38.9",
+      "url": "https://www.eff.org/deeplinks/2026/05/californias-terrible-no-good-very-bad-social-media-ban-effector-389",
+      "summary": "・カリフォルニア州のソーシャルメディア禁止法案はオンライン検閲の危険な前例となりうるとEFFは警告しており、年齢確認ゲートは「銀の弾丸」ではないと主張している。\n・ユタ州でのVPN規制への攻撃など、世界各地でオンライン安全の名目で導入される規制がVPNや言論の自由に対する統制強化につながっている。\n・EFFの立法アナリストMolly Buckleyは、ソーシャルメディア禁止は米国憲法を迂回できないと指摘しており、開発者・市民はEFFのニュースレターを通じて対抗手段を取れる。",
+      "category": "tech-news",
+      "source": "EFF",
+      "source_type": "rss"
+    },
+    {
+      "title": "I got cancelled for my 2x speed",
+      "url": "https://www.youtube.com/watch?v=B2ag364pRgQ",
+      "summary": "・著者は数年前にアニメやTVを2〜3倍速で視聴するという動画を公開し、「有害な生産性主義」としてネット上で炎上・低評価50%超を受けた。\n・批判を受けて動画を非公開にしたが、現在は2.5倍速でオーディオブックを聴きながら「自分がより多くの価値を得られるなら速聴きは全く問題ない」という考えに至っている。\n・一方で、没入したい良質な作品は等倍速で視聴するなど、コンテンツの質や目的に応じて再生速度を使い分けることを実践している。",
+      "category": "productivity",
+      "source": "Ali Abdaal",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Day 512 growing my SaaS startup to $1M 🎉",
+      "url": "https://www.youtube.com/watch?v=98Mh_6cKedc",
+      "summary": "・WebアナリティクスSaaS「DataFast」が20K MRR（約$1M評価額）を達成するまでに512日かかり、9ヶ月間ほぼ成長がなかった後に急加速するという典型的なホッケースティック成長を経験した。\n・新サイドプロジェクト「Super Shrimp」（姿勢分析アプリ）はローンチから4時間で$1,000の収益を達成し、短期デッドラインを設けて即リリースする戦略の有効性を実証した。\n・開発者へのキーメッセージとして「完璧を求めず厳格な締め切りを設けてシップする」「モチベーション喪失時は休暇や新チャレンジで仕事をゲーム化する」「多数のプロジェクトを試す分散戦略が機能するケースもある」点が強調されている。",
+      "category": "indie-hacker",
+      "source": "Marc Lou",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Would you pay $50 for a protein bar? 2 people did.",
+      "url": "https://www.youtube.com/watch?v=lADu2hN0RWs",
+      "summary": "・AIエージェントを活用して自販機ビジネスのリサーチから商品調達（CostcoやAmazon経由）まで自動化し、クラウドコードと「Open Claw」で在庫管理や価格設定を実装した。\n・AIが自律的にプロテインバーの価格を$15に設定するハルシネーションが発生し、その結果として利益率が約500%になるケースが生じた。\n・この価格設定バグがRobert Scovilleの動画投稿によってバイラル化し、実際に$50のプロテインバーを購入した人が2人いたことが話題となった。",
+      "category": "startup",
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    }
+  ]
+}

--- a/web/src/content/editions/0013.json
+++ b/web/src/content/editions/0013.json
@@ -1,0 +1,49 @@
+{
+  "issue_no": 13,
+  "date": "2026-05-08",
+  "standfirst": null,
+  "daily_title": null,
+  "sources_scanned": null,
+  "articles": [
+    {
+      "title": "An everyday mechanical keyboard - Keychron K3 Ultra",
+      "url": "https://www.youtube.com/watch?v=d8ocjQydLDs",
+      "summary": "・Keychron K3シリーズには8kHzポーリングレート対応の「Ultra 8K」（$110）とホール効果（磁気）スイッチ搭載の「K3H」（$120）の2モデルがあり、どちらも75%レイアウト・ロープロファイル・ホットスワップ対応のワイヤレスメカニカルキーボードである。\n・K3Hの磁気スイッチはアナログ入力（キーの押し込み量で歩き/走りを制御）が可能だが、バッテリー持続時間が約55時間と短く、8K版の500時間超と比べて大幅に劣るため、トラベル用途では8K版を1,000Hzで運用する方が実用的と評価されている。\n・RGBはスイッチ内部の拡散が美しいものの付属キーキャップがシャインスルー非対応なため恩恵を受けにくく、カスタマイズ派はキーキャップ交換を検討すべきである。",
+      "category": "gadget",
+      "source": "ShortCircuit",
+      "source_type": "youtube"
+    },
+    {
+      "title": "The GUARD Act Isn’t Targeting Dangerous AI—It’s Blocking Everyday Internet Use",
+      "url": "https://www.eff.org/deeplinks/2026/04/guard-act-isnt-targeting-dangerous-ai-its-blocking-everyday-internet-use",
+      "summary": "・GUARD法案は「AIコンパニオン」を広く定義しており、宿題支援ツールやカスタマーサービスチャットボットなど日常的なAIツールも規制対象に含まれる可能性がある。\n・18歳未満のユーザーへのサービス提供には政府発行IDや生体認証などによる「合理的な年齢確認」が全ユーザーに義務付けられ、プライバシーリスクと個人情報漏洩の危険を生む。\n・違反1件あたり最大10万ドルの罰則と曖昧な定義の組み合わせにより、企業は未成年者を全面ブロックする方向に動き、中小開発者は参入困難となって大手企業の寡占がさらに進む懸念がある。",
+      "category": "tech-news",
+      "source": "EFF",
+      "source_type": "rss"
+    },
+    {
+      "title": "What Is AI Visibility? The 3 Types Every Marketer Needs to Know  | 1.3. AEO Course by Ahrefs",
+      "url": "https://www.youtube.com/watch?v=SIXVq28jTc4",
+      "summary": "・AIの可視性には「リンク付き引用」「リンクなし言及」「未掲載」の3種類があり、平均でAIの言及のうちリンクが付くのは約28%に過ぎず、プラットフォームによって大きく異なる（Perplexity約52%〜AI Overviews約11%）。\n・リンクなしの言及も無価値ではなく、ブランドのウェブ上での言及数はAI可視性との相関係数0.664と、バックリンクやドメイン評価など従来のSEO指標より強い相関を示すというデータがある。\n・Ahrefsの「Brand Radar」を活用して自社のAI上での言及・引用・インプレッションを競合と比較し、自社が言及されていないトピックのギャップを特定することがAEO戦略の起点となる。",
+      "category": "marketing",
+      "source": "Ahrefs",
+      "source_type": "youtube"
+    },
+    {
+      "title": "An Introduction to Meshtastic",
+      "url": "https://meshtastic.org/docs/introduction/",
+      "summary": "・MeshtasticはLoRa無線を使用した長距離オフグリッド通信プラットフォームで、331kmの通信記録を持ち、追加ライセンス不要で利用できるオープンソースプロジェクトである。\n・各デバイスはメッセージを再ブロードキャストしてメッシュネットワークを形成し、専用ルーター不要の分散型暗号化通信を実現、スマートフォンとのペアリングも可能だが1デバイスにつき同時接続は1ユーザーのみ対応している。\n・`meshtastic --listen`コマンドでメッセージ受信が可能なCLIツールが提供されており、GitHubやDiscordを通じたコミュニティ主導で開発・サポートが行われている。",
+      "category": "tech-news",
+      "source": "Hacker News (Front Page)",
+      "source_type": "rss"
+    },
+    {
+      "title": "YC Paper Club",
+      "url": "https://www.youtube.com/watch?v=ClxjYoiEirw",
+      "summary": "・YCがAI研究者・エンジニア・創業者向けのコミュニティ「YC Paper Club」を立ち上げ、数週間ごとにMountain Viewオフィスで最新AI論文の発表・議論を行う。\n・各回は参加者が論文を発表してディスカッションを行い、その後ディナーで議論を継続する形式で、発表はオンライン公開されるがディナーはオフレコとなる。\n・対象は論文を読むビルダーや本番環境での問題に関心を持つ研究者で、初回は100人未満の規模で5月20日に開催予定、リンクから申し込み可能。",
+      "category": "startup",
+      "source": "Y Combinator",
+      "source_type": "youtube"
+    }
+  ]
+}

--- a/web/src/content/editions/0014.json
+++ b/web/src/content/editions/0014.json
@@ -1,0 +1,49 @@
+{
+  "issue_no": 14,
+  "date": "2026-05-09",
+  "standfirst": null,
+  "daily_title": null,
+  "sources_scanned": null,
+  "articles": [
+    {
+      "title": "EFF Submission to UN Report on the Role of Media in the Context of Israel’s Policies Toward Palestinians",
+      "url": "https://www.eff.org/deeplinks/2026/04/eff-submission-un-report-role-media-context-israels-policies-toward-palestinians",
+      "summary": "・EFFは国連特別報告者への提出書で、2023年10月以降のパレスチナにおける報道の自由と表現の自由の著しい悪化（検閲強化・ジャーナリスト殺害増加）を指摘した。\n・具体的な懸念事項として、政府によるコンテンツ削除要請、偽情報とコンテンツモデレーション、インターネットインフラへの攻撃の3点が挙げられている。\n・パレスチナ人への意図的なデジタル孤立化を終わらせることが基本的人権保護に不可欠であると結論づけており、デジタルアクセスと情報インフラの保護が国際的課題として位置づけられている。",
+      "category": "tech-news",
+      "source": "EFF",
+      "source_type": "rss"
+    },
+    {
+      "title": "Designers don't need to ship code",
+      "url": "https://www.youtube.com/watch?v=5GkWPkdDEvM",
+      "summary": "・デザイナーがコードを本番環境にシップするかどうかは重要ではなく、コードを書くことで「設計対象の素材」を深く理解できることに価値がある。\n・エージェントループのような複雑な仕組みを理解してデザインできる人材の方が、UIの細部を調整できるだけの人材より重要とされている。\n・エージェントループはコードという素材で作られているため、それを真に理解するにはコードで実際に構築する経験が不可欠だという示唆がある。",
+      "category": "podcast",
+      "source": "Lenny's Podcast",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Read Programming as Theory Building",
+      "url": "https://codeutopia.net/blog/2026/05/09/you-should-read-programming-as-theory-building/",
+      "summary": "・Peter Naurの「プログラミングとは理論構築である」は、コードや文書は副次的なものであり、プログラムの「理論（メンタルモデル）」を構築・共有することがプログラミングの本質だと主張する。\n・クリーンコード・アーキテクチャ・ドキュメント・テストなどは個別の活動と捉えられがちだが、「プログラムの理論を伝える」という共通目標のもとで統合して考えることで、保守性向上に向けてより効果的に活用できる。\n・デザインパターンやDDDも「プログラムの理論を伝えるための手段」として位置づけられ、この視点を持つことで「なぜ良いソフトウェアを書くことが難しいのか」という問いへの根本的な答えが得られる。",
+      "category": "tech-news",
+      "source": "Hacker News (Front Page)",
+      "source_type": "rss"
+    },
+    {
+      "title": "Can an AI Agent Legally Own a Company? Christian van der Henst's Wild Experiment| E2283",
+      "url": "https://www.youtube.com/watch?v=4elRU7BlbDQ",
+      "summary": "・GitLab創業者Sid Sijbrandijの発案で、AIエージェント「Valerie」を法人の受益者として信託構造を通じて登録し、OpenClawを活用してAmazon/Costcoでの仕入れ・在庫管理・動的価格設定を自律的に運営するベンディングマシンを実装した。\n・現状の技術的制約として、エージェントは商品カートへの追加まで可能だがStripeなど決済時にbotと検出されること、KYC要件によりエージェント名義の銀行口座開設が不可能なことが主なボトルネックとなっている。\n・今後の発展として、許認可申請などの官僚的手続きをエージェントに代行させるユースケースや、1人企業・最終的には1エージェント企業という組織構造の進化が示唆されている。",
+      "category": "startup",
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    },
+    {
+      "title": "3 Surprising Things I Learned As a New Dad",
+      "url": "https://www.youtube.com/watch?v=OgbLx7K5jKI",
+      "summary": "(この記事は音楽・技術・実装・開発に関する内容を含まず、要約対象として適切な情報が存在しないため、出力なし)",
+      "category": "productivity",
+      "source": "Ali Abdaal",
+      "source_type": "youtube"
+    }
+  ]
+}

--- a/web/src/content/editions/0015.json
+++ b/web/src/content/editions/0015.json
@@ -1,0 +1,33 @@
+{
+  "issue_no": 15,
+  "date": "2026-05-10",
+  "standfirst": null,
+  "daily_title": null,
+  "sources_scanned": null,
+  "articles": [
+    {
+      "title": "Utah’s New Law Targeting VPNs Goes Into Effect May 6th",
+      "url": "https://www.eff.org/deeplinks/2026/04/utahs-new-law-regulating-vpns-goes-effect-next-week",
+      "summary": "・ユタ州は2026年5月6日より施行のSB 73により、年齢確認を回避するためのVPN使用を規制する米国初の州となり、VPN経由でもユタ州に物理的にいるユーザーの年齢確認義務をサイト運営者に課す。\n・法律はVPNの完全禁止ではなく「ドント・アスク・ドント・テル」方式を採用するが、企業がVPN使用方法をユーザーに提供することを禁止するため、合法的なプライバシーツールに関する情報発信を制限し第一修正条項上の問題を生じさせる。\n・技術的には既知のVPN/プロキシIPをすべてブロックすることは不可能であり、規制を受けた商用VPNの代替としてAWSなどクラウド経由のプライベートトンネルや住宅用プロキシへの移行が数時間以内に起きると予測され、実害はプライバシーを必要とする一般ユーザーや企業・ジャーナリストに集中する。",
+      "category": "tech-news",
+      "source": "EFF",
+      "source_type": "rss"
+    },
+    {
+      "title": "EFF Submission to UK Consultation on Digital ID",
+      "url": "https://www.eff.org/deeplinks/2026/05/eff-submission-uk-consultation-digital-id",
+      "summary": "・EFFは英国政府の国家デジタルIDスキーム導入に対するパブリックコンサルテーションに意見書を提出し、ミッションクリープ・プライバシー侵害・セキュリティリスク・不正確な技術への依存・差別と排除・権力不均衡の深化という6つの相互に関連する問題点を指摘した。\n・デジタルIDは「誰であるかを確認する」だけでなく「何にアクセスできるかを国家が決定する」鍵として機能し、強力な保護措置を設けても根本的な問題は解決できないと主張している。\n・EFFは、公共生活への完全な参加のために技術的・社会的にデジタルシステムへの参加を強制されるべき人は誰もいないとして、英国政府にデジタルID計画の撤回を求めている。",
+      "category": "tech-news",
+      "source": "EFF",
+      "source_type": "rss"
+    },
+    {
+      "title": "Naval's GP, Ankur Nagpal, Breaks Down The Viral “USVC” Fund | E2284",
+      "url": "https://www.youtube.com/watch?v=DTLfMgAhF98",
+      "summary": "・AngelListが運営するUSVC.comは、最低500ドルから非認定投資家でも誰でも参加できるクローズドエンドファンドで、スタートアップへの投資の民主化を目指している。\n・クローズドエンドファンドの仕組みとして、NAV（純資産価値）に基づくシェアを購入し、四半期ごとに最大5%までの償還機会を提供することで、従来の10年ロックアップより高い流動性を実現している。\n・費用構造はキャリーなし・管理報酬1%を含む実質2.5%の純費用比率（ネットエクスペンスレシオ）で、規制対応の公開商品として従来VCファンドと比較して競争力のある設計となっている。",
+      "category": "startup",
+      "source": "This Week in Startups",
+      "source_type": "youtube"
+    }
+  ]
+}

--- a/web/src/content/editions/0016.json
+++ b/web/src/content/editions/0016.json
@@ -1,0 +1,49 @@
+{
+  "issue_no": 16,
+  "date": "2026-05-11",
+  "standfirst": null,
+  "daily_title": null,
+  "sources_scanned": null,
+  "articles": [
+    {
+      "title": "Milestone 1.0.0 Release of APK Downloader `apkeep` Powers Research on Android Apps",
+      "url": "https://www.eff.org/deeplinks/2026/05/milestone-100-release-apk-downloader-apkeep-powers-research-android-apps",
+      "summary": "・`apkeep` v1.0.0では、Google Play StoreのCloud Profile付きdexメタデータのダウンロード、Aurora Storeトークンによる匿名ログイン、カスタムデバイスプロファイルの指定など、研究・解析用途に有用な機能が追加された。\n・macOS向けHomebrewへの収録も実現し、Linux・Windows・Androidに加えてクロスプラットフォーム対応がさらに強化されている。\n・Exodus PrivacyやAndroidマルウェア研究（2万1千件超のAPP解析）など実際の研究ワークフローで活用されており、今後はF-Droid以外のストアへの対応拡充とコントリビューター募集が予定されている。",
+      "category": "tech-news",
+      "source": "EFF",
+      "source_type": "rss"
+    },
+    {
+      "title": "How to Run a Brand Gap Analysis | 2.1. AEO Course by Ahrefs",
+      "url": "https://www.youtube.com/watch?v=E0VFNbZtZKM",
+      "summary": "・ブランドギャップ分析では「可視性・ナラティブ・トピック・フォーマット・Webメンション・需要」の6次元でブランドの露出状況を評価する。\n・AhrefsのBrand Radarを使い、AIプラットフォームでのメンション数・引用数・インプレッション・AIシェアオブボイスを計測し、競合と自社の差分を洗い出す。\n・特定したギャップは「Fix（既存コンテンツ改善）・Build（新規コンテンツ作成）・Influence（外部サイトへのアウトリーチ）」の3アクションに分類して優先順位付けし、AIへの引用獲得戦略へ繋げる。",
+      "category": "marketing",
+      "source": "Ahrefs",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Congress Narrowed the GUARD Act, But Serious Problems Remain",
+      "url": "https://www.eff.org/deeplinks/2026/05/congress-narrowed-guard-act-serious-problems-remain",
+      "summary": "・修正版GUARD法はAIコンパニオン（感情的・対人的なやり取りを模擬する会話システム）に対象を絞ったが、金融記録やアプリストアのアカウントなど実世界の本人確認と紐づいた年齢認証の義務は依然として残っている。\n・「AIコンパニオン」の定義が曖昧なまま罰則が1件あたり最大25万ドルに引き上げられたため、小規模開発者は未成年ユーザーの全ブロックや会話機能の無効化など過剰な制限に走るインセンティブが生まれる。\n・EFFは、プライバシーを侵害する年齢認証よりも悪質なアクターへの標的型執行と包括的なプライバシー法で対処すべきと主張しており、スピーチ・プライバシー・セキュリティ上の根本的問題は解決されていないと指摘している。",
+      "category": "tech-news",
+      "source": "EFF",
+      "source_type": "rss"
+    },
+    {
+      "title": "How Ranking in Google AI Overviews, ChatGPT, and Perplexity are Different | 1.2 AEO Course by Ahrefs",
+      "url": "https://www.youtube.com/watch?v=LXdtraYM1dg",
+      "summary": "・Google AI Overviews・ChatGPT・Perplexityの上位引用ドメインの重複はわずか14%であり、各プラットフォームが異なるソースを優先するため、一律の最適化戦略では可視性を損なう可能性がある。\n・Google AI OverviewsはYouTube・Redditなど権威あるサイトを、ChatGPTはDR90以上の高権威パブリッシャーを、PerplexityはGoogleトップ10ランキングページを約28.6%引用するなど、各プラットフォームで最適化の方向性が異なる。\n・実装の優先順位としては、まずトラフィックシェアの大きいGoogleとChatGPTを狙い、ChatGPT向けにはForbesなど高権威編集サイトへの言及獲得、AI Overviews向けにはYouTubeとRedditへの露出強化が効果的である。",
+      "category": "marketing",
+      "source": "Ahrefs",
+      "source_type": "youtube"
+    },
+    {
+      "title": "Getting Digital Fairness Right: EFF's Recommendations for the EU's Digital Fairness Act",
+      "url": "https://www.eff.org/deeplinks/2026/04/dos-and-donts-eus-digital-fairness-act-effs-recommendation-regulating-digital",
+      "summary": "・EUのデジタル公正法（DFA）はダークパターンの明確な禁止と強制力のある執行規則の導入により、ユーザーの自律的な意思決定を妨げるインターフェース設計を規制すべきとEFFは提言している。\n・監視型ビジネスモデルへの対処として、DFAはプライバシー信号（ブラウザやOSによるトラッキング拒否シグナル）の法的認定を支持し、それを無効化するバナーやUI設計を不公正行為とみなす仕組みを導入すべきである。\n・ユーザー主権の強化のため、DFAは購入後のリモートロックアウトや一方的な機能制限などの不公正な利用制限を規制し、相互運用性とサードパーティアプリへのアクセスを保証することでロックイン解消を目指すべきである。",
+      "category": "tech-news",
+      "source": "EFF",
+      "source_type": "rss"
+    }
+  ]
+}


### PR DESCRIPTION
Pure data PR. Output of \`scripts/dump_editions_to_json.py --apply\` against production Neon.

Refs #41. Depends on #67 (rendering pipeline) — merged.

## What's in this PR

16 JSON files in \`web/src/content/editions/\`:
- \`0001.json\` (2026-04-18, 20 articles) — backfill day 1
- ... through \`0016.json\` (2026-05-11)
- Schema matches \`web/src/content/config.ts\` (validated by Astro on build)
- All editions have \`sources_scanned: null\` — PR #64 populates new cron runs, not retroactively

## Verified locally

\`\`\`sh
cd web
npm run build
# 17 page(s) built in 1.18s — 16 /edition/NNNN/index.html + 1 /index.html
\`\`\`

No build warnings (the earlier "collection editions is empty" warning is gone now that the directory has content).

## What's NOT in this PR

- No \`sources_scanned\` data for past editions — that's structural (PR #64 has no retroactive collection step, and the issue body for #52 explicitly allowed \`sources_scanned IS NULL\` for past editions).
- No daily re-dump automation. Future cron flow (\`daily_news.py\` → optional commit of new JSON to a generated branch) is a separate concern, likely landing alongside #59 (CF Pages deploy).

## Why JSON files are committed (recap)

Per the rule added in PR #65 (\`hibi-domain.md\` → "Web Frontend Constraints"):
> データ取得は build-time。Astro から DB へ実行時アクセスしない

→ CF Pages builds from a git commit; it should NOT need \`DATABASE_URL\`. Committing the JSON is the build-time data path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)