### PR TITLE
feat(email): subject line formatter with full-width count + emoji/dash guard (#56)

### DIFF
--- a/send_mail.py
+++ b/send_mail.py
@@ -7,7 +7,9 @@ Usage:
 """
 import argparse
 import json
+import logging
 import os
+import unicodedata
 from datetime import date
 
 from dotenv import load_dotenv
@@ -15,13 +17,130 @@ from mailer import send
 
 load_dotenv()
 
+log = logging.getLogger(__name__)
+
+# Design-system limit for email subjects, see design-system/README.md:
+# "Email subject: <= 28 zen-kaku chars. Always begins with the date."
+_SUBJECT_MAX_FULLWIDTH = 28
+
+# Em-dash used as the legitimate separator in the subject line.
+_EM_DASH = "—"
+# Katakana prolonged sound mark — must NOT be used as a clause separator.
+_KATAKANA_PROLONG = "ー"
+
+
+def _fullwidth_count(s: str) -> int:
+    """Return the visual width of ``s`` measured in zen-kaku (full-width) chars.
+
+    Each character contributes 1.0 if its East Asian Width is Wide / Fullwidth
+    / Ambiguous, and 0.5 if it is Narrow / Halfwidth / Neutral. The result is
+    rounded up to the next integer so a single trailing half-width char still
+    counts as 1 toward the budget.
+
+    This intentionally mirrors how Gmail / Apple Mail render the subject in
+    a Japanese-locale inbox list, where ASCII glyphs occupy roughly half the
+    advance width of a CJK glyph.
+    """
+    total: float = 0.0
+    for ch in s:
+        width = unicodedata.east_asian_width(ch)
+        if width in ("W", "F", "A"):
+            total += 1.0
+        else:
+            total += 0.5
+    # Round up so 27.5 -> 28 (still within budget) but 28.5 -> 29 (over).
+    rounded = int(total)
+    if total > rounded:
+        rounded += 1
+    return rounded
+
+
+def _has_emoji(s: str) -> bool:
+    """Return True iff ``s`` contains any emoji / pictograph codepoint.
+
+    Covers the ranges Hibi's templates leaked into output historically:
+    - Pictographs / dingbats (U+2600..U+27BF)
+    - Variation selector-16 paired with emoji (U+FE0F)
+    - Emoji planes (U+1F300..U+1FAFF) — covers 1F300..1F5FF, 1F600..1F64F
+      (smileys, e.g. U+1F600), 1F900..1F9FF, 1FA00..1FAFF.
+    - Other-Symbol (Unicode general category ``So``) catches stragglers.
+    """
+    for ch in s:
+        cp = ord(ch)
+        if 0x2600 <= cp <= 0x27BF:
+            return True
+        if cp == 0xFE0F:
+            return True
+        if 0x1F300 <= cp <= 0x1FAFF:
+            return True
+        if unicodedata.category(ch) == "So":
+            return True
+    return False
+
+
+def _has_dangerous_dash(s: str) -> bool:
+    """Return True iff the katakana prolong「ー」is used as a clause separator.
+
+    The subject canonical shape is ``<date> — <body>`` where ``—`` is U+2014.
+    A common authoring mistake is typing「ー」(U+30FC) instead, which looks
+    similar in a sans-serif font but is semantically wrong (it is the
+    katakana long-vowel mark, not a dash).
+
+    Heuristic: flag any「ー」that is surrounded by spaces (likely used as a
+    separator), or any「ー」at all when the subject does NOT also contain a
+    real em-dash — that combination means the author tried to write the
+    separator and reached for the wrong key.
+    """
+    if _KATAKANA_PROLONG not in s:
+        return False
+    if _EM_DASH not in s:
+        # No real em-dash present, so the only candidate for the separator
+        # role is the prolong mark — flag it.
+        return True
+    # Em-dash is present, but a prolong mark surrounded by ASCII spaces is
+    # also suspicious (likely a second, accidental separator).
+    if f" {_KATAKANA_PROLONG} " in s:
+        return True
+    return False
+
 
 def format_subject(date_str: str, count: int) -> str:
     """Build the daily subject line.
 
     Format: ``YYYY.MM.DD — 今朝のN本`` (half-width period + em-dash, no emoji).
+
+    Soft validation: the function ALWAYS returns the formatted subject. If
+    the result violates design-system constraints (over 28 zen-kaku chars,
+    contains emoji, or contains a misused「ー」), the violation is logged at
+    WARNING level so the daily pipeline keeps running and the operator can
+    see the regression in logs.
     """
-    return f"{date_str} — 今朝の{count}本"
+    subject = f"{date_str} {_EM_DASH} 今朝の{count}本"
+
+    width = _fullwidth_count(subject)
+    if width > _SUBJECT_MAX_FULLWIDTH:
+        log.warning(
+            "email subject exceeds design-system width budget: "
+            "%d full-width chars > %d (subject=%r)",
+            width,
+            _SUBJECT_MAX_FULLWIDTH,
+            subject,
+        )
+
+    if _has_emoji(subject):
+        log.warning(
+            "email subject contains emoji / pictograph codepoint (subject=%r)",
+            subject,
+        )
+
+    if _has_dangerous_dash(subject):
+        log.warning(
+            "email subject uses katakana prolong mark instead of em-dash "
+            "(subject=%r)",
+            subject,
+        )
+
+    return subject
 
 
 def main():

--- a/tests/test_subject.py
+++ b/tests/test_subject.py
@@ -1,0 +1,194 @@
+"""Subject-line formatter tests for ``send_mail.format_subject``.
+
+Covers:
+- Canonical shape ``YYYY.MM.DD — 今朝のN本`` (half-width period + em-dash).
+- Full-width width budget (<= 28 zen-kaku chars per design-system/README.md).
+- Stability across realistic counts (3 / 5 / 10).
+- Internal helper contracts: ``_has_emoji`` and ``_has_dangerous_dash``.
+- Warning log emission when the width budget is blown — subject itself is
+  returned unmodified (soft validation, never raises).
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from send_mail import (
+    _fullwidth_count,
+    _has_dangerous_dash,
+    _has_emoji,
+    format_subject,
+)
+
+# Design-system budget (see design-system/README.md "Lengths").
+SUBJECT_MAX_FULLWIDTH = 28
+
+
+# ── Canonical shape ────────────────────────────────────────────────────
+
+
+def test_format_subject_canonical_shape() -> None:
+    """Standard case: matches the design-system example verbatim."""
+    assert format_subject("2026.05.10", count=5) == "2026.05.10 — 今朝の5本"
+
+
+def test_format_subject_uses_em_dash_not_hyphen() -> None:
+    """The separator must be U+2014 em-dash, not ASCII hyphen-minus."""
+    subject = format_subject("2026.05.10", count=5)
+    assert "—" in subject  # U+2014
+    # ASCII hyphen-minus must NOT be present (would indicate fallback drift).
+    assert "-" not in subject
+
+
+def test_format_subject_uses_halfwidth_period_in_date() -> None:
+    """Date separator must be ASCII `.`, not the full-width `．` (U+FF0E)."""
+    subject = format_subject("2026.05.10", count=5)
+    assert "．" not in subject
+    assert "." in subject
+
+
+# ── Width budget ───────────────────────────────────────────────────────
+
+
+def test_format_subject_within_fullwidth_budget() -> None:
+    """Canonical subject must fit under the 28 zen-kaku design-system cap."""
+    subject = format_subject("2026.05.10", count=5)
+    assert _fullwidth_count(subject) <= SUBJECT_MAX_FULLWIDTH
+
+
+@pytest.mark.parametrize("count", [3, 5, 10])
+def test_format_subject_stable_across_counts(count: int) -> None:
+    """Realistic counts (3 / 5 / 10) must keep the format intact and within budget."""
+    subject = format_subject("2026.05.10", count=count)
+    assert subject == f"2026.05.10 — 今朝の{count}本"
+    assert _fullwidth_count(subject) <= SUBJECT_MAX_FULLWIDTH
+
+
+def test_format_subject_logs_warning_when_over_budget(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """If the formatted subject exceeds 28 zen-kaku chars, a WARNING must be
+    emitted — but the subject is still returned unmodified (soft validation).
+    """
+    # Force an overlong date string. 30 ASCII chars = 15 zen-kaku, plus
+    # ` — 今朝の99999本` adds ~10 more zen-kaku, total ~25... so use a much
+    # longer payload to comfortably exceed 28.
+    long_date = "2026.05.10-extra-tag-please-overflow-the-budget"
+    with caplog.at_level(logging.WARNING, logger="send_mail"):
+        subject = format_subject(long_date, count=5)
+    # Subject is still returned verbatim — soft validation never raises or
+    # silently truncates.
+    assert subject == f"{long_date} — 今朝の5本"
+    # Width budget warning was emitted.
+    width_warnings = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and "width budget" in r.getMessage()
+    ]
+    assert width_warnings, "expected a width-budget warning record"
+
+
+def test_format_subject_no_warning_when_within_budget(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Canonical subject must emit zero WARNING records."""
+    with caplog.at_level(logging.WARNING, logger="send_mail"):
+        format_subject("2026.05.10", count=5)
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+
+
+# ── _has_emoji helper ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("ch", ["📅", "🔥", "😀", "⭐", "✨"])
+def test_has_emoji_detects_emoji_codepoints(ch: str) -> None:
+    assert _has_emoji(f"prefix {ch} suffix") is True
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "2026.05.10 — 今朝の5本",
+        "Anthropic、Claude 4.6 をリリース",
+        "plain ascii only",
+        "日本語のみ",
+    ],
+)
+def test_has_emoji_returns_false_for_safe_text(text: str) -> None:
+    assert _has_emoji(text) is False
+
+
+# ── _has_dangerous_dash helper ─────────────────────────────────────────
+
+
+def test_has_dangerous_dash_flags_katakana_prolong_as_separator() -> None:
+    """U+30FC「ー」used in the separator slot must be flagged."""
+    assert _has_dangerous_dash("2026.05.10 ー 今朝の5本") is True
+
+
+def test_has_dangerous_dash_passes_canonical_em_dash() -> None:
+    """U+2014「—」used as the separator is the correct, expected form."""
+    assert _has_dangerous_dash("2026.05.10 — 今朝の5本") is False
+
+
+def test_has_dangerous_dash_passes_legitimate_prolong_in_word() -> None:
+    """A prolong mark inside a katakana word (e.g.「サーバー」) with the
+    correct em-dash separator must NOT be flagged.
+    """
+    assert _has_dangerous_dash("2026.05.10 — サーバー更新") is False
+
+
+def test_format_subject_logs_warning_on_dangerous_dash(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the formatter ever produces a「ー」-shaped subject (via future
+    refactor), a WARNING must surface so the regression is loud in logs.
+    Today this is impossible because the literal in ``format_subject`` is
+    hard-coded — so we exercise the helper path directly.
+    """
+    # Drive the warning path through the public surface by simulating a
+    # bad render: call the internal predicate that the formatter delegates to.
+    assert _has_dangerous_dash("2026.05.10 ー 今朝の5本") is True
+
+
+def test_format_subject_logs_warning_on_emoji_subject(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Emoji in a date string must trip the emoji-detection branch and emit a
+    WARNING. Subject is returned unmodified.
+    """
+    with caplog.at_level(logging.WARNING, logger="send_mail"):
+        subject = format_subject("2026.05.10 🔥", count=5)
+    assert subject == "2026.05.10 🔥 — 今朝の5本"
+    emoji_warnings = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and "emoji" in r.getMessage()
+    ]
+    assert emoji_warnings, "expected an emoji warning record"
+
+
+# ── _fullwidth_count helper ────────────────────────────────────────────
+
+
+def test_fullwidth_count_empty_string_is_zero() -> None:
+    assert _fullwidth_count("") == 0
+
+
+def test_fullwidth_count_ascii_is_half_per_char() -> None:
+    # 10 ASCII chars = 5.0 zen-kaku → rounded up to 5.
+    assert _fullwidth_count("abcdefghij") == 5
+
+
+def test_fullwidth_count_cjk_is_one_per_char() -> None:
+    # 4 CJK chars = 4.0 zen-kaku.
+    assert _fullwidth_count("今朝の本") == 4
+
+
+def test_fullwidth_count_canonical_subject_is_well_under_budget() -> None:
+    # Sanity: the example from design-system/README.md leaves plenty of room.
+    width = _fullwidth_count("2026.05.10 — 今朝の5本")
+    assert width <= SUBJECT_MAX_FULLWIDTH
+    # And the width is realistic (not absurdly small / large).
+    assert 8 <= width <= 20


### PR DESCRIPTION
## Summary

\`format_subject(date_str, count)\` continues to return the canonical \`YYYY.MM.DD — 今朝のN本\` shape, but now runs three soft-validation guards aligned with design-system/README.md:

- **Full-width width budget** (\`≤ 28\` 全角): East Asian Width counts each CJK / wide / ambiguous char as 1.0 and ASCII as 0.5, ceiling'd. Over-budget subjects log a WARNING and ship anyway.
- **Emoji / pictograph detection**: U+2600..U+27BF, VS-16, U+1F300..U+1FAFF, Unicode category \`So\`. Warns if any sneak in (subject name, count rendering, etc.).
- **Katakana long-vowel「ー」vs em-dash「—」**: warns when「ー」is used as a clause separator. Carefully tuned not to fire on legitimate words like「サーバー」(katakana prolong inside a word, not as separator).

All three are **observe-only** — the daily pipeline never fails because of a bad subject. Operators see the regression in logs.

## Test plan

- [x] \`pytest tests/test_subject.py -v\` → **28/28 PASS** (new file)
- [x] \`pytest tests/\` → **55/55 PASS** (existing 27 untouched)
- [x] canonical subject \`2026.05.10 — 今朝の5本\` emits no warnings
- [x] over-budget subject emits warning but is still returned verbatim
- [x] emoji / wrong-dash detection unit-tested at the helper level

## Out of scope

- Subject A/B testing
- Multilingual (EN/JP) variants
- Hard failure on over-budget (would risk a missed daily delivery)

Closes #56
Related: #40 (closed), #39 (epic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)