### PR TITLE
feat(ci): add manual workflow for embedding backfill

### DIFF
--- a/.github/workflows/backfill-embeddings.yml
+++ b/.github/workflows/backfill-embeddings.yml
@@ -1,0 +1,44 @@
+name: Backfill Embeddings
+
+# 既存 articles 行のうち embedding が NULL のものに、OpenAI text-embedding-3-small
+# でベクトルを埋める one-shot 運用 workflow。手動 dispatch 専用。
+#
+# 使い方:
+#   GitHub UI → Actions → Backfill Embeddings → Run workflow → "Run dry-run"
+#   選択肢: dry-run (件数+コスト推定のみ) / apply (実書き込み)
+#
+# Phase 3 完了後、cron で新規 article は daily_news.py 内で同期的に embed される
+# ので、本 workflow は OPENAI_API_KEY 設定 / migration 適用直後の一回だけ走らせる
+# 想定。再利用可能だが日常運用では使わない。
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "dry-run = 件数+コスト推定のみ。apply = 実書き込み (OpenAI 課金発生)"
+        required: true
+        type: choice
+        options:
+          - dry-run
+          - apply
+        default: dry-run
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - run: pip install -r requirements.txt
+
+      - name: Run backfill (${{ inputs.mode }})
+        run: python scripts/backfill_embeddings.py --${{ inputs.mode }}
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## Summary
- New `backfill-embeddings.yml` workflow with `workflow_dispatch` only (manual trigger)
- Two modes via input: `dry-run` (count + cost estimate) and `apply` (actual writes)
- Reuses existing `OPENAI_API_KEY` / `DATABASE_URL` GitHub Secrets

Refs #37 (closes after the one-time apply run completes successfully).

## Why a workflow (not local script run)
- `OPENAI_API_KEY` lives in GitHub Secrets, not local `.env` (per Kazuki's setup)
- Avoids exposing the key locally
- Reusable if backfill ever needed again (e.g., schema migration that resets embeddings)

## Run plan after merge
1. **Actions → Backfill Embeddings → Run workflow → mode = `dry-run`**
   - Confirms 153 rows, ~$0.0003 estimated cost
2. **Run workflow → mode = `apply`**
   - Embeds all NULL rows in batches of 50, ~30 seconds total
3. Verify via Neon SQL Editor: `SELECT count(*) FROM articles WHERE embedding IS NULL` should return 0
4. Ranking will use sim/score on next scheduled daily-news run (cron at 13:17 UTC)

## Cost
Dry-run today on local mirror: 153 articles, 13,157 tokens, **\$0.0003** total. Negligible.

## Test plan
- [ ] After merge, dry-run completes successfully and prints expected counts
- [ ] After apply, `SELECT count(*) WHERE embedding IS NULL` = 0 in Neon
- [ ] Next daily-news run produces sim/score logs in the action output

🤖 Generated with [Claude Code](https://claude.com/claude-code)