### PR TITLE
chore(infra): rename docker-compose image and containers to hibi

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   fastapi:
-    image: ghcr.io/kazuki-0418/personal-daily-news:latest
-    container_name: personal-daily-news-fastapi
+    image: ghcr.io/kazuki-0418/hibi-api:latest
+    container_name: hibi-fastapi
     restart: unless-stopped
     env_file:
       - ./secrets.env
@@ -20,7 +20,7 @@ services:
 
   cloudflared:
     image: cloudflare/cloudflared:latest
-    container_name: personal-daily-news-cloudflared
+    container_name: hibi-cloudflared
     restart: unless-stopped
     command: tunnel --no-autoupdate run
     env_file:

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -72,8 +72,8 @@ Expected result:
 
 | container                           | PORTS  |
 | ----------------------------------- | ------ |
-| `personal-daily-news-fastapi`       | *(empty — no host bind)* |
-| `personal-daily-news-cloudflared`   | *(empty)* |
+| `hibi-fastapi`                      | *(empty — no host bind)* |
+| `hibi-cloudflared`                  | *(empty)* |
 
 ## 5. Verify
 

--- a/service/README.md
+++ b/service/README.md
@@ -16,6 +16,6 @@ curl http://localhost:8000/health
 ## Docker
 
 ```bash
-docker build -t personal-daily-news:local -f service/Dockerfile .
-docker run --rm -p 8000:8000 personal-daily-news:local
+docker build -t hibi-api:local -f service/Dockerfile .
+docker run --rm -p 8000:8000 hibi-api:local
 ```


### PR DESCRIPTION
## Summary
- `docker-compose.yml`: image → `ghcr.io/kazuki-0418/hibi-api:latest`; container_name → `hibi-fastapi` / `hibi-cloudflared`
- `docs/deploy.md`: container table reflects new names
- `service/README.md`: local docker example uses `hibi-api:local`

Closes #81.

## Why
Repo was renamed Personal-Daily-News → hibi (#35) and `.github/workflows/build-and-push.yml` already pushes `ghcr.io/kazuki-0418/hibi-api`, but `docker-compose.yml` was still pulling the old `personal-daily-news` image (which no longer publishes). Without this fix, the next `docker compose pull` on homelab fails.

## Test plan
- [x] `grep -rn "personal-daily-news" --include={yml,yaml,conf,env,md,Dockerfile}` → zero hits
- [x] Compose YAML loads (validation only failed on missing secrets.env, which is `.gitignore`d homelab-only)
- [ ] Manual on homelab after merge:
  - `docker compose pull` → succeeds (new tag exists in GHCR)
  - `docker compose up -d` → both containers come up healthy
  - `docker ps` shows `hibi-fastapi` and `hibi-cloudflared`
  - `curl https://api.hibi-news.com/health` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)