### PR TITLE
feat(email): show skipped article count in footer (#12)

### DIFF
--- a/daily_news.py
+++ b/daily_news.py
@@ -503,7 +503,9 @@ def main():
 
     date_str = datetime.now(timezone.utc).strftime("%Y.%m.%d")
     articles = _sections_to_articles(sections)
-    html = build_hibi_html(articles, date_str)
+    # スキップ件数を footer で透明性表示する (#12 Phase 1)。
+    # 字幕不足 / Claude による短文 reject の合計。詳細区別は今回はしない。
+    html = build_hibi_html(articles, date_str, skipped_count=skipped_count)
     send_email(
         subject=format_subject(date_str, count=len(articles)),
         html_body=html,

--- a/mailer.py
+++ b/mailer.py
@@ -160,12 +160,20 @@ def _sources_html(articles: list[dict]) -> str:
     return "".join(rows)
 
 
-def build_html(articles: list[dict], date: str) -> str:
+def build_html(
+    articles: list[dict],
+    date: str,
+    skipped_count: int = 0,
+) -> str:
     """Build the daily email HTML from enriched article dicts.
 
     Articles are rendered top-to-bottom with numeric prefix 01..N matching
     design-system/ui_kits/email. Importance scores no longer drive layout —
     Hibi's design-system removes group headings, pills, and stars.
+
+    ``skipped_count`` is the number of candidate articles dropped during the
+    summarization stage (字幕不足 / 短すぎる要約など). When > 0 it is shown
+    discreetly in the colophon for transparency. 0 (default) hides the line.
     """
     with open(TEMPLATE_PATH, encoding="utf-8") as f:
         template = Template(f.read())
@@ -181,12 +189,25 @@ def build_html(articles: list[dict], date: str) -> str:
     sources_html = _sources_html(articles)
     source_count = len({a.get("source") or a.get("source_name") for a in articles if a.get("source") or a.get("source_name")})
 
+    if skipped_count > 0:
+        # Inline tokens reuse the existing colophon palette (#9B9894 muted
+        # gray, Noto Sans JP). No new colors / fonts introduced.
+        skipped_html = (
+            f'<br><span style="font-family:{FONT_JP};letter-spacing:0;'
+            'font-size:11px;color:#9B9894;">'
+            f"字幕不足等でスキップ: {skipped_count}件"
+            "</span>"
+        )
+    else:
+        skipped_html = ""
+
     return template.safe_substitute(
         date=date,
         article_count=len(articles),
         articles_html=articles_html,
         sources_html=sources_html,
         source_count=source_count,
+        skipped_html=skipped_html,
     )
 
 

--- a/templates/email.html
+++ b/templates/email.html
@@ -73,7 +73,7 @@
         <td class="hb-colo-meta" align="right" valign="top" style="vertical-align:top;font-family:'Inter',system-ui,-apple-system,sans-serif;font-size:11px;letter-spacing:0.15em;color:#9B9894;text-align:right;line-height:1.7;">
           <div style="font-family:'Noto Sans JP',system-ui,-apple-system,'Yu Gothic','Hiragino Kaku Gothic ProN',sans-serif;letter-spacing:0;font-size:12px;color:#9B9894;">日々の小さな知らせ。</div>
           Generated $date JST<br>
-          $source_count sources scanned
+          $source_count sources scanned$skipped_html
         </td>
       </tr>
     </table>

--- a/tests/test_email_template.py
+++ b/tests/test_email_template.py
@@ -262,3 +262,64 @@ def test_build_html_escapes_dangerous_chars_in_user_fields() -> None:
     # The escaped form must be present.
     assert "&amp;" in rendered, "ampersand should be escaped to &amp;"
     assert "&lt;" in rendered and "&gt;" in rendered, "angle brackets escaped"
+
+
+# ── Skipped article count footer (#12 Phase 1) ─────────────────────────
+
+
+def test_build_html_omits_skipped_line_when_count_is_zero() -> None:
+    """``skipped_count=0`` (default) must not render the skipped footer line.
+
+    Transparency line is opt-in: a clean run should not leak operational
+    noise into the colophon.
+    """
+    html = mailer.build_html(SAMPLE_ARTICLES, "2026.05.10")
+    assert "字幕不足等でスキップ" not in html
+    # Default arg path should match the explicit-zero path.
+    html_explicit = mailer.build_html(SAMPLE_ARTICLES, "2026.05.10", skipped_count=0)
+    assert "字幕不足等でスキップ" not in html_explicit
+
+
+def test_build_html_shows_skipped_line_when_count_positive() -> None:
+    """Positive ``skipped_count`` renders the count + Japanese label inline.
+
+    The line lives inside the colophon block so the standfirst / story area
+    remains untouched. Color must reuse the existing muted palette
+    (``#9B9894``) — no new design tokens introduced.
+    """
+    html = mailer.build_html(SAMPLE_ARTICLES, "2026.05.10", skipped_count=3)
+    assert "字幕不足等でスキップ: 3件" in html
+    # Must reuse the colophon muted gray (no new tokens).
+    skipped_idx = html.index("字幕不足等でスキップ")
+    # Look back ~200 chars for the inline style declaration on this span.
+    window = html[max(0, skipped_idx - 200):skipped_idx]
+    assert "#9B9894" in window, "skipped line must reuse muted #9B9894 token"
+    # Sits inside the colophon (between Generated and the closing </footer>).
+    colophon_start = html.index("Generated")
+    footer_end = html.index("</footer>")
+    assert colophon_start < skipped_idx < footer_end, (
+        "skipped line must be rendered inside the colophon footer"
+    )
+
+
+def test_build_html_skipped_count_signature_accepts_keyword_arg() -> None:
+    """Contract: ``skipped_count`` is keyword-callable with a sane default.
+
+    Guards against future positional reordering that would silently break
+    the daily_news.py caller (``build_hibi_html(articles, date_str,
+    skipped_count=...)``).
+    """
+    sig = inspect.signature(mailer.build_html)
+    params = sig.parameters
+    assert "skipped_count" in params
+    assert params["skipped_count"].default == 0
+    assert params["skipped_count"].kind in (
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    )
+
+
+def test_build_html_large_skipped_count_renders_without_truncation() -> None:
+    """Boundary: a two-digit skip count must render verbatim, not bucketed."""
+    html = mailer.build_html(SAMPLE_ARTICLES, "2026.05.10", skipped_count=27)
+    assert "字幕不足等でスキップ: 27件" in html


### PR DESCRIPTION
## Summary

- Issue #12 (Phase 1 エラーハンドリング) の残スコープ「スキップ動画数をメール末尾に表示」を実装
- 既存の `colophon` に muted gray (#9B9894) + Noto Sans JP で控えめに 1 行追加
- `skipped_count=0` のときは行ごと出さないので既存配信と完全互換

## Scope notes

`#12` の 3 項目のうち:
- ✅ 空メール防止 → 既に `daily_news.py:420-422 / :500-502` で実装済み（今回は触らず）
- ⚙️ GitHub Actions 失敗通知 → コード不要、UI 設定のみ（#12 にコメントで手順記載予定）
- ✅ **このPR**: スキップ件数のメール末尾表示

詳細な原因区別（字幕不足 / Claude 短文 reject）はせず、合算カウントのみ表示。文言は「字幕不足等でスキップ: N件」。

## Test plan

- [x] `pytest tests/` 全 18 件 PASS（新規 4 件 + 既存 14 件無回帰）
- [x] `skipped_count=0` で footer 行が出ないこと
- [x] `skipped_count=3` で「字幕不足等でスキップ: 3件」が colophon 内に出ること
- [x] `inspect.signature` で `skipped_count` が kwarg + default=0 であることを契約として固定
- [ ] 翌朝の自動配信 (cron 17:13 UTC) で実メールを目視確認

Closes #12 の残スコープ（GitHub UI 設定の通知 ON は別途）

🤖 Generated with [Claude Code](https://claude.com/claude-code)