### PR TITLE
feat(design): adopt design-system tokens as shared source of truth (#50)

### DIFF
--- a/.claude/skills/hibi-design
+++ b/.claude/skills/hibi-design
@@ -1,0 +1,1 @@
+../../design-system

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# Hibi (日々)
+
+A personal AI newspaper. A cron at 13:17 UTC fetches curated YouTube channels
+and RSS feeds, has Claude summarize the best five stories in Japanese, and
+emails the digest to a single recipient. The same articles are surfaced as
+an archive on `hibi-news.com`.
+
+## Layout overview
+
+- `daily_news.py` — pipeline entry point (fetch → rank → summarize → save → mail).
+- `service/` — FastAPI click-tracking service, deployed to homelab via
+  GHCR + self-hosted runner + nginx + Cloudflare Tunnel.
+- `manager/` — code-driven state machine that orchestrates the project's
+  slash-command sub-agents. Has its own rules in `.claude/rules/manager-agent.md`.
+- `design-system/` — brand guide + tokens + UI kits (see "Design system" below).
+- `web/` — Astro site for the public archive on hibi-news.com.
+
+## Agent rules
+
+Role-specific guardrails live next door — read the one that matches the work:
+
+- `.claude/rules/dev-agent.md` — implementation tasks (Python, migrations, workflows).
+- `.claude/rules/test-agent.md` — tests under `tests/**` and `conftest.py`.
+- `.claude/rules/spec-agent.md` — requirements / planning before non-trivial code.
+- `.claude/rules/manager-agent.md` — anything inside `manager/`.
+
+Project-wide non-negotiables (also re-stated in each file):
+- Type hints required; no `Any` / `# type: ignore` escape hatches.
+- psycopg 3.x only — no psycopg2 / SQLAlchemy / Alembic.
+- No async or concurrency in the daily pipeline (single epic = single process).
+- Migrations are additive; never edit an existing migration file.
+- Secrets stay in `.env` (or homelab `/opt/ops/env/hibi/api.env`); never in code or commit messages.
+
+## Design system — single source of truth
+
+`design-system/` is the only place that owns brand decisions. The skill
+`/hibi-design` (symlinked from `.claude/skills/hibi-design/`) loads the same
+files Claude sees here.
+
+**Tokens** (colors, spacing, fonts, radii, line-heights) come from exactly
+one file:
+
+```
+design-system/colors_and_type.css
+```
+
+When implementing UI:
+- Reference these tokens via the CSS custom properties they define
+  (`--bg-primary`, `--text-primary`, `--font-jp`, `--space-N`, ...).
+- For email, inline the relevant tokens into the template; for web, link
+  the file directly.
+- **Do not redefine** tokens (color hex, font family, spacing scale) in
+  other files. If a token needs to change, edit `colors_and_type.css` and
+  let every surface inherit.
+- Do not introduce new tokens without first putting them in this file.
+
+Non-negotiable visual rules (Japanese minimalist) live in
+`design-system/README.md` — read it before any work touching email
+templates, web pages, or marketing surfaces:
+
+- Grayscale (7 values) only — no saturated color, no gradients, no emoji.
+- Hairline rules (`1px solid #E8E6E1`) instead of cards / shadows.
+- Noto Sans JP for body/headings, Noto Serif JP for display, Inter for
+  Latin labels.
+- Voice & tone: third-person, observational; no exclamation marks,
+  no marketing CTAs, no second-person address.
+
+Detailed guidance, UI kits, and assets are inside `design-system/`; that
+directory is the SSoT, and `/hibi-design` exposes it to Claude Code.
+
+## Auto-deploy (FYI)
+
+A push to `main` that touches `service/**` builds a SHA-pinned image
+(`ghcr.io/kazuki-0418/hibi-api:sha-<sha>`), and the homelab self-hosted
+runner rolls forward via `make deploy-hibi`. See `docs/deploy.md` for the
+full flow and the rollback escape hatch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ Role-specific guardrails live next door — read the one that matches the work:
 - `.claude/rules/manager-agent.md` — anything inside `manager/`.
 
 Project-wide non-negotiables (also re-stated in each file):
+
 - Type hints required; no `Any` / `# type: ignore` escape hatches.
 - psycopg 3.x only — no psycopg2 / SQLAlchemy / Alembic.
 - No async or concurrency in the daily pipeline (single epic = single process).
@@ -40,11 +41,12 @@ files Claude sees here.
 **Tokens** (colors, spacing, fonts, radii, line-heights) come from exactly
 one file:
 
-```
+```text
 design-system/colors_and_type.css
 ```
 
 When implementing UI:
+
 - Reference these tokens via the CSS custom properties they define
   (`--bg-primary`, `--text-primary`, `--font-jp`, `--space-N`, ...).
 - For email, inline the relevant tokens into the template; for web, link

--- a/design-system/README.md
+++ b/design-system/README.md
@@ -32,6 +32,30 @@ The product is bilingual JP/EN, technical, and intimate — built for one reader
 
 ---
 
+## Source of truth
+
+`colors_and_type.css` is the **only** place that owns tokens — colors,
+fonts, spacing, line-heights, radii, motion. Every surface (email
+inlined, web linked) reads from this file.
+
+When you need to change a token:
+
+- Edit `colors_and_type.css`. Nothing else.
+- Do not duplicate a hex code, font family, or spacing value in another
+  CSS / HTML / template file. Reference the custom property
+  (`var(--bg-primary)`, `var(--space-3)`, ...) instead.
+- Email templates inline the relevant tokens because mail clients strip
+  `<link rel="stylesheet">`, but the inlined values must come from this
+  file at build time, not be re-typed by hand.
+- A new token is allowed only after it lives in this file. The rule is
+  "tokens flow from `colors_and_type.css` outward" — never inward.
+
+If a stakeholder asks for a different blue, the answer is one line in
+this file. If it isn't, the design system is no longer the source of
+truth and the brand splits.
+
+---
+
 ## Content fundamentals
 
 Hibi is **bilingual but JP-led**. Body copy is Japanese; English appears as eyebrow labels, numeric metadata, and source titles (which often arrive in English from the feed).


### PR DESCRIPTION
## Summary

Lay the SSoT plumbing for the Hibi design system. Nothing downstream changes yet — this just makes the rule (and the files) reachable so #40 (email rewrite) and #41 (web edition) have a single, unambiguous place to read tokens from.

## Changes

- **`.claude/skills/hibi-design`** — symlink to `../../design-system/`. Claude Code now discovers the skill (confirmed: it appeared in the session's skill list after creation). Symlink keeps SSoT intact — no duplicated `colors_and_type.css` / `README.md` / `assets/`.
- **`CLAUDE.md`** (was empty) — now states the project shape, agent-rule entrypoints, and the **design tokens SSoT rule**: every token lives in `design-system/colors_and_type.css`; surfaces reference custom properties (or inline at build time from this file), never re-type hex / font / spacing values.
- **`design-system/README.md`** — adds a "Source of truth" section spelling out the same rule from the brand-guide side.

## Acceptance criteria

- [x] `design-system/colors_and_type.css` exists on main (was already there from the handoff bundle).
- [x] `.claude/skills/hibi-design/` is populated (via symlink) and `.claude/skills/hibi-design/SKILL.md` resolves to the manifest.
- [x] SSoT rule is written down in both `CLAUDE.md` and `design-system/README.md`.
- [x] `/hibi-design` is invocable via Claude Code skill discovery (confirmed in the session that produced this PR).

## Out of scope (covered by other issues)

- #40: email template rewrite with inlined tokens
- #41: web edition page that `<link>`s `colors_and_type.css`
- #56, #57, #58, ...: subject / voice / landing / archive that consume the tokens
- Tailwind / Astro / framework wiring — when introduced, will still read from this file

## Related

- Parent epic: #39
- Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)