### PR TITLE
fix(service): catch all psycopg errors in get_article to prevent 500 on cold start (#88)

### DIFF
--- a/service/app/db.py
+++ b/service/app/db.py
@@ -6,10 +6,13 @@ to stand up a real Postgres.
 
 from __future__ import annotations
 
+import logging
 from typing import Optional, TypedDict
 
 import psycopg
 from psycopg_pool import ConnectionPool
+
+log = logging.getLogger(__name__)
 
 
 class Article(TypedDict):
@@ -48,6 +51,12 @@ def get_article(article_id: str) -> Optional[Article]:
             return {"url": row[0], "user_id": row[1]}
     except psycopg.DataError:
         # e.g. article_id is not a valid uuid shape → treat as missing
+        return None
+    except psycopg.Error:
+        # Pool / connection failures (OperationalError, InterfaceError, ...)
+        # — typically Neon scale-to-zero cold start. Return None so the click
+        # handler can fall back to missing_redirect_url instead of 500-ing.
+        log.exception("get_article: db error for article_id=%s", article_id)
         return None
 
 

--- a/service/tests/test_click.py
+++ b/service/tests/test_click.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import hashlib
 
+import psycopg
+
 from app.signing import sign_article
 
 ARTICLE_ID = "11111111-1111-1111-1111-111111111111"
@@ -83,6 +85,49 @@ def test_missing_article_redirects_to_missing_page(app_client):
     assert r.status_code == 302
     assert r.headers["location"] == settings.missing_redirect_url
     db.log_click.assert_not_called()
+
+
+def test_db_cold_start_falls_back_to_missing_redirect(
+    app_client, monkeypatch
+):
+    """Neon scale-to-zero cold start path: the real get_article catches
+    psycopg.OperationalError internally and returns None, so the click handler
+    must 302 to missing_redirect_url rather than 500.
+
+    This exercises the real db.get_article through the route by re-importing
+    a fresh app.db (the conftest db_stub mocked the module-level attribute);
+    we then point the pool at a stub that raises on .connection(). log_click
+    stays mocked at the conftest layer so we never hit a real DB.
+    """
+    import importlib
+
+    client, db_stub_mock, settings = app_client
+
+    from app import db as db_module
+    real_db = importlib.reload(db_module)
+
+    class _PoolRaising:
+        def connection(self) -> object:
+            raise psycopg.OperationalError("connection closed (cold start)")
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(real_db, "_pool", _PoolRaising())
+    # After importlib.reload, db_module.get_article is the real function again
+    # (the conftest mock was discarded). The click route imported
+    # `from .. import db`, so it sees the reloaded module attribute directly.
+
+    r = client.get(
+        f"/r/{ARTICLE_ID}",
+        params={"s": _valid_sig()},
+        follow_redirects=False,
+        headers={"user-agent": "Mozilla/5.0 human", "cf-connecting-ip": "203.0.113.14"},
+    )
+
+    assert r.status_code == 302
+    assert r.headers["location"] == settings.missing_redirect_url
+    db_stub_mock.log_click.assert_not_called()
 
 
 def test_rate_limit_returns_429_after_threshold(app_client):

--- a/service/tests/test_db.py
+++ b/service/tests/test_db.py
@@ -1,0 +1,70 @@
+"""Unit tests for app.db.
+
+These tests monkeypatch the module-level connection pool so they exercise the
+exception-handling branches in get_article() without standing up real Postgres.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import psycopg
+import pytest
+
+from app import db as db_module
+
+ARTICLE_ID = "11111111-1111-1111-1111-111111111111"
+
+
+class _PoolRaising:
+    """Stand-in ConnectionPool whose .connection() raises a given exception."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    def connection(self) -> object:
+        raise self._exc
+
+
+def test_get_article_returns_none_on_operational_error(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Pool/connection failures (Neon cold start) must be swallowed → None."""
+    fake_pool = _PoolRaising(psycopg.OperationalError("connection closed"))
+    monkeypatch.setattr(db_module, "_pool", fake_pool)
+
+    with caplog.at_level(logging.ERROR, logger="app.db"):
+        result = db_module.get_article(ARTICLE_ID)
+
+    assert result is None
+    # Non-DataError branches must be logged so we can see cold-start churn.
+    assert any(
+        "get_article: db error" in record.message and ARTICLE_ID in record.message
+        for record in caplog.records
+    )
+
+
+def test_get_article_returns_none_on_interface_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """InterfaceError (pool closed / broken) must also be swallowed → None."""
+    fake_pool = _PoolRaising(psycopg.InterfaceError("pool is closed"))
+    monkeypatch.setattr(db_module, "_pool", fake_pool)
+
+    assert db_module.get_article(ARTICLE_ID) is None
+
+
+def test_get_article_returns_none_on_data_error_without_logging(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Malformed UUID stays on the silent DataError branch (no error log)."""
+    fake_pool = _PoolRaising(psycopg.DataError("invalid input syntax for uuid"))
+    monkeypatch.setattr(db_module, "_pool", fake_pool)
+
+    with caplog.at_level(logging.ERROR, logger="app.db"):
+        result = db_module.get_article("not-a-uuid")
+
+    assert result is None
+    assert not any("get_article: db error" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

- `service/app/db.py:get_article()` の例外 catch を `psycopg.DataError` のみから `psycopg.Error` 全般に拡張
- Neon の Scale-to-Zero cold start や connection pool 由来の `OperationalError` / `InterfaceError` が出ても `None` を返し、click handler の既存 `missing_redirect_url` フォールバックに合流させる
- `psycopg.DataError`（不正 UUID）は従来通り silent return — ログノイズを増やさない
- `psycopg.Error` 経路は `log.exception` で Sentry / app log に必ず残す（#89 で Sentry を入れたら自動で拾える)

## Root cause

2026-05-13 の Issue #36 E2E 検証で `/r/163d3731-…` が 500 を返した。原因は `get_article()` が pool 由来の transient error を catch しておらず FastAPI のデフォルト 500 に到達していたこと。

## Test plan

- [x] `service/tests/test_db.py` 新規: `OperationalError` / `InterfaceError` で `None` 返却 + error log を検証。`DataError` の silent path 維持も確認
- [x] `service/tests/test_click.py` 新規: pool が `OperationalError` を吐く状況で route が **302 → missing_redirect_url** を返し、`log_click` が呼ばれないことを E2E で確認
- [x] `pytest service/tests/` 全 23 件 PASS
- [ ] 本番 deploy 後、cold start 時に 5xx が出ないことを Cloudflare Analytics で確認

## Out of scope

- リトライロジック（pool 設定 `min_size` 含む）は別 issue で扱う
- Sentry 連携自体は #89 で扱う

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)