### PR TITLE
feat(ci): auto-deploy hibi-api to homelab on main push

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,13 +1,21 @@
 name: Build and Push Service Image
 
 on:
+  # Versioned releases publish images without auto-deploying — homelab
+  # operators decide when to roll forward by re-pointing HIBI_API_TAG.
   push:
-    branches: [main]
     tags: ["v*.*.*"]
-    paths:
-      - "service/**"
-      - ".github/workflows/build-and-push.yml"
+  # Manual rebuild when iterating on the workflow itself.
   workflow_dispatch:
+  # Reusable from the orchestrator (which adds deploy after build).
+  workflow_call:
+    outputs:
+      image_tag:
+        description: "Tag of the freshly-published image, e.g. sha-<long-sha>"
+        value: ${{ jobs.build-and-push.outputs.image_tag }}
+      image_ref:
+        description: "Fully-qualified image ref pinned to the SHA tag"
+        value: ${{ jobs.build-and-push.outputs.image_ref }}
 
 env:
   REGISTRY: ghcr.io
@@ -21,6 +29,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      image_tag: ${{ steps.pin.outputs.image_tag }}
+      image_ref: ${{ steps.pin.outputs.image_ref }}
 
     steps:
       - uses: actions/checkout@v4
@@ -56,3 +67,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Pin image to SHA tag for downstream deploy
+        id: pin
+        run: |
+          TAG="sha-${GITHUB_SHA}"
+          echo "image_tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "image_ref=${REGISTRY}/${IMAGE_NAME}:${TAG}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,74 @@
+name: Deploy to homelab
+
+on:
+  workflow_call:
+    inputs:
+      image_tag:
+        description: "Image tag to deploy (e.g. sha-<long-sha>). Written to /opt/ops/.env.deploy as HIBI_API_TAG."
+        required: true
+        type: string
+      image_ref:
+        description: "Fully-qualified image ref, used only for logging."
+        required: false
+        type: string
+        default: ""
+      commit_sha:
+        required: true
+        type: string
+
+jobs:
+  deploy:
+    # Pinned to the hibi-labelled runner so monogatari's deploys are not
+    # blocked while this one runs (and vice-versa).
+    runs-on: [self-hosted, hibi]
+
+    steps:
+      - name: Update HIBI_API_TAG in /opt/ops/.env.deploy
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          set -euo pipefail
+          ENV_FILE="/opt/ops/.env.deploy"
+
+          # Create the file on first run; preserve any existing lines
+          # (MONOGATARI_*_TAG etc.) on subsequent runs.
+          touch "${ENV_FILE}"
+
+          # Drop any prior HIBI_API_TAG=... line, then append the new one.
+          # Use a tmpfile + mv for atomicity.
+          tmp="$(mktemp)"
+          grep -v '^HIBI_API_TAG=' "${ENV_FILE}" > "${tmp}" || true
+          echo "HIBI_API_TAG=${IMAGE_TAG}" >> "${tmp}"
+          mv "${tmp}" "${ENV_FILE}"
+
+          echo "=== ${ENV_FILE} (after update) ==="
+          cat "${ENV_FILE}"
+
+      - name: make deploy-hibi
+        run: |
+          cd /opt/ops
+          make deploy-hibi
+
+      - name: Verify /health via Cloudflare-fronted URL
+        run: |
+          set -euo pipefail
+          # Give Cloudflare/cloudflared a moment to pick up the new container.
+          for i in 1 2 3 4 5; do
+            if curl -fsS https://api.hibi-news.com/health > /tmp/hibi_health.json; then
+              echo "health OK on attempt ${i}:"
+              cat /tmp/hibi_health.json
+              exit 0
+            fi
+            echo "health check ${i} failed; retrying..."
+            sleep 5
+          done
+          echo "health check failed after 5 attempts" >&2
+          exit 1
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "### Deploy ${{ inputs.commit_sha }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- image_tag: \`${{ inputs.image_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- image_ref: \`${{ inputs.image_ref }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -1,0 +1,32 @@
+name: Hibi Orchestrator
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "service/**"
+      - ".github/workflows/build-and-push.yml"
+      - ".github/workflows/deploy.yml"
+      - ".github/workflows/orchestrator.yml"
+  # Manual rerun (e.g. after rolling back homelab or rotating Sentry DSN).
+  workflow_dispatch:
+
+# Only one deploy at a time; cancel earlier in-flight runs targeting the
+# same ref so a quick succession of merges does not interleave.
+concurrency:
+  group: hibi-prod-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-and-push.yml
+    secrets: inherit
+
+  deploy:
+    needs: build
+    uses: ./.github/workflows/deploy.yml
+    with:
+      image_tag: ${{ needs.build.outputs.image_tag }}
+      image_ref: ${{ needs.build.outputs.image_ref }}
+      commit_sha: ${{ github.sha }}
+    secrets: inherit

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,10 +1,9 @@
 # Homelab deploy
 
