### PR TITLE
chore(design-system): calibrate web typography toward NYT-style balance

### DIFF
--- a/design-system/ui_kits/web/web.css
+++ b/design-system/ui_kits/web/web.css
@@ -47,7 +47,7 @@ body { margin: 0; background: var(--bg-primary); }
 
 /* ── Masthead ───────────────────────────────────────────── */
 .masthead-web {
-  padding: 96px 48px 64px;
+  padding: 64px 48px 48px;
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 48px;
@@ -57,7 +57,7 @@ body { margin: 0; background: var(--bg-primary); }
 .masthead-web .big {
   font-family: var(--font-jp-serif);
   font-weight: 700;
-  font-size: 220px;
+  font-size: 96px;
   line-height: 0.9;
   letter-spacing: -0.04em;
   color: var(--text-primary);
@@ -109,7 +109,7 @@ body { margin: 0; background: var(--bg-primary); }
 }
 
 /* ── Section header ────────────────────────────────────── */
-.section { padding: 96px 48px; }
+.section { padding: 64px 48px; }
 .section-head {
   display: flex;
   align-items: baseline;
@@ -206,11 +206,11 @@ body { margin: 0; background: var(--bg-primary); }
 }
 .feature .left h3 {
   font-family: var(--font-jp);
-  font-size: 56px;
+  font-size: 36px;
   font-weight: 700;
-  line-height: 1.15;
+  line-height: 1.2;
   letter-spacing: -0.02em;
-  margin: 0 0 24px;
+  margin: 0 0 20px;
 }
 .feature .left .meta {
   font-family: var(--font-en);
@@ -412,7 +412,7 @@ body { margin: 0; background: var(--bg-primary); }
 .edition-page .ehead .date-big {
   font-family: var(--font-en);
   font-variant-numeric: tabular-nums;
-  font-size: 96px;
+  font-size: 56px;
   font-weight: 500;
   line-height: 1;
   letter-spacing: -0.04em;


### PR DESCRIPTION
Local preview of #69's archive index revealed the kit's display sizes were oversized for actual content density. Hibi sits between "single edition page" and "wall of headlines"; NYT's masthead-to-headline ratio is the closer reference.

## Specific changes to \`design-system/ui_kits/web/web.css\`

| Selector | Property | Before | After |
|---|---|---|---|
| \`.masthead-web .big\` | font-size | 220px | **96px** |
| \`.feature .left h3\` | font-size | 56px | **36px** |
| \`.feature .left h3\` | line-height | 1.15 | 1.2 |
| \`.feature .left h3\` | margin | \`0 0 24px\` | \`0 0 20px\` |
| \`.edition-page .ehead .date-big\` | font-size | 96px | **56px** |
| \`.masthead-web\` | padding | \`96 48 64\` | **\`64 48 48\`** |
| \`.section\` | padding | \`96 48\` | **\`64 48\`** |

## What didn't change

- No token redeclarations (\`colors_and_type.css\` SSoT untouched).
- No grid layout changes — the 2-up \`grid-template-columns: 1fr 1fr\` on masthead-web stays. It's a fine ratio once the wordmark fits its column.
- Story body / metadata sizes unchanged.

## Verified

\`\`\`sh
cd web
node scripts/sync-design-system.mjs
npm run build  # 17 pages built, no warnings
\`\`\`

The change ships as a CSS file edit on the SSoT (\`design-system/ui_kits/web/web.css\`); \`web/public/design-system/\` is regenerated by the \`prebuild\` hook so Astro picks it up automatically.

## Merge order note

Independent of #69 (archive index) — they touch different files. Either order works; sizes are calibrated specifically against the rendered archive page so seeing both together is most informative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)