### PR TITLE
feat(summarizer): apply design-system voice & tone to summary prompts (#57)

### DIFF
--- a/daily_news.py
+++ b/daily_news.py
@@ -6,6 +6,7 @@ Fetches YouTube uploads + RSS articles → summarizes with Claude → sends Gmai
 import base64
 import hashlib
 import hmac
+import logging
 import os
 import random
 import sys
@@ -34,6 +35,9 @@ from mailer import build_html as build_hibi_html
 from observability import init_sentry_from_env
 from ranking import compute_interest_centroid, cosine_similarity, count_recent_clicks
 from send_mail import format_subject
+from voice import check_voice_violations
+
+log = logging.getLogger(__name__)
 
 # ============================================================
 # CONFIG
@@ -166,7 +170,20 @@ def embed_batch(openai_client, texts: list[str]) -> list[list[float] | None]:
 # Claude summarize
 # ============================================================
 def summarize(client: Anthropic, title: str, content: str) -> str:
-    prompt = f"""以下の記事/動画を日本語で3行に要約してください。
+    # design-system/README.md "Content fundamentals → Voice" 由来。
+    # 具体的な禁止ワード列挙ではなく原則だけを 5-7 行で示し、
+    # post-processing (`check_voice_violations`) で観測する設計。
+    voice_rule = """あなたは新聞 Hibi の編集者として要約を書きます。文体ルール:
+- 三人称・観察的・宣言的に書く。新聞は報告するのであって売り込まない。
+- 一人称(「私」「僕」)も二人称呼びかけ(「あなた」「読者の皆様」)も使わない。
+- 賞賛は抑制する。「すごい」「最高」より「興味深い」「注目」。
+- 感嘆符(「!」「！」)、絵文字、絵文字的記号は使わない。
+- マーケティング的な煽り(「今すぐ」「お見逃しなく」「驚愕」「衝撃」)を避ける。
+- 句点「。」で終える事実の記述を基本とする。"""
+
+    prompt = f"""{voice_rule}
+
+以下の記事/動画を日本語で3行に要約してください。
 技術的な要点、実装のヒント、開発者にとっての示唆を優先してください。
 各行は1文で、「・」で始めてください。
 
@@ -187,7 +204,16 @@ def summarize(client: Anthropic, title: str, content: str) -> str:
         max_tokens=500,
         messages=[{"role": "user", "content": prompt}],
     )
-    return response.content[0].text.strip()
+    summary = response.content[0].text.strip()
+
+    # design-system voice & tone への準拠を観測する。違反があっても配信は
+    # 止めず warning ログのみ。意図は voice.py module docstring を参照。
+    if summary:
+        violations = check_voice_violations(summary)
+        if violations:
+            log.warning("voice violations in summary: %s", violations)
+
+    return summary
 
 
 # ============================================================

