### PR TITLE
chore(observability): bake HIBI_RELEASE into image at build time

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -65,6 +65,11 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Bake the commit SHA into the image so Sentry release matches
+          # the image identity without operator intervention. See
+          # service/Dockerfile ARG HIBI_RELEASE.
+          build-args: |
+            HIBI_RELEASE=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -21,9 +21,16 @@ RUN uv sync --frozen --no-install-project --no-dev
 
 FROM python:3.12-slim AS runtime
 
+# Release identifier baked into the image at build time. The CI workflow
+# passes the commit SHA via --build-arg, so every image tagged sha-<sha>
+# also reports release=<sha> to Sentry without operator action. Falls back
+# to "dev" for local docker build invocations.
+ARG HIBI_RELEASE=dev
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PATH="/opt/venv/bin:$PATH"
+    PATH="/opt/venv/bin:$PATH" \
+    HIBI_RELEASE=${HIBI_RELEASE}
 
 RUN groupadd --system --gid 10001 appuser \
  && useradd --system --uid 10001 --gid 10001 --home-dir /app --shell /usr/sbin/nologin appuser


### PR DESCRIPTION
## Summary

Currently \`HIBI_RELEASE\` has to be set manually in \`/opt/ops/env/hibi/api.env\` on each rollout. In practice the placeholder \`<git SHA or タグ>\` was left as-is, which would have made Sentry's release dashboard meaningless.

This PR bakes the release into the image at build time so every \`sha-<sha>\` image self-identifies to Sentry with that same SHA — no operator action per deploy.

## Changes

\`\`\`dockerfile
# service/Dockerfile — runtime stage
ARG HIBI_RELEASE=dev
ENV ... HIBI_RELEASE=\${HIBI_RELEASE}
\`\`\`

\`\`\`yaml
# .github/workflows/build-and-push.yml — Build and push step
build-args: |
  HIBI_RELEASE=\${{ github.sha }}
\`\`\`

## ⚠️ Required homelab change after merge

\`env_file\` entries **override** image \`ENV\` values. The current
\`/opt/ops/env/hibi/api.env\` has a line like:

\`\`\`
HIBI_RELEASE=<git SHA or タグ>
\`\`\`

That literal placeholder wins over the image-baked SHA. After this PR lands:

\`\`\`bash
ssh homelab
sed -i '/^HIBI_RELEASE=/d' /opt/ops/env/hibi/api.env
\`\`\`

Then the next orchestrator deploy (which fires automatically on this PR's merge commit since it touches \`service/Dockerfile\`) will roll out a new \`sha-<sha>\` image whose \`HIBI_RELEASE\` env equals \`<sha>\`. Confirm via:

\`\`\`bash
docker compose exec hibi-api env | grep HIBI_RELEASE
\`\`\`

## Test plan

- [x] Dockerfile parses (build will validate at CI time)
- [x] YAML parses
- [ ] After merge: orchestrator publishes a new image, deploy verifies \`/health\`
- [ ] On homelab, drop \`HIBI_RELEASE=\` line from \`api.env\`, then \`docker compose exec hibi-api env | grep HIBI_RELEASE\` shows the merge commit SHA
- [ ] Next Sentry event from \`hibi-api\` shows up under release \`<merge-commit-sha>\` in the Sentry releases dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)