-Personal AI Newspaper's FastAPI service is shipped as a private GHCR image and
-fronted by a Cloudflare Tunnel. The homelab never opens inbound ports: the
-outbound `cloudflared` daemon terminates the tunnel at Cloudflare's edge, and
-Cloudflare proxies traffic to the local `fastapi` container over the internal
-Docker network.
+Hibi's FastAPI service is shipped as a private GHCR image and fronted by a
+Cloudflare Tunnel. **Main-branch pushes auto-deploy to the homelab** via a
+self-hosted GitHub Actions runner — no manual `docker compose pull` needed in
+the normal path.
 
 ```
 Internet
@@ -13,116 +12,127 @@ Cloudflare Edge (TLS + WAF)
   │ Argo Tunnel (outbound, encrypted)
 cloudflared container
   │ docker network "internal"
-fastapi container :8000  (no host port binding)
+nginx → hibi-api :8000  (no host port binding)
 ```
 
-## Prerequisites
+## Auto-deploy pipeline
 
-- A Cloudflare account with the target domain onboarded as a zone.
-- Docker + `docker compose` on the homelab host.
-- A GitHub PAT with `read:packages` scope, if the GHCR image is private.
+Triggered by `push` to `main` that touches `service/**` or a deploy-related
+workflow file. The orchestrator runs:
 