--- a/tests/test_voice.py
+++ b/tests/test_voice.py
@@ -1,0 +1,168 @@
+"""Voice & tone guard tests.
+
+`voice.check_voice_violations` は design-system/README.md "What we don't do"
+を観測する pure function。配信を止めない検出器なので、ここで検証するのは:
+
+- 禁止ワード (substring 一致) が拾われる
+- 感嘆符 (半角/全角) が拾われる
+- 絵文字が拾われる
+- 規範的な要約 (Hibi voice 準拠) は violations=[] になる
+
+また `daily_news.summarize` 経由でも、API 呼び出しを monkeypatch でモックして
+違反検出時に warning ログが出ることを 1 ケース確認する。Claude / Neon /
+OpenAI / Gmail は呼ばない。
+"""
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+import pytest
+
+import daily_news
+from voice import check_voice_violations
+
+
+# ============================================================
+# check_voice_violations: pure function tests
+# ============================================================
+def test_check_voice_violations_detects_clickbait_word() -> None:
+    """「驚愕の発表」のような典型的なクリックベイト動詞を拾う。"""
+    violations = check_voice_violations("驚愕の発表があった。")
+    assert "驚愕" in violations
+
+
+def test_check_voice_violations_detects_marketing_cta_and_exclamation() -> None:
+    """二人称呼びかけ + マーケ CTA + 感嘆符の複合ケース。"""
+    violations = check_voice_violations("読者の皆様、必見!")
+    assert "読者の皆様" in violations
+    assert "必見" in violations
+    assert "感嘆符" in violations
+
+
+def test_check_voice_violations_detects_fullwidth_exclamation() -> None:
+    """全角感嘆符「！」も検出する (design-system は両方禁止)。"""
+    violations = check_voice_violations("発表があった！")
+    assert "感嘆符" in violations
+
+
+def test_check_voice_violations_detects_emoji() -> None:
+    """絵文字 (📅 など Misc Symbols and Pictographs) を検出する。"""
+    violations = check_voice_violations("📅 イベントが開催される。")
+    assert "絵文字" in violations
+
+
+def test_check_voice_violations_clean_summary_returns_empty() -> None:
+    """design-system 準拠の要約は違反なし。
+
+    README.md の "Example summary block" を踏襲した文面。三人称・宣言的・
+    句点で終わる・記号は中黒のみ。
+    """
+    clean = "・Anthropic が Claude 4.6 を発表した。"
+    assert check_voice_violations(clean) == []
+
+
+def test_check_voice_violations_allows_middot_separator() -> None:
+    """「・」(middot, U+30FB) は design-system が明示的に許可する唯一の記号。
+
+    絵文字検出レンジに含まれないことを境界条件として確認する。
+    """
+    assert check_voice_violations("・前提・背景・結論") == []
+
+
+def test_check_voice_violations_detects_first_person() -> None:
+    """一人称「私」「僕」は newspaper voice では使わない。"""
+    assert "私" in check_voice_violations("私はこう考える。")
+    assert "僕" in check_voice_violations("僕の意見は違う。")
+
+
+# ============================================================
+# summarize: integration with logging (Claude API is mocked)
+# ============================================================
+class _FakeContentBlock:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _FakeResponse:
+    def __init__(self, text: str) -> None:
+        self.content = [_FakeContentBlock(text)]
+
+
+class _FakeMessages:
+    def __init__(self, text: str) -> None:
+        self._text = text
+        # behavior 検証のため呼び出し時の引数も拾える形にしておく
+        self.last_kwargs: dict[str, object] = {}
+
+    def create(self, **kwargs: object) -> _FakeResponse:
+        self.last_kwargs = kwargs
+        return _FakeResponse(self._text)
+
+
+class _FakeAnthropic:
+    def __init__(self, text: str) -> None:
+        self.messages = _FakeMessages(text)
+
+
+def _fake_client(text: str) -> _FakeAnthropic:
+    return _FakeAnthropic(text)
+
+
+def test_summarize_logs_warning_on_voice_violation(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Claude の戻り値に違反ワードがあると warning ログが出る。配信は通す。
+
+    monkeypatch で `Anthropic` クライアントを差し替え、外部 API を一切
+    呼ばずに `summarize()` の post-processing パスだけを検証する。
+    """
+    dirty_summary = "・驚愕の発表があった!"
+    fake = _fake_client(dirty_summary)
+
+    with caplog.at_level(logging.WARNING, logger=daily_news.log.name):
+        result = daily_news.summarize(fake, title="t", content="c" * 600)
+
+    # 配信は通す (= 戻り値はそのまま返される)
+    assert result == dirty_summary
+
+    # warning が出ている & 検出語が含まれている
+    warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warning_records, "expected a WARNING log for voice violations"
+    msg = warning_records[0].getMessage()
+    assert "voice violations" in msg
+    assert "驚愕" in msg
+    assert "感嘆符" in msg
+
+
+def test_summarize_no_warning_for_clean_output(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """規範的な出力に対しては warning が出ない (false-positive 防止)。"""
+    clean = "・Anthropic が Claude 4.6 を発表した。\n・API は既存キーで利用できる。\n・料金は前世代と同じ。"
+    fake = _fake_client(clean)
+
+    with caplog.at_level(logging.WARNING, logger=daily_news.log.name):
+        result = daily_news.summarize(fake, title="t", content="c" * 600)
+
+    assert result == clean
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+
+def test_summarize_skips_check_on_empty_output(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Claude が defended (空文字列) を返した場合、violation チェックは
+    skip され warning は出ない。
+
+    空文字列に対する false-positive (例: 絵文字検出ロジックの誤動作で空が
+    引っかかる) を未然に防ぐ境界条件テスト。
+    """
+    fake = _fake_client("")
+
+    with caplog.at_level(logging.WARNING, logger=daily_news.log.name):
+        result = daily_news.summarize(fake, title="t", content="c" * 600)
+
+    assert result == ""
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []

--- a/voice.py
+++ b/voice.py
@@ -1,0 +1,99 @@
+"""Voice & tone guard for Hibi summary text.
+
+Hibi の design-system は `design-system/README.md` の "Content fundamentals"
+で voice & tone を定義している (三人称・観察的・宣言的、賞賛は抑制、感嘆符
+/絵文字/二人称呼びかけ/マーケ語禁止)。`summarize()` が Claude から受け取った
+要約文に対し、この関数で violation を検出する。
+
+検出はあくまで **観測目的** で、配信パイプラインは止めない。違反があれば
+呼び出し側で warning ログを出す想定。意図:
+
+- LLM の出力が design-system から逸脱しているかを継続的に観測したい
+- ただし「驚愕」「!」が含まれた途端に配信が落ちると運用負荷が跳ねるので、
+  検出だけして配信は通す
+- 将来的に違反率が下がらない場合は、ここで検出した patterns を hard-fail
+  条件に格上げできる余地を残す
+
+このため本モジュールは副作用なしの pure function に限定する (psycopg・
+ネットワーク・logging 依存を持ち込まない)。
+"""
+from __future__ import annotations
+
+import re
+
+# design-system/README.md "Content fundamentals → What we don't do" と
+# "Voice" セクションを根拠とする禁止表現。
+#
+# - クリックベイト動詞: 驚愕 / 衝撃 / やばい / 革命的 / 画期的
+# - 過剰賞賛: すごい / 最高
+# - マーケ CTA: 今すぐ / お見逃しなく / 必見
+# - 二人称呼びかけ: あなた / 読者の皆様
+# - 一人称: 私 / 僕 (newspaper has no first-person voice)
+#
+# 完全一致ではなく substring 検出。「驚愕の発表」「読者の皆様、必見」のような
+# 自然な文脈で機能するため。
+_FORBIDDEN_WORDS: tuple[str, ...] = (
+    "驚愕",
+    "衝撃",
+    "やばい",
+    "すごい",
+    "最高",
+    "画期的",
+    "革命的",
+    "お見逃しなく",
+    "今すぐ",
+    "必見",
+    "あなた",
+    "読者の皆様",
+    "私",
+    "僕",
+)
+
+# 絵文字検出: Unicode の主要な絵文字ブロックをカバー。
+# - Misc Symbols and Pictographs (1F300-1F5FF): ☂️ 📅 📰 など
+# - Emoticons (1F600-1F64F): 😀 など
+# - Transport and Map (1F680-1F6FF): 🚀 など
+# - Supplemental Symbols and Pictographs (1F900-1F9FF): 🤖 など
+# - Symbols and Pictographs Extended-A (1FA70-1FAFF)
+# - Misc Symbols (2600-26FF) + Dingbats (2700-27BF): ☀ ✨ など
+#
+# design-system は「・」(middot, U+30FB) を例外として明示的に許可しているが、
+# 上記レンジには含まれないので除外不要。
+_EMOJI_RE = re.compile(
+    "["
+    "\U0001F300-\U0001F5FF"
+    "\U0001F600-\U0001F64F"
+    "\U0001F680-\U0001F6FF"
+    "\U0001F900-\U0001F9FF"
+    "\U0001FA70-\U0001FAFF"
+    "☀-⛿"
+    "✀-➿"
+    "]"
+)
+
+
+def check_voice_violations(text: str) -> list[str]:
+    """要約テキストの voice & tone 違反を列挙する。
+
+    Returns:
+        違反パターンの list。重複は除去するが、複数種類の違反は別要素として
+        返す。空 list は「違反なし」。
+
+    検出対象:
+        - `_FORBIDDEN_WORDS` のいずれかが substring として含まれる
+        - 感嘆符 ``!`` または全角 ``！`` が含まれる
+        - 絵文字 (`_EMOJI_RE`) が含まれる
+    """
+    violations: list[str] = []
+
+    for word in _FORBIDDEN_WORDS:
+        if word in text:
+            violations.append(word)
+
+    if "!" in text or "！" in text:
+        violations.append("感嘆符")
+
+    if _EMOJI_RE.search(text) is not None:
+        violations.append("絵文字")
+
+    return violations


### PR DESCRIPTION
## Summary

Prepend a 6-line voice rule (derived from \`design-system/README.md\` "Content fundamentals → Voice") to the \`summarize()\` prompt, and observe — but do not block — voice violations in the model's output.

The rule is principle-based, not a forbidden-word listing, so the model is guided rather than fenced. The post-processor in \`voice.py\` watches for the specific patterns the design system flags ("驚愕", "やばい", second-person address, 感嘆符, emoji, etc.) and logs warnings without failing the daily delivery — the cost of a missed digest outweighs the cost of a noisy log line.

## Why warn-only

A hard fail on the cron path would mean operators wake up to a missed delivery the first time Claude says "革命的な" in a summary. We want the **signal**, not the outage. If violation rates stay high, we can upgrade the warn to a retry / hard-fail in a follow-up.

## Files

- \`daily_news.py\`: \`summarize()\` now prepends \`voice_rule\` to the prompt and post-checks the returned summary. Skip the check on the defended-empty case to avoid noise.
- \`voice.py\` (new): pure-function \`check_voice_violations(text) -> list[str]\` covering forbidden words, half-and full-width exclamation marks, and the main Unicode emoji blocks. Explicitly preserves U+30FB「・」(middot) which the design system allows.
- \`tests/test_voice.py\` (new, 10 cases): pure-function correctness + an integration test that monkeypatches \`Anthropic\` so the test doesn't hit the network.

## Test plan

- [x] \`pytest tests/test_voice.py -v\` → 10/10 PASS
- [x] \`pytest tests/\` → 37/37 PASS (existing untouched)
- [x] False-positive guard: a clean summary like 「Anthropic が Claude 4.6 を発表した。」 produces no warnings
- [x] Bullet character「・」does NOT trip the emoji detector

## Known false-positive surface

- 「私」「僕」 are substring-matched, so words like 「私立」「公私」「私見」 would trip the warning. This is acceptable for a warn-only system; if we see real noise we can tighten to \\b-style boundaries.

Closes #57
Related: #39 (epic), #53 (will reuse the same voice rule in standfirst / daily_title prompts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)