### PR TITLE
feat(ci): auto-dump editions and push to trigger CF Pages rebuild

### DIFF
--- a/.github/workflows/daily-news.yml
+++ b/.github/workflows/daily-news.yml
@@ -7,6 +7,11 @@ on:
   repository_dispatch:
     # 外部から API で叩ける
     types: [ daily-news ]
+
+permissions:
+  # 後段の dump → auto-commit + push に必要 (CF Pages の auto-rebuild を main push で発火させる)
+  contents: write
+
 jobs:
   send:
     runs-on: ubuntu-latest
@@ -40,3 +45,26 @@ jobs:
           # Embeddings for similarity ranking (optional — if unset, articles
           # are saved with embedding = NULL; backfill later).
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+      # Dump editions from Neon → JSON files Astro reads at build time.
+      # Idempotent overwrite; no-op if no editions changed.
+      - name: Dump editions to web content collection
+        run: python scripts/dump_editions_to_json.py --apply
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
+      # Auto-commit & push only if dump produced JSON diffs. Push to main
+      # triggers Cloudflare Pages auto-rebuild (separate webhook, not
+      # affected by [skip ci]). [skip ci] suppresses re-firing this and
+      # other GitHub workflows on the bot commit.
+      - name: Commit & push edition JSON if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add web/src/content/editions/
+          if git diff --cached --quiet; then
+            echo "No edition changes — skipping commit"
+          else
+            git commit -m "chore(web): auto-dump editions $(date -u +%Y-%m-%d) [skip ci]"
+            git push
+          fi


### PR DESCRIPTION
## Summary
- After `python daily_news.py`, dump editions from Neon to `web/src/content/editions/*.json`
- Auto-commit + push to main if (and only if) JSON changed
- CF Pages auto-rebuilds on the push, so new editions appear on hibi-news.com without manual intervention

Closes #82.

## Why this approach (not the curl deploy hook)
Earlier plan was `curl -X POST $CF_PAGES_DEPLOY_HOOK_URL`. That alone is a no-op because CF would rebuild from the pre-existing repo state (no new JSON committed). The dump → commit → push flow is the only way to actually publish today's edition.

`CF_PAGES_DEPLOY_HOOK_URL` secret is still available if a future workflow needs to force a rebuild without a content change.

## Risk + mitigations
- **Auto-commits accumulate in main history**: 1 per day, only when content changed. `[skip ci]` keeps them from triggering further workflows.
- **Push permission**: requires `permissions: contents: write` (added). Default `GITHUB_TOKEN` is sufficient (no PAT needed).
- **Dump failure** would leave the workflow failed before commit — no broken state pushed.
- **Race with manual edits to `web/src/content/editions/`**: dump is idempotent overwrite; manual edits would be replaced. If someone has WIP there, the daily run will clobber it. (Currently no one is editing those files manually.)

## Test plan
- [ ] After merge, manually trigger via Actions → Daily News → Run workflow → confirm:
  - daily_news step succeeds
  - dump step runs and writes JSON
  - commit step either commits & pushes OR skips with "No edition changes" message
  - if commit happened: new commit appears in main with `[skip ci]` in message
  - CF Pages dashboard shows a deploy triggered by the bot commit
  - https://hibi-news.com reflects the new edition within ~3 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)