### PR TITLE
feat(observability): introduce Sentry for service and pipeline (#89)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,11 @@ DATABASE_URL=postgresql://user:password@host-pooler.region.aws.neon.tech/neondb?
 # Without this, articles are saved with embedding = NULL; backfill later with
 #   python scripts/backfill_embeddings.py --apply
 OPENAI_API_KEY=
+
+# Sentry (optional). Unset → no-op for local dev. Project: hibi-pipeline.
+# Get the DSN from https://kazuki-0418.sentry.io after creating the project.
+SENTRY_DSN=
+# Release identifier. CI sets this to ${{ github.sha }}; defaults to "dev".
+HIBI_RELEASE=dev
+# Environment tag in Sentry. CI sets "production".
+HIBI_ENV=development

--- a/.github/workflows/daily-news.yml
+++ b/.github/workflows/daily-news.yml
@@ -45,6 +45,11 @@ jobs:
           # Embeddings for similarity ranking (optional — if unset, articles
           # are saved with embedding = NULL; backfill later).
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # Sentry observability (#89). Optional — if SENTRY_DSN is unset
+          # the pipeline runs without telemetry.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          HIBI_RELEASE: ${{ github.sha }}
+          HIBI_ENV: production
 
       # Dump editions from Neon → JSON files Astro reads at build time.
       # Idempotent overwrite; no-op if no editions changed.

--- a/daily_news.py
+++ b/daily_news.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta, timezone
 from email.mime.text import MIMEText
 from urllib.parse import quote
 
+import sentry_sdk
 import yaml
 from googleapiclient.discovery import build
 from google.oauth2.credentials import Credentials
@@ -30,6 +31,7 @@ from db import (
 from fetchers import rss as rss_fetcher
 from fetchers import youtube as youtube_fetcher
 from mailer import build_html as build_hibi_html
+from observability import init_sentry_from_env
 from ranking import compute_interest_centroid, cosine_similarity, count_recent_clicks
 from send_mail import format_subject
 
@@ -514,4 +516,18 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    sentry_active = init_sentry_from_env()
+    try:
+        main()
+    except Exception:
+        # Make sure Sentry captures the error before the GitHub Actions
+        # runner tears the process down. Re-raise so the workflow still
+        # fails (existing failure-email path stays intact).
+        if sentry_active:
+            sentry_sdk.capture_exception()
+        raise
+    finally:
+        if sentry_active:
+            # Flush is critical for short-lived processes (cron jobs);
+            # without it, async transport may drop events on exit.
+            sentry_sdk.flush(timeout=5)

--- a/observability.py
+++ b/observability.py
@@ -1,0 +1,78 @@
+"""Sentry initialization for the daily-news pipeline (root-level scripts).
+
+Kept separate from `service/app/observability.py` because the service has
+its own pyproject.toml and is deployed independently. The two scrubbers
+differ in scope: this one focuses on the recipient email and SMTP errors
+that the pipeline can emit, since there is no HTTP request context here.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Any, Optional
+
+import sentry_sdk
+
+log = logging.getLogger(__name__)
+
+# Crude — good enough to redact a recipient address that leaked into an
+# exception message or breadcrumb. Not a general PII detector.
+_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+
+
+def _redact_emails(text: str) -> str:
+    return _EMAIL_RE.sub("[redacted-email]", text)
+
+
+def scrub_event(event: dict[str, Any], _hint: dict[str, Any]) -> Optional[dict[str, Any]]:
+    """before_send hook: redact email addresses from messages and breadcrumbs."""
+    msg = event.get("message")
+    if isinstance(msg, str):
+        event["message"] = _redact_emails(msg)
+
+    exc_values = event.get("exception", {}).get("values")
+    if isinstance(exc_values, list):
+        for exc in exc_values:
+            if isinstance(exc, dict):
+                value = exc.get("value")
+                if isinstance(value, str):
+                    exc["value"] = _redact_emails(value)
+
+    crumbs = event.get("breadcrumbs", {}).get("values")
+    if isinstance(crumbs, list):
+        for crumb in crumbs:
+            if isinstance(crumb, dict):
+                message = crumb.get("message")
+                if isinstance(message, str):
+                    crumb["message"] = _redact_emails(message)
+
+    return event
+
+
+def init_sentry_from_env() -> bool:
+    """Initialize Sentry from environment. Returns True if active.
+
+    Env vars (all optional):
+    - SENTRY_DSN: enables Sentry; unset → no-op
+    - HIBI_RELEASE: release tag (default "dev"; set to git SHA in CI)
+    - HIBI_ENV: environment tag (default "production")
+    """
+    dsn = os.environ.get("SENTRY_DSN")
+    if not dsn:
+        log.info("sentry: SENTRY_DSN unset — pipeline observability disabled")
+        return False
+
+    sentry_sdk.init(
+        dsn=dsn,
+        release=os.environ.get("HIBI_RELEASE", "dev"),
+        environment=os.environ.get("HIBI_ENV", "production"),
+        # Pipeline is short-lived; traces add no value for batch jobs.
+        traces_sample_rate=0.0,
+        send_default_pii=False,
+        before_send=scrub_event,
+    )
+    sentry_sdk.set_tag("pipeline", "daily_news")
+    log.info("sentry: pipeline initialized")
+    return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ openai>=1.55.0
 feedparser>=6.0.10
 trafilatura>=1.12.0
 python-dotenv>=1.0.0
+sentry-sdk>=2.18

--- a/service/app/main.py
+++ b/service/app/main.py
@@ -8,6 +8,7 @@ from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 
 from . import db
+from .observability import init_sentry
 from .rate_limit import limiter
 from .routes import click
 from .settings import Settings
@@ -16,6 +17,15 @@ from .settings import Settings
 def _build_app(settings: Settings | None = None) -> FastAPI:
     settings = settings or Settings()
     logging.basicConfig(level=settings.log_level)
+
+    # Initialize Sentry before FastAPI so the integration can hook lifespan.
+    # No-op when SENTRY_DSN is unset (local dev, tests).
+    init_sentry(
+        settings.sentry_dsn,
+        release=settings.hibi_release,
+        environment=settings.hibi_env,
+        traces_sample_rate=settings.sentry_traces_sample_rate,
+    )
 
     @asynccontextmanager
     async def lifespan(_app: FastAPI):

--- a/service/app/observability.py
+++ b/service/app/observability.py
@@ -1,0 +1,79 @@
+"""Sentry initialization for the FastAPI service.
+
+`SENTRY_DSN` is optional — when unset, init_sentry() is a no-op so local
+dev / CI without secrets keeps working. PII is scrubbed defensively before
+events leave the process even though send_default_pii is False, because
+the click route may have IP and signed-URL query strings in breadcrumbs.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+import sentry_sdk
+from sentry_sdk.integrations.fastapi import FastApiIntegration
+from sentry_sdk.integrations.starlette import StarletteIntegration
+
+log = logging.getLogger(__name__)
+
+# Header keys that may carry a raw client IP. Sentry strips these when
+# send_default_pii=False, but we belt-and-suspenders in before_send too.
+_IP_HEADERS = ("x-forwarded-for", "cf-connecting-ip", "x-real-ip", "true-client-ip")
+
+
+def scrub_event(event: dict[str, Any], _hint: dict[str, Any]) -> Optional[dict[str, Any]]:
+    """before_send hook: drop raw IPs, cookies, and signed-URL query strings."""
+    request = event.get("request")
+    if isinstance(request, dict):
+        # Drop raw IP that Sentry's wsgi/asgi auto-collects.
+        env = request.get("env")
+        if isinstance(env, dict):
+            env.pop("REMOTE_ADDR", None)
+
+        headers = request.get("headers")
+        if isinstance(headers, dict):
+            for key in list(headers.keys()):
+                if key.lower() in _IP_HEADERS:
+                    headers.pop(key, None)
+
+        # Cookies can carry session tokens — drop entirely.
+        request.pop("cookies", None)
+
+        # Strip query string from URL so HMAC signatures don't leak.
+        url = request.get("url")
+        if isinstance(url, str) and "?" in url:
+            request["url"] = url.split("?", 1)[0]
+        request.pop("query_string", None)
+
+    user = event.get("user")
+    if isinstance(user, dict):
+        user.pop("ip_address", None)
+        user.pop("email", None)
+
+    return event
+
+
+def init_sentry(
+    dsn: Optional[str],
+    *,
+    release: str,
+    environment: str,
+    traces_sample_rate: float = 0.1,
+) -> bool:
+    """Initialize Sentry if a DSN is provided. Returns True if initialized."""
+    if not dsn:
+        log.info("sentry: SENTRY_DSN unset — observability disabled")
+        return False
+
+    sentry_sdk.init(
+        dsn=dsn,
+        integrations=[FastApiIntegration(), StarletteIntegration()],
+        release=release,
+        environment=environment,
+        traces_sample_rate=traces_sample_rate,
+        send_default_pii=False,
+        before_send=scrub_event,
+    )
+    log.info("sentry: initialized (env=%s release=%s)", environment, release)
+    return True

--- a/service/app/settings.py
+++ b/service/app/settings.py
@@ -26,3 +26,13 @@ class Settings(BaseSettings):
     # Rate limit for /r/{id}. Read from env at rate_limit.py import time;
     # kept here too so /health can echo it if needed later.
     click_rate_limit: str = "60/minute"
+
+    # Sentry. Optional — unset → no-op (local dev / CI without secrets).
+    sentry_dsn: str | None = None
+    # Release identifier (git SHA in CI, "dev" locally).
+    hibi_release: str = "dev"
+    # Sentry environment tag. Distinct from app_env so we can run in dev mode
+    # but still report to the production Sentry project if desired.
+    hibi_env: str = "production"
+    # Performance traces sample rate. Keep low to fit the free-tier quota.
+    sentry_traces_sample_rate: float = 0.1

--- a/service/pyproject.toml
+++ b/service/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pydantic-settings>=2.6",
     "psycopg[binary,pool]>=3.2",
     "slowapi>=0.1.9",
+    "sentry-sdk[fastapi]>=2.18",
 ]
 
 [dependency-groups]

--- a/service/tests/test_observability.py
+++ b/service/tests/test_observability.py
@@ -1,0 +1,106 @@
+"""Unit tests for the Sentry init + PII scrubber.
+
+We do NOT want real Sentry traffic in tests, so init is only exercised
+through scrub_event() directly (no DSN) plus a single init/no-init path
+check via monkeypatch.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from app.observability import init_sentry, scrub_event
+
+
+def _evt(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "request": {
+            "env": {"REMOTE_ADDR": "203.0.113.42"},
+            "headers": {
+                "X-Forwarded-For": "203.0.113.42, 198.51.100.7",
+                "CF-Connecting-IP": "203.0.113.42",
+                "User-Agent": "Mozilla/5.0",
+            },
+            "cookies": {"session": "secret-token"},
+            "url": "https://api.hibi-news.com/r/abc123?s=hmac-sig-value",
+            "query_string": "s=hmac-sig-value",
+        },
+        "user": {
+            "ip_address": "203.0.113.42",
+            "email": "kazuki.castle0418@gmail.com",
+            "id": "00000000-0000-0000-0000-000000000001",
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def test_scrub_removes_remote_addr_from_env() -> None:
+    out = scrub_event(_evt(), {})
+    assert out is not None
+    assert "REMOTE_ADDR" not in out["request"]["env"]
+
+
+def test_scrub_removes_ip_headers_case_insensitive() -> None:
+    out = scrub_event(_evt(), {})
+    assert out is not None
+    headers = out["request"]["headers"]
+    assert "X-Forwarded-For" not in headers
+    assert "CF-Connecting-IP" not in headers
+    # Benign headers survive — User-Agent is useful for triage.
+    assert headers.get("User-Agent") == "Mozilla/5.0"
+
+
+def test_scrub_drops_cookies_entirely() -> None:
+    out = scrub_event(_evt(), {})
+    assert out is not None
+    assert "cookies" not in out["request"]
+
+
+def test_scrub_strips_query_string_from_url() -> None:
+    """HMAC signatures must not leave the process."""
+    out = scrub_event(_evt(), {})
+    assert out is not None
+    assert out["request"]["url"] == "https://api.hibi-news.com/r/abc123"
+    assert "query_string" not in out["request"]
+
+
+def test_scrub_removes_user_ip_and_email_but_keeps_id() -> None:
+    out = scrub_event(_evt(), {})
+    assert out is not None
+    user = out["user"]
+    assert "ip_address" not in user
+    assert "email" not in user
+    assert user["id"] == "00000000-0000-0000-0000-000000000001"
+
+
+def test_scrub_handles_event_without_request_or_user() -> None:
+    """Defensive: event shape varies (exceptions outside a request scope)."""
+    out = scrub_event({"message": "boom"}, {})
+    assert out == {"message": "boom"}
+
+
+def test_init_sentry_returns_false_when_dsn_missing() -> None:
+    assert init_sentry(None, release="dev", environment="test") is False
+    assert init_sentry("", release="dev", environment="test") is False
+
+
+def test_init_sentry_calls_sdk_init_when_dsn_present() -> None:
+    with patch("app.observability.sentry_sdk.init") as mock_init:
+        ok = init_sentry(
+            "https://key@sentry.io/123",
+            release="abc123",
+            environment="production",
+            traces_sample_rate=0.05,
+        )
+
+    assert ok is True
+    mock_init.assert_called_once()
+    kwargs = mock_init.call_args.kwargs
+    assert kwargs["dsn"] == "https://key@sentry.io/123"
+    assert kwargs["release"] == "abc123"
+    assert kwargs["environment"] == "production"
+    assert kwargs["traces_sample_rate"] == 0.05
+    assert kwargs["send_default_pii"] is False
+    assert kwargs["before_send"] is scrub_event

--- a/service/uv.lock
+++ b/service/uv.lock
@@ -207,6 +207,7 @@ dependencies = [
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "slowapi" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -223,6 +224,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2" },
     { name = "pydantic", specifier = ">=2.9" },
     { name = "pydantic-settings", specifier = ">=2.6" },
+    { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.18" },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
 ]
@@ -500,6 +502,24 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.60.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/a2/2e6c090db384cc515069f4f85542bd5baf6786852073020ea73d4a76d3ea/sentry_sdk-2.60.0.tar.gz", hash = "sha256:0bd25e54e78ca02d0be512529fa644bbbf9e8470d7b26371294012d4ca93c978", size = 452946, upload-time = "2026-05-13T13:34:52.516Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/41/f2b800b7f12a05dd48c2a6280d4dd812d1425fc66ed3fe3fd99420c41d1a/sentry_sdk-2.60.0-py3-none-any.whl", hash = "sha256:28a536c03291c8bcb363cf35c611b32738ec118ff64d8d6383b096448ac4c803", size = 475616, upload-time = "2026-05-13T13:34:50.259Z" },
+]
+
+[package.optional-dependencies]
+fastapi = [
+    { name = "fastapi" },
+]
+
+[[package]]
 name = "slowapi"
 version = "0.1.9"
 source = { registry = "https://pypi.org/simple" }
@@ -552,6 +572,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,112 @@
+"""Unit tests for the pipeline-side Sentry scrubber + init switch."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from observability import _redact_emails, init_sentry_from_env, scrub_event
+
+
+def test_redact_emails_replaces_all_addresses() -> None:
+    text = "send to kazuki@example.com failed; also a@b.co bounced"
+    out = _redact_emails(text)
+    assert "kazuki@example.com" not in out
+    assert "a@b.co" not in out
+    assert out.count("[redacted-email]") == 2
+
+
+def test_redact_emails_passes_text_without_addresses() -> None:
+    assert _redact_emails("nothing here") == "nothing here"
+
+
+def test_scrub_event_redacts_message() -> None:
+    event: dict[str, Any] = {"message": "SMTP failed for kazuki@example.com"}
+    out = scrub_event(event, {})
+    assert out is not None
+    assert out["message"] == "SMTP failed for [redacted-email]"
+
+
+def test_scrub_event_redacts_exception_value() -> None:
+    event: dict[str, Any] = {
+        "exception": {
+            "values": [
+                {"type": "SMTPError", "value": "Bad recipient kazuki@example.com"}
+            ]
+        }
+    }
+    out = scrub_event(event, {})
+    assert out is not None
+    val = out["exception"]["values"][0]["value"]
+    assert "kazuki@example.com" not in val
+    assert "[redacted-email]" in val
+
+
+def test_scrub_event_redacts_breadcrumb_message() -> None:
+    event: dict[str, Any] = {
+        "breadcrumbs": {
+            "values": [
+                {"message": "to=kazuki@example.com"},
+                {"message": "no email here"},
+            ]
+        }
+    }
+    out = scrub_event(event, {})
+    assert out is not None
+    crumbs = out["breadcrumbs"]["values"]
+    assert "[redacted-email]" in crumbs[0]["message"]
+    assert crumbs[1]["message"] == "no email here"
+
+
+def test_scrub_event_handles_minimal_event_shape() -> None:
+    assert scrub_event({"level": "error"}, {}) == {"level": "error"}
+
+
+@pytest.fixture
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in ("SENTRY_DSN", "HIBI_RELEASE", "HIBI_ENV"):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_init_returns_false_when_dsn_missing(clean_env: None) -> None:
+    assert init_sentry_from_env() is False
+
+
+def test_init_calls_sdk_init_with_env_values(
+    monkeypatch: pytest.MonkeyPatch, clean_env: None
+) -> None:
+    monkeypatch.setenv("SENTRY_DSN", "https://key@sentry.io/42")
+    monkeypatch.setenv("HIBI_RELEASE", "abc123")
+    monkeypatch.setenv("HIBI_ENV", "production")
+
+    with patch("observability.sentry_sdk.init") as mock_init, patch(
+        "observability.sentry_sdk.set_tag"
+    ) as mock_tag:
+        ok = init_sentry_from_env()
+
+    assert ok is True
+    mock_init.assert_called_once()
+    kwargs = mock_init.call_args.kwargs
+    assert kwargs["dsn"] == "https://key@sentry.io/42"
+    assert kwargs["release"] == "abc123"
+    assert kwargs["environment"] == "production"
+    assert kwargs["traces_sample_rate"] == 0.0
+    assert kwargs["send_default_pii"] is False
+    assert kwargs["before_send"] is scrub_event
+    mock_tag.assert_called_once_with("pipeline", "daily_news")
+
+
+def test_init_defaults_release_and_env_when_unset(
+    monkeypatch: pytest.MonkeyPatch, clean_env: None
+) -> None:
+    monkeypatch.setenv("SENTRY_DSN", "https://key@sentry.io/42")
+    with patch("observability.sentry_sdk.init") as mock_init, patch(
+        "observability.sentry_sdk.set_tag"
+    ):
+        init_sentry_from_env()
+    kwargs = mock_init.call_args.kwargs
+    assert kwargs["release"] == "dev"
+    assert kwargs["environment"] == "production"


### PR DESCRIPTION
## Summary

- `service/app/` (FastAPI) と `daily_news.py` (cron pipeline) の両方に Sentry を導入
- `SENTRY_DSN` が未設定なら no-op（ローカル dev / 既存 CI が壊れない）
- service と pipeline は依存ツリー別なので各々独立に `observability.py` を持つ
- PII スクラバーは両方とも `before_send` で防御:
  - **service**: 生 IP / `cf-connecting-ip` 等 / cookie / クエリ文字列（HMAC 署名漏洩防止）を落とす
  - **pipeline**: メッセージ・例外 value・breadcrumb 内のメールアドレスを `[redacted-email]` に置換
- pipeline 側は `sentry_sdk.flush(timeout=5)` を finally で呼ぶ（GH Actions runner shutdown で取りこぼし回避）
- traces サンプル: service=0.1, pipeline=0.0（cron 短命ジョブで transaction は不要）

## What's NOT in this PR

- Sentry side の project 作成は手動（MCP に create_project が無いため）。下記「マージ後の手動作業」参照
- Manager (`manager/`) への導入は Phase 2（別 issue）
- Slack/Discord alert ルール、performance dashboard は Phase 2

## Test plan

- [x] `pytest service/tests/` 全 **31 件 PASS**（新規 8 件: scrubber 各種 + init 分岐 / 既存 23 件無回帰）
- [x] `pytest tests/test_observability.py tests/test_email_template.py` 全 **27 件 PASS**（新規 9 件 / 既存 18 件無回帰）
- [x] `daily_news.py` / `observability.py` syntax OK
- [x] `SENTRY_DSN` を空にして `init_sentry_from_env()` が `False` 返却（no-op 検証）
- [x] 既存 PR #91 で導入した click handler の cold-start fallback も合わせて変わらず PASS

## マージ後の手動作業（受け入れ条件の残り）

`SENTRY_DSN` 未設定では Sentry が動かないので、以下を済ませて初めて #89 完了:

1. https://kazuki-0418.sentry.io で Python project を作成（推奨名: \`hibi\`、もしくは分けるなら \`hibi-service\` + \`hibi-pipeline\`）
2. DSN を控える
3. GitHub Secrets (\`kazuki-0418/hibi\`) に \`SENTRY_DSN\` を追加 → 翌朝の cron で pipeline 側が有効化
4. homelab \`/opt/ops/env/hibi/api.env\` に \`SENTRY_DSN\` / \`HIBI_RELEASE\` / \`HIBI_ENV=production\` を追加 → service 再起動で有効化
5. Smoke test:
   - pipeline: 一時的に \`daily_news.py\` で \`raise RuntimeError(\"sentry smoke\")\` → Sentry に届くこと確認 → revert
   - service: \`/r/{bad-uuid}\` 等で意図的にエラー発生 or 一時 endpoint で \`raise\`

## 関連

- Closes #89 (Phase 1)
- 後追い: #88 (Sentry があれば自動検知できた事象), #12 (Actions 失敗通知の上位互換)

🤖 Generated with [Claude Code](https://claude.com/claude-code)