### PR TITLE
chore(security): disable /openapi.json /docs /redoc in production

### DIFF
--- a/service/app/main.py
+++ b/service/app/main.py
@@ -25,7 +25,15 @@ def _build_app(settings: Settings | None = None) -> FastAPI:
         finally:
             db.close_pool()
 
-    app = FastAPI(title="Personal AI Newspaper API", version="0.1.0", lifespan=lifespan)
+    is_prod = settings.app_env.lower() == "production"
+    app = FastAPI(
+        title="Personal AI Newspaper API",
+        version="0.1.0",
+        lifespan=lifespan,
+        openapi_url=None if is_prod else "/openapi.json",
+        docs_url=None if is_prod else "/docs",
+        redoc_url=None if is_prod else "/redoc",
+    )
     app.state.settings = settings
     app.state.limiter = limiter
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)

--- a/service/tests/test_main_docs.py
+++ b/service/tests/test_main_docs.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import _build_app
+from app.settings import Settings
+
+
+def _client_with_app_env(monkeypatch: pytest.MonkeyPatch, app_env: str | None) -> TestClient:
+    if app_env is None:
+        monkeypatch.delenv("APP_ENV", raising=False)
+    else:
+        monkeypatch.setenv("APP_ENV", app_env)
+    settings = Settings()
+    app = _build_app(settings)
+    return TestClient(app)
+
+
+@pytest.mark.parametrize("app_env", [None, "development", "staging", "prod"])
+def test_docs_exposed_when_not_production(
+    monkeypatch: pytest.MonkeyPatch, db_stub: MagicMock, app_env: str | None
+) -> None:
+    with _client_with_app_env(monkeypatch, app_env) as client:
+        assert client.get("/docs").status_code == 200
+        assert client.get("/openapi.json").status_code == 200
+        assert client.get("/redoc").status_code == 200
+        assert client.get("/health").status_code == 200
+
+
+@pytest.mark.parametrize("app_env", ["production", "PRODUCTION", "Production"])
+def test_docs_disabled_in_production(
+    monkeypatch: pytest.MonkeyPatch, db_stub: MagicMock, app_env: str
+) -> None:
+    with _client_with_app_env(monkeypatch, app_env) as client:
+        assert client.get("/docs").status_code == 404
+        assert client.get("/openapi.json").status_code == 404
+        assert client.get("/redoc").status_code == 404
+        assert client.get("/health").status_code == 200


### PR DESCRIPTION
## Summary
- FastAPI initialization gates `openapi_url` / `docs_url` / `redoc_url` to `None` when `Settings.app_env == "production"` (case-insensitive)
- Reduces attack surface on `api.hibi-news.com` (no schema disclosure, no route enumeration via `/docs`)
- Uses existing `APP_ENV` env var via `Settings.app_env` — no new env variable introduced

Closes #80.

## Why this approach
The original Issue suggested introducing a new `ENV` variable. Architect (during prior planning) flagged that this would create a duplicate of the existing `APP_ENV` / `Settings.app_env` pair. Going with the existing `Settings` field keeps configuration single-sourced.

## Test plan
- [x] `pytest` from `service/`: 19 passed in 0.53s (existing 12 + new 7)
- [x] New tests cover:
  - Non-production (None / `development` / `staging` / `prod` short form): `/docs`, `/openapi.json`, `/redoc`, `/health` all 200
  - Production (`production` / `PRODUCTION` / `Production`): docs trio 404, `/health` 200
- [ ] Manual post-deploy verification on api.hibi-news.com:
  - `curl -I https://api.hibi-news.com/docs` → 404
  - `curl -I https://api.hibi-news.com/openapi.json` → 404
  - `curl -I https://api.hibi-news.com/redoc` → 404
  - `curl -I https://api.hibi-news.com/health` → 200

## Homelab rollout (out of repo, manual after merge)
1. Append `APP_ENV=production` to `/opt/ops/env/hibi/api.env`
2. `docker compose up -d --force-recreate fastapi`
3. Run the 4 `curl` checks above

🤖 Generated with [Claude Code](https://claude.com/claude-code)