### PR TITLE
fix(ci): grant packages:write on orchestrator so build-and-push can push

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -17,6 +17,13 @@ concurrency:
   group: hibi-prod-${{ github.ref }}
   cancel-in-progress: true
 
+# Reusable workflows can only narrow the parent's permission set, so the
+# orchestrator must grant the union of what its children need. The deploy
+# job runs on a self-hosted runner and uses nothing from GITHUB_TOKEN.
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     uses: ./.github/workflows/build-and-push.yml


### PR DESCRIPTION
## Summary

The first orchestrator run after merging #93 failed with:

> The nested job 'build-and-push' is requesting 'packages: write', but is only allowed 'packages: read'.

Reusable workflows can only narrow the parent's permission set. `build-and-push.yml` declares `packages: write` at job level, but the orchestrator didn't grant it, so GitHub rejected the `uses:` call before any job started.

This PR adds a top-level `permissions:` block to `orchestrator.yml`:

\`\`\`yaml
permissions:
  contents: read
  packages: write
\`\`\`

`contents:read` is also declared explicitly to prevent the implicit default from creeping wider over time. The deploy job runs on the self-hosted runner and uses nothing from `GITHUB_TOKEN`, so no extra scopes are needed.

## Test plan

After merge, this very merge commit modifies `.github/workflows/orchestrator.yml` which matches the orchestrator's `paths:` filter, so the orchestrator re-fires immediately and we can observe whether build + deploy now go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)