### PR TITLE
fix(email): tighten daily digest layout on mobile (<=600px)

### DIFF
--- a/mailer.py
+++ b/mailer.py
@@ -87,30 +87,30 @@ def _story_html(index: int, article: dict, is_last: bool) -> str:
 
     body_parts: list[str] = []
     if summary:
-        body_parts.append(f'<p style="{P_STYLE}">{summary}</p>')
+        body_parts.append(f'<p class="hb-story-p" style="{P_STYLE}">{summary}</p>')
     if learning:
-        body_parts.append(f'<p style="{P_STYLE}">{learning}</p>')
+        body_parts.append(f'<p class="hb-story-p" style="{P_STYLE}">{learning}</p>')
     if practical:
-        body_parts.append(f'<p style="{P_STYLE}">{practical}</p>')
+        body_parts.append(f'<p class="hb-story-p" style="{P_STYLE}">{practical}</p>')
     body_html = "".join(body_parts)
 
     src_label = source_name or "Source"
     src_html = (
-        f'<div style="{SRC_STYLE}">'
+        f'<div class="hb-story-src" style="{SRC_STYLE}">'
         f'Source <a href="{url}" style="{SRC_LINK_STYLE}">{src_label}</a>'
         f"</div>"
     )
 
     wrapper = STORY_WRAPPER_LAST if is_last else STORY_WRAPPER
     return (
-        f'<article style="{wrapper}">'
+        f'<article class="hb-story" style="{wrapper}">'
         '<table role="presentation" width="100%" cellpadding="0" '
         'cellspacing="0" border="0" style="border-collapse:collapse;">'
         "<tr>"
-        f'<td style="{NUM_STYLE}">{index:02d}</td>'
+        f'<td class="hb-story-num" style="{NUM_STYLE}">{index:02d}</td>'
         "<td>"
         f'<div style="{META_STYLE}">{meta_html}</div>'
-        f'<h2 style="{H2_STYLE}">{title}</h2>'
+        f'<h2 class="hb-story-h2" style="{H2_STYLE}">{title}</h2>'
         f"{body_html}"
         f"{src_html}"
         "</td>"

--- a/templates/email.html
+++ b/templates/email.html
@@ -7,50 +7,70 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Noto+Serif+JP:wght@400;500;700&family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+  <style>
+    @media only screen and (max-width: 600px) {
+      .hb-body { padding: 16px 8px !important; }
+      .hb-mast { padding: 24px 22px 20px !important; }
+      .hb-mark { font-size: 40px !important; padding-right: 12px !important; }
+      .hb-mark-meta { padding-left: 12px !important; font-size: 9px !important; letter-spacing: 0.22em !important; }
+      .hb-date { font-size: 11px !important; letter-spacing: 0.16em !important; }
+      .hb-date-small { font-size: 9px !important; }
+      .hb-stand { padding: 22px 22px 20px !important; font-size: 15px !important; }
+      .hb-story { padding: 22px 22px !important; }
+      .hb-story-num { font-size: 22px !important; width: 36px !important; padding-right: 14px !important; }
+      .hb-story-h2 { font-size: 19px !important; margin-bottom: 10px !important; }
+      .hb-story-p { font-size: 14px !important; line-height: 1.7 !important; }
+      .hb-story-src { font-size: 10px !important; margin-top: 12px !important; }
+      .hb-srcs { padding: 24px 22px !important; }
+      .hb-colo { padding: 24px 22px 28px !important; }
+      .hb-seal { width: 56px !important; height: 56px !important; }
+      .hb-colo-meta { font-size: 10px !important; line-height: 1.65 !important; }
+    }
+  </style>
 </head>
-<body style="margin:0;padding:32px 16px;background:#FAFAF7;font-family:'Noto Sans JP',system-ui,-apple-system,'Yu Gothic','Hiragino Kaku Gothic ProN',sans-serif;color:#1A1A1A;-webkit-font-smoothing:antialiased;">
+<body class="hb-body" style="margin:0;padding:32px 16px;background:#FAFAF7;font-family:'Noto Sans JP',system-ui,-apple-system,'Yu Gothic','Hiragino Kaku Gothic ProN',sans-serif;color:#1A1A1A;-webkit-font-smoothing:antialiased;">
 <div style="max-width:680px;margin:0 auto;background:#FFFFFF;">
 
-  <header style="border-top:2px solid #1A1A1A;border-bottom:1px solid #E8E6E1;padding:32px 48px 28px;">
+  <header class="hb-mast" style="border-top:2px solid #1A1A1A;border-bottom:1px solid #E8E6E1;padding:32px 48px 28px;">
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;">
       <tr>
         <td valign="bottom" style="vertical-align:baseline;">
           <table role="presentation" cellpadding="0" cellspacing="0" border="0"><tr>
-            <td style="font-family:'Noto Serif JP','Hiragino Mincho ProN',serif;font-weight:700;font-size:56px;line-height:1;letter-spacing:-0.02em;color:#1A1A1A;padding-right:18px;">日々</td>
-            <td style="font-family:'Inter',system-ui,-apple-system,sans-serif;font-size:10px;letter-spacing:0.25em;text-transform:uppercase;color:#5C5A57;border-left:1px solid #E8E6E1;padding-left:16px;line-height:1.5;">
+            <td class="hb-mark" style="font-family:'Noto Serif JP','Hiragino Mincho ProN',serif;font-weight:700;font-size:56px;line-height:1;letter-spacing:-0.02em;color:#1A1A1A;padding-right:18px;">日々</td>
+            <td class="hb-mark-meta" style="font-family:'Inter',system-ui,-apple-system,sans-serif;font-size:10px;letter-spacing:0.25em;text-transform:uppercase;color:#5C5A57;border-left:1px solid #E8E6E1;padding-left:16px;line-height:1.5;">
               <strong style="color:#1A1A1A;font-weight:500;">HIBI</strong><br>
               DAILY · TOKYO
             </td>
           </tr></table>
         </td>
-        <td align="right" valign="bottom" style="vertical-align:baseline;font-family:'Inter',system-ui,-apple-system,sans-serif;font-variant-numeric:tabular-nums;letter-spacing:0.2em;font-size:13px;color:#1A1A1A;text-align:right;line-height:1.5;">
+        <td class="hb-date" align="right" valign="bottom" style="vertical-align:baseline;font-family:'Inter',system-ui,-apple-system,sans-serif;font-variant-numeric:tabular-nums;letter-spacing:0.2em;font-size:13px;color:#1A1A1A;text-align:right;line-height:1.5;">
           $date
-          <div style="font-size:10px;color:#9B9894;letter-spacing:0.25em;text-transform:uppercase;">$article_count STORIES</div>
+          <div class="hb-date-small" style="font-size:10px;color:#9B9894;letter-spacing:0.25em;text-transform:uppercase;">$article_count STORIES</div>
         </td>
       </tr>
     </table>
   </header>
 
-  <section style="padding:28px 48px 24px;border-bottom:1px solid #E8E6E1;font-family:'Noto Sans JP',system-ui,-apple-system,'Yu Gothic','Hiragino Kaku Gothic ProN',sans-serif;font-size:18px;font-weight:400;line-height:1.6;color:#5C5A57;">
+  <section class="hb-stand" style="padding:28px 48px 24px;border-bottom:1px solid #E8E6E1;font-family:'Noto Sans JP',system-ui,-apple-system,'Yu Gothic','Hiragino Kaku Gothic ProN',sans-serif;font-size:18px;font-weight:400;line-height:1.6;color:#5C5A57;">
     <em style="font-style:normal;color:#1A1A1A;font-weight:500;">今朝の$article_count本。</em>静かな朝の読みもの。
   </section>
 
   $articles_html
 
-  <section style="padding:32px 48px;border-top:1px solid #1A1A1A;background:#FAFAF7;">
+  <section class="hb-srcs" style="padding:32px 48px;border-top:1px solid #1A1A1A;background:#FAFAF7;">
     <div style="font-family:'Inter',system-ui,-apple-system,sans-serif;font-size:10px;letter-spacing:0.25em;text-transform:uppercase;color:#9B9894;margin-bottom:14px;">Sources scanned this morning</div>
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;">
       $sources_html
     </table>
   </section>
 
-  <footer style="padding:32px 48px 40px;background:#FAFAF7;border-top:1px solid #E8E6E1;">
+  <footer class="hb-colo" style="padding:32px 48px 40px;background:#FAFAF7;border-top:1px solid #E8E6E1;">
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;">
       <tr>
         <td valign="top" style="vertical-align:top;">
-          <img src="https://raw.githubusercontent.com/kazuki-0418/Personal-Daily-News/main/design-system/ui_kits/email/seal.svg" width="72" height="72" alt="日々 seal" style="display:block;border:0;">
+          <img class="hb-seal" src="https://raw.githubusercontent.com/kazuki-0418/Personal-Daily-News/main/design-system/ui_kits/email/seal.svg" width="72" height="72" alt="日々 seal" style="display:block;border:0;">
         </td>
-        <td align="right" valign="top" style="vertical-align:top;font-family:'Inter',system-ui,-apple-system,sans-serif;font-size:11px;letter-spacing:0.15em;color:#9B9894;text-align:right;line-height:1.7;">
+        <td class="hb-colo-meta" align="right" valign="top" style="vertical-align:top;font-family:'Inter',system-ui,-apple-system,sans-serif;font-size:11px;letter-spacing:0.15em;color:#9B9894;text-align:right;line-height:1.7;">
           <div style="font-family:'Noto Sans JP',system-ui,-apple-system,'Yu Gothic','Hiragino Kaku Gothic ProN',sans-serif;letter-spacing:0;font-size:12px;color:#9B9894;">日々の小さな知らせ。</div>
           Generated $date JST<br>
           $source_count sources scanned

--- a/tests/test_email_template.py
+++ b/tests/test_email_template.py
@@ -210,12 +210,23 @@ def test_mailer_send_signature_unchanged() -> None:
 def test_build_html_returns_str_with_inline_styles_only() -> None:
     html = mailer.build_html(SAMPLE_ARTICLES, "2026.05.10")
     assert isinstance(html, str) and len(html) > 0
-    # The design-system migration inlines tokens via style="…" attributes;
-    # no <style> block, no premailer/juice dependency.
-    assert "<style" not in html.lower()
-    # Token color literals from design-system/colors_and_type.css.
+    # Design tokens live inline on style="…" attributes (no premailer/juice).
+    # A <style> block is allowed only for responsive @media overrides — it
+    # must not carry token literals or non-media rules, which would signal a
+    # regression toward stylesheet-driven design.
     for token in ("#1A1A1A", "#5C5A57", "#9B9894", "#FAFAF7", "#E8E6E1"):
         assert token in html
+    lower = html.lower()
+    style_open = lower.find("<style")
+    if style_open != -1:
+        style_close = lower.find("</style>", style_open)
+        assert style_close != -1, "<style> opened without closing tag"
+        block = html[style_open:style_close]
+        assert "@media" in block, "<style> block must only carry @media rules"
+        for token in ("#1A1A1A", "#5C5A57", "#9B9894", "#FAFAF7", "#E8E6E1"):
+            assert token not in block, (
+                f"design token {token} leaked into <style>; tokens belong inline"
+            )
 
 
 # ── HTML escaping of user-controlled fields ────────────────────────────


### PR DESCRIPTION
## Summary
- デスクトップ向けの 48px ガター / 56px の「日々」マークがモバイル表示で支配的だったため、`@media (max-width: 600px)` ブロックをテンプレート `<head>` に追加し、各セクションに `hb-*` クラスフックを付けて padding・マーク・番号・見出し・本文サイズをモバイル時のみ縮小。
- デザイントークン (`#1A1A1A` 等) は引き続きインライン `style="…"` に常駐。`<style>` ブロックは responsive overrides 専用とし、`test_build_html_returns_str_with_inline_styles_only` を更新して `@media` 限定を許容しつつトークン漏れがないことを assert。

| 要素 | デスクトップ | モバイル |
|---|---|---|
| Body 外 padding | 32/16 | 16/8 |
| Section 横 padding | 48 | 22 |
| 日々 ロゴ | 56px | 40px |
| 番号 (01..) | 32px / 48幅 | 22px / 36幅 |
| H2 | 22px | 19px |
| 本文 p | 15px | 14px |
| Seal | 72×72 | 56×56 |

## Test plan
- [x] `pytest tests/test_email_template.py` — 14/14 pass
- [x] `pytest` (全体) — 100 pass。既存 5 errors は `service/tests` の `psycopg_pool` 未インストール起因で本変更と無関係
- [ ] iPhone Gmail / Apple Mail で実機レンダ確認
- [ ] Gmail desktop でデスクトップレイアウトに退行が無いことを確認
- [ ] Outlook desktop が `@media` を無視してデスクトップサイズを維持することを確認

## Status
- Pytest Passed
- Dry-run Not Run (HTML テンプレ変更のみ。配信ロジック非変更)
- Migration N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)