-## 1. Create the Cloudflare Tunnel
-
-1. In Cloudflare's **Zero Trust** dashboard: **Networks → Tunnels → Create tunnel**.
-2. Connector type: **Cloudflared**. Tunnel name: `personal-newspaper`.
-3. On the **Install connector** step, copy the generated token — this is the
-   `TUNNEL_TOKEN` value used below. Do not click through the install command;
-   `docker compose` brings up `cloudflared` with the token instead.
-4. **Public Hostnames** tab → **Add a public hostname**:
-   - Subdomain: `newspaper`
-   - Domain: your Cloudflare-managed domain
-   - Type: `HTTP`
-   - URL: `fastapi:8000`  (Docker service DNS, not `localhost`)
-5. Save. Cloudflare creates the DNS record automatically; no registrar work
-   needed.
-
-## 2. Log in to GHCR (one-time, if image is private)
-
-```bash
-echo "$GITHUB_PAT" | docker login ghcr.io -u <github-username> --password-stdin
+```
+push to main (service/** changed)
+  │
+orchestrator.yml (ubuntu-latest)
+  ├─ build-and-push.yml   →  ghcr.io/<owner>/hibi-api:sha-<long-sha>
+  └─ deploy.yml (self-hosted runner on homelab)
+        ├─ /opt/ops/.env.deploy ← HIBI_API_TAG=sha-<long-sha>
+        ├─ cd /opt/ops && make deploy-hibi
+        └─ curl https://api.hibi-news.com/health (retry up to 5×)
 ```
 
-Store the PAT somewhere the host user can re-read on rotation (e.g. a pass
-entry) — the credential helper caches it in `~/.docker/config.json`.
+Concurrency group `hibi-prod-${ref}` cancels in-flight runs when a newer
+commit lands so deploys never interleave.
 
-## 3. Populate `secrets.env`
+`sha-*` tagging pins each deploy to its exact build (the same image identity
+flows into `HIBI_RELEASE` for Sentry via the image's env). `:latest` is still
+pushed for ad-hoc operations but is not what production normally runs.
 
-Clone the repo (or just copy `docker-compose.yml` and `secrets.env.example`):
+## One-time prerequisites
+
+These are recorded for reference; they have already been done for this repo.
+
+### Cloudflare Tunnel
+
+1. Cloudflare **Zero Trust → Networks → Tunnels → Create tunnel**.
+2. Connector type: **Cloudflared**. Reuse the existing homelab tunnel.
+3. **Public Hostnames** → **Add a public hostname**:
+   - Subdomain: `api`, Domain: `hibi-news.com`
+   - Type: `HTTP`, URL: `nginx:80` (nginx fronts hibi-api over the internal
+     Docker network and adds the `X-Forwarded-*` headers FastAPI needs).
+
+### Self-hosted runner on homelab
+
+1. https://github.com/<owner>/hibi/settings/actions/runners → **New
+   self-hosted runner** (Linux x64).
+2. On the homelab box:
+   ```bash
+   mkdir -p ~/actions-runner-hibi && cd ~/actions-runner-hibi
+   curl -o actions-runner.tar.gz -L <URL from GitHub install page>
+   tar xzf actions-runner.tar.gz
+   ./config.sh --url https://github.com/<owner>/hibi \
+               --token <one-shot token from the install page> \
+               --name homelab-hibi \
+               --labels self-hosted,hibi \
+               --unattended
+   sudo ./svc.sh install
+   sudo ./svc.sh start
+   ```
+3. Runner appears as `Idle` (green) on the Actions runners page. The deploy
+   workflow targets `runs-on: [self-hosted, hibi]` so it never lands on the
+   monogatari runner.
+
+### `/opt/ops/` on homelab
+
+The compose stack and Makefile live under `/opt/ops/` and are shared with
+monogatari. Required pieces specific to hibi:
+
+- `compose.yml` (or `docker-compose.yml`) declares `hibi-api` with
+  `image: ghcr.io/<owner>/hibi-api:${HIBI_API_TAG:-latest}` and a Python-based
+  healthcheck (slim images do not ship `wget`).
+- `nginx/conf.d/hibi.conf` proxies `api.hibi-news.com` → `hibi-api:8000`
+  with `X-Forwarded-*` and `proxy_redirect off` (the click route 302s to
+  external URLs).
+- `env/hibi/api.env` carries `CLICK_SIGNING_SECRET`, `DATABASE_URL`,
+  `PUBLIC_BASE_URL`, `IP_SALT`, `SENTRY_DSN`, `HIBI_RELEASE`, `HIBI_ENV`,
+  etc. `chmod 600` and keep out of git.
+- `Makefile` has `deploy-hibi` (`pull-hibi` → `up-hibi` → `clean-images`).
+
+## Manual override (rollback / red button)
 
 ```bash
-git clone https://github.com/kazuki-0418/Personal-Daily-News.git
-cd Personal-Daily-News
-cp secrets.env.example secrets.env
-chmod 600 secrets.env
-$EDITOR secrets.env   # paste TUNNEL_TOKEN from step 1
+ssh homelab
+cd /opt/ops
+
+# Point at a known-good SHA (any tag the registry has).
+sed -i '/^HIBI_API_TAG=/d' .env.deploy
+echo "HIBI_API_TAG=sha-<known-good-long-sha>" >> .env.deploy
+make deploy-hibi
 ```
 
-`secrets.env` is `.gitignore`d — never commit it.
+`/opt/ops/.env.deploy` is the single source of truth for which image is
+running; the workflow only edits its own `HIBI_API_TAG=` line and leaves
+sibling lines (`FRONT_TAG`, `BACK_TAG`, etc.) untouched.
 
-## 4. Bring the stack up
-
-```bash
-docker compose pull
-docker compose up -d
-docker compose ps
-```
-
-Expected result:
-
-| container                           | PORTS  |
-| ----------------------------------- | ------ |
-| `hibi-fastapi`                      | *(empty — no host bind)* |
-| `hibi-cloudflared`                  | *(empty)* |
-
-## 5. Verify
+## Verifying a deploy
 
 ```bash
-# From the homelab, via docker network:
-docker compose exec cloudflared wget -qO- http://fastapi:8000/health
-
-# From anywhere on the internet, via the tunnel:
-curl https://newspaper.<your-domain>/health
+# From any client:
+curl https://api.hibi-news.com/health
 # → {"status":"ok","version":"0.1.0"}
-```
 
-Sanity check: stop `cloudflared` and confirm the public URL goes 5xx while
-the `fastapi` container stays healthy — the service is reachable only via the
-tunnel.
-
-```bash
-docker compose stop cloudflared
-curl -I https://newspaper.<your-domain>/health   # 5xx expected
-docker compose start cloudflared
-```
-
-## 6. Router / firewall
-
-Leave inbound 80/443 **closed** on the home router. `cloudflared` establishes
-outbound connections to Cloudflare on 443 only. No port forwarding required.
-
-## Upgrades
-
-```bash
-docker compose pull     # pulls :latest from GHCR
-docker compose up -d    # recreates containers whose image digest changed
+# On homelab:
+docker compose ps hibi-api          # expect Up ... (healthy)
+docker compose logs --tail=50 hibi-api
 ```
 
 ## Troubleshooting
 
-- `cloudflared` keeps restarting → `docker compose logs cloudflared`. Most
-  often a stale / revoked `TUNNEL_TOKEN`; re-generate in Zero Trust and
-  update `secrets.env`.
-- Public URL returns 502 → the hostname route points at `fastapi:8000` but
-  the container isn't healthy yet. `docker compose ps` should show `fastapi`
-  as `healthy` before Cloudflare serves traffic.
-- `docker pull` from GHCR 403s → PAT missing `read:packages` or the package
-  visibility hasn't been flipped to allow the account. Re-run `docker login`.
+- `deploy.yml` fails at "Verify /health": container started but
+  `api.hibi-news.com` 5xx → check `nginx` logs first (`docker compose logs
+  nginx`), then `cloudflared`. If nginx is healthy and hibi-api is healthy,
+  Cloudflare's tunnel routing may have been edited.
+- `make deploy-hibi` fails on the self-hosted runner: the runner user needs
+  rights to read `/opt/ops/.env.deploy` and to run `docker compose`. Confirm
+  with `sudo ./svc.sh status` and a manual `make pull-hibi` as the runner
+  user.
+- `docker pull` from GHCR 403s → the runner user needs a PAT with
+  `read:packages` cached in `~/.docker/config.json`. `docker login ghcr.io`
+  once on the host.
 
-## Access policies (future)
+## Future work
 
-Cloudflare Access is not enabled yet. Click-tracking endpoints (`/r/*`, once
-they land) stay public because they're hit from email clients. Management or
-admin endpoints added later should be gated by a Zero Trust Access
-application (email allowlist). Track under the relevant follow-up issue
-before shipping any admin surface.
+Cloudflare Access is not enabled yet. Click-tracking endpoints (`/r/*`) stay
+public because they're hit from email clients. Any admin surface added later
+should be gated by a Zero Trust Access application — track under a separate
+issue.


### PR DESCRIPTION
## Summary

`push` to `main` that touches `service/**` (or any of the deploy workflows themselves) now builds & publishes a SHA-pinned image to GHCR, then immediately rolls homelab forward via the `homelab-hibi` self-hosted runner. Mirrors monogatari's orchestrator pattern.

```
push to main (service/** changed)
  ↓
orchestrator.yml (ubuntu-latest)
  ├─ build-and-push.yml   → ghcr.io/.../hibi-api:sha-<long-sha>
  └─ deploy.yml (runs-on: [self-hosted, hibi])
        ├─ rewrite ONLY HIBI_API_TAG=... in /opt/ops/.env.deploy
        ├─ cd /opt/ops && make deploy-hibi
        └─ curl https://api.hibi-news.com/health (retry up to 5×)
```

## Files

- `.github/workflows/build-and-push.yml`: converted to `workflow_call` reusable, exposes `image_tag` + `image_ref` outputs. Direct push trigger restricted to semver tags (`v*.*.*`) so version cuts still publish without deploying.
- `.github/workflows/deploy.yml` (new): runs on `[self-hosted, hibi]`. Updates only the `HIBI_API_TAG=` line in `/opt/ops/.env.deploy` (`MONOGATARI_*_TAG` etc. preserved). Runs `make deploy-hibi`. Post-deploy health check gates success.
- `.github/workflows/orchestrator.yml` (new): triggered by `push: branches: [main]` with `paths: service/**, .github/workflows/{build-and-push,deploy,orchestrator}.yml`. `concurrency: hibi-prod-${ref}, cancel-in-progress: true` so quick-succession merges do not interleave.
- `docs/deploy.md`: rewritten around the auto-deploy flow. Manual `docker compose pull/up` demoted to a "rollback / red button" section.

## Homelab prerequisites (already done)

- [x] Self-hosted runner `homelab-hibi` registered with labels `self-hosted,hibi` — Idle on GitHub Settings → Actions → Runners
- [x] `/opt/ops/compose.yml` has `hibi-api` with `image: ghcr.io/.../hibi-api:${HIBI_API_TAG:-latest}` and a Python-based healthcheck (slim image has no `wget`)
- [x] `/opt/ops/Makefile` has `pull-hibi` / `up-hibi` / `deploy-hibi` / `logs-hibi-api`
- [x] `nginx/conf.d/hibi.conf` proxies `api.hibi-news.com` → `hibi-api:8000`
- [x] Cloudflare Tunnel hostname `api.hibi-news.com` → `nginx:80`

## Test plan

- [x] YAML parse OK for all three workflows
- [ ] After merge: first run of orchestrator on main publishes a SHA-tagged image to GHCR and `homelab-hibi` runner picks up the deploy job
- [ ] `/opt/ops/.env.deploy` shows `HIBI_API_TAG=sha-<this-merge-sha>` while keeping `MONOGATARI_*_TAG` lines untouched
- [ ] `curl https://api.hibi-news.com/health` returns 200 within 5 retries
- [ ] `docker compose ps hibi-api` on homelab shows the new SHA in the image column and status `Up ... (healthy)`

## Out of scope / follow-ups

- n8n deploy webhook (monogatari sends one; this PR omits — easy to add later if desired)
- Baking `HIBI_RELEASE` into the image at build time via Dockerfile `ARG/ENV` so Sentry release tagging is fully automated. Currently `HIBI_RELEASE` is set via `/opt/ops/env/hibi/api.env` and must be updated on rollouts; small follow-up to make it match the image's `sha-` tag automatically.
- The first orchestrator run will pull from GHCR; if `docker login` is missing on the runner host, the deploy step fails fast and surfaces the error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)