### PR TITLE
feat(backend): generate standfirst + daily_title per edition (Claude API) (#53)

### DIFF
--- a/daily_news.py
+++ b/daily_news.py
@@ -6,9 +6,11 @@ Fetches YouTube uploads + RSS articles → summarizes with Claude → sends Gmai
 import base64
 import hashlib
 import hmac
+import json
 import logging
 import os
 import random
+import re
 import sys
 from datetime import datetime, timedelta, timezone
 from email.mime.text import MIMEText
@@ -27,6 +29,7 @@ from db import (
     get_or_create_edition_for_today,
     is_already_sent,
     save_article,
+    update_edition_meta,
     update_edition_sources_scanned,
 )
 from fetchers import rss as rss_fetcher
@@ -214,6 +217,173 @@ def summarize(client: Anthropic, title: str, content: str) -> str:
             log.warning("voice violations in summary: %s", violations)
 
     return summary
+
+
+# ============================================================
+# Edition meta (standfirst / daily_title) generation — Issue #53
+# ============================================================
+# design-system/README.md の voice & tone を守らせる:
+#   - 第三者・観察的 (one-on-one ではない)
+#   - 「驚愕」「やばい」「お見逃しなく」のような marketing CTA / clickbait 禁止
+#   - 絵文字 / 感嘆符禁止
+#   - 句点「。」、 半角ピリオドではなく日本語句読点
+#
+# standfirst は「今朝のN本。」で始まる 1 文。daily_title は 30 文字以内の
+# 一行要約 (アーカイブ用)。
+#
+# 失敗時 (Claude exception / JSON parse fail / 空応答) はそれぞれ安全な
+# フォールバック値を返し、生成自体は通す。
+_EDITION_META_MAX_TITLE_CHARS = 30
+_EDITION_META_MAX_TOKENS = 400
+# 禁止ワードの非網羅リスト。post-processing は warn のみで block しない
+# (Claude を再呼び出ししたくない / 既にフォールバック側でも安全)。
+_BANNED_WORDS = ("驚愕", "やばい", "衝撃", "お見逃しなく", "今すぐ")
+# emoji / variation selector / pictograph の検出 (test_email_template と
+# 整合)。General Category 'So' は呼び出し側でカバー。
+_EMOJI_PATTERN = re.compile(
+    "["
+    "\U00002600-\U000027BF"
+    "\U0001F300-\U0001FAFF"
+    "★☆️"
+    "]"
+)
+
+
+def _fallback_edition_meta(articles: list[dict]) -> dict[str, str]:
+    """Claude 失敗時のフォールバック値。"""
+    return {
+        "standfirst": f"今朝の{len(articles)}本。",
+        "daily_title": " / ".join(a.get("title", "") for a in articles),
+    }
+
+
+def _warn_if_violates_voice(field: str, value: str) -> None:
+    """禁止ワード / 絵文字を含んでいたら warn のみ。生成は通す。"""
+    for word in _BANNED_WORDS:
+        if word in value:
+            log.warning(
+                "generate_edition_meta: %s contains banned word %r: %s",
+                field,
+                word,
+                value,
+            )
+            return
+    if _EMOJI_PATTERN.search(value):
+        log.warning(
+            "generate_edition_meta: %s contains emoji-range codepoint: %s",
+            field,
+            value,
+        )
+
+
+def generate_edition_meta(
+    client: Anthropic, articles: list[dict]
+) -> dict[str, str]:
+    """edition の standfirst + daily_title を Claude で 1 回生成する。
+
+    Args:
+        client: Anthropic SDK client (既存 daily_news 内で生成済みのものを流用)。
+        articles: 配信確定済みの記事 dict のリスト。各要素は最低限
+            ``title`` (str) と ``summary`` (str) を持つ前提。
+
+    Returns:
+        ``{"standfirst": str, "daily_title": str}``。Claude が JSON を返さ
+        なかった / 例外を投げた場合はフォールバック値:
+            standfirst = f"今朝の{N}本。"
+            daily_title = " / ".join(a["title"] for a in articles)
+
+    Side effects:
+        post-processing で禁止ワード / 絵文字を検出したら ``log.warning`` のみ。
+        block はしない (= 生成自体は通す)。
+    """
+    if not articles:
+        # 配信記事ゼロのときはそもそも呼ばれない想定だが、安全側に倒す。
+        return {"standfirst": "今朝の0本。", "daily_title": ""}
+
+    # Claude に渡す入力。要約は既に「・」で始まる 3 行になっている前提
+    # (summarize() の出力形式)。元の summary を素直に渡す。
+    items_repr = "\n\n".join(
+        f"{i}. {a.get('title', '')}\n{a.get('summary', '')}"
+        for i, a in enumerate(articles, 1)
+    )
+
+    prompt = (
+        "あなたは Hibi (日々) という静かな日本語デイリーニュースレターの編集者です。\n"
+        "以下の今朝の記事リスト (タイトル + 3 行要約) を読み、メール冒頭に置く\n"
+        "standfirst (リード一文) と、アーカイブ用の daily_title (一行要約) を\n"
+        "JSON で出力してください。\n"
+        "\n"
+        "voice & tone (厳守):\n"
+        "- 第三者視点・観察的。Hibi は報じる存在で、売り込まない。\n"
+        "- 「あなた」「読者の皆様」「私」「僕」を使わない。\n"
+        "- 感嘆符 (! ！) と絵文字を使わない。\n"
+        "- 「驚愕」「やばい」「衝撃」「お見逃しなく」「今すぐ」等の\n"
+        "  clickbait / marketing 用語を使わない。\n"
+        "- 句点は「。」、読点は「、」。半角ピリオドは使わない。\n"
+        "\n"
+        "出力要件:\n"
+        f"- standfirst: 必ず「今朝の{len(articles)}本。」で始まる 1 文。\n"
+        "  続けて、その日の記事群を貫く静かな観察を 1 つだけ書く。全体で 60 文字以内。\n"
+        f"- daily_title: 1 行、{_EDITION_META_MAX_TITLE_CHARS} 文字以内。\n"
+        "  その日のニュースを 1 行に圧縮した観察的見出し。\n"
+        "\n"
+        "出力形式 (JSON のみ。前後に余計な文字を入れない):\n"
+        '{"standfirst": "...", "daily_title": "..."}\n'
+        "\n"
+        "今朝の記事:\n"
+        f"{items_repr}\n"
+    )
+
+    try:
+        response = client.messages.create(
+            model=CLAUDE_MODEL,
+            max_tokens=_EDITION_META_MAX_TOKENS,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        text = response.content[0].text.strip()
+    except Exception as exc:
+        log.warning("generate_edition_meta: Claude call failed: %s", exc)
+        return _fallback_edition_meta(articles)
+
+    # Claude が前後にコードブロックを付けてくることがあるので、最初の
+    # `{` から最後の `}` までを切り出す。
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        log.warning("generate_edition_meta: no JSON object in response: %r", text)
+        return _fallback_edition_meta(articles)
+
+    try:
+        parsed = json.loads(text[start : end + 1])
+    except json.JSONDecodeError as exc:
+        log.warning(
+            "generate_edition_meta: JSON parse failed (%s): %r", exc, text
+        )
+        return _fallback_edition_meta(articles)
+
+    standfirst = parsed.get("standfirst")
+    daily_title = parsed.get("daily_title")
+    if not isinstance(standfirst, str) or not isinstance(daily_title, str):
+        log.warning(
+            "generate_edition_meta: missing/typed fields in JSON: %r", parsed
+        )
+        return _fallback_edition_meta(articles)
+
+    standfirst = standfirst.strip()
+    daily_title = daily_title.strip()
+    if not standfirst or not daily_title:
+        log.warning(
+            "generate_edition_meta: empty field after strip: %r / %r",
+            standfirst,
+            daily_title,
+        )
+        return _fallback_edition_meta(articles)
+
+    # post-processing ガード: 禁止ワード / 絵文字を warn だけ。
+    _warn_if_violates_voice("standfirst", standfirst)
+    _warn_if_violates_voice("daily_title", daily_title)
+
+    return {"standfirst": standfirst, "daily_title": daily_title}
 
 
 # ============================================================
@@ -531,9 +701,30 @@ def main():
 
     date_str = datetime.now(timezone.utc).strftime("%Y.%m.%d")
     articles = _sections_to_articles(sections)
+
+    # Stage D: edition meta (standfirst + daily_title) を Claude で生成し、
+    # editions テーブルに書き戻す (Issue #53)。Claude 失敗時はフォールバック値
+    # ("今朝のN本。" / タイトルを「 / 」で連結) を使う。生成 / 保存とも
+    # メール配信を blocking しない設計だが、現状は serial に呼んでログを残す。
+    meta = generate_edition_meta(claude, articles)
+    standfirst = meta["standfirst"]
+    daily_title = meta["daily_title"]
+    print(f"📝 standfirst: {standfirst}")
+    print(f"📝 daily_title: {daily_title}")
+    try:
+        update_edition_meta(edition_issue_no, standfirst, daily_title)
+    except Exception as exc:
+        # DB 書き込み失敗はメール配信を止めない (best effort)。
+        log.warning("update_edition_meta failed: %s", exc)
+
     # スキップ件数を footer で透明性表示する (#12 Phase 1)。
     # 字幕不足 / Claude による短文 reject の合計。詳細区別は今回はしない。
-    html = build_hibi_html(articles, date_str, skipped_count=skipped_count)
+    html = build_hibi_html(
+        articles,
+        date_str,
+        skipped_count=skipped_count,
+        standfirst=standfirst,
+    )
     send_email(
         subject=format_subject(date_str, count=len(articles)),
         html_body=html,

--- a/db.py
+++ b/db.py
@@ -149,3 +149,27 @@ def update_edition_sources_scanned(
             (Jsonb(sources_scanned), issue_no),
         )
         conn.commit()
+
+
+def update_edition_meta(
+    issue_no: int, standfirst: str, daily_title: str
+) -> None:
+    """`editions.standfirst` / `editions.daily_title` を更新する (Issue #53)。
+
+    daily_news.py の Stage D (Claude による edition meta 生成) 完了時に
+    1 回呼ぶ想定。失敗時のフォールバック値も呼び出し側で確定済みで
+    渡される (= 空文字 / None は入らない想定)。
+
+    上書き保存。冪等。
+    """
+    with get_conn() as conn:
+        conn.execute(
+            """
+            update editions
+               set standfirst = %s,
+                   daily_title = %s
+             where issue_no = %s
+            """,
+            (standfirst, daily_title, issue_no),
+        )
+        conn.commit()

--- a/mailer.py
+++ b/mailer.py
@@ -164,6 +164,7 @@ def build_html(
     articles: list[dict],
     date: str,
     skipped_count: int = 0,
+    standfirst: str = "",
 ) -> str:
     """Build the daily email HTML from enriched article dicts.
 
@@ -174,6 +175,12 @@ def build_html(
     ``skipped_count`` is the number of candidate articles dropped during the
     summarization stage (字幕不足 / 短すぎる要約など). When > 0 it is shown
     discreetly in the colophon for transparency. 0 (default) hides the line.
+
+    ``standfirst`` is the Claude-generated one-line lead (Issue #53). It is
+    rendered just below the masthead, replacing the static "今朝のN本。静か
+    な朝の読みもの。" placeholder. Empty string (default) keeps the legacy
+    static standfirst so callers that do not opt-in stay byte-compatible
+    behavior-wise.
     """
     with open(TEMPLATE_PATH, encoding="utf-8") as f:
         template = Template(f.read())
@@ -201,6 +208,23 @@ def build_html(
     else:
         skipped_html = ""
 
+    # Standfirst: when caller provides a Claude-generated line, render it
+    # wrapped in the same primary-emphasis <em> the legacy static lead uses
+    # so the section style continues to flow (HTML-escape first to neutralize
+    # any feed-injected markup). When empty, leave the static fallback.
+    if standfirst:
+        standfirst_html = (
+            f'<em style="font-style:normal;color:#1A1A1A;font-weight:500;">'
+            f"{html.escape(standfirst)}"
+            f"</em>"
+        )
+    else:
+        standfirst_html = (
+            f'<em style="font-style:normal;color:#1A1A1A;font-weight:500;">'
+            f"今朝の{len(articles)}本。"
+            f"</em>静かな朝の読みもの。"
+        )
+
     return template.safe_substitute(
         date=date,
         article_count=len(articles),
@@ -208,6 +232,7 @@ def build_html(
         sources_html=sources_html,
         source_count=source_count,
         skipped_html=skipped_html,
+        standfirst_html=standfirst_html,
     )
 
 

--- a/templates/email.html
+++ b/templates/email.html
@@ -52,7 +52,7 @@
   </header>
 
   <section class="hb-stand" style="padding:28px 48px 24px;border-bottom:1px solid #E8E6E1;font-family:'Noto Sans JP',system-ui,-apple-system,'Yu Gothic','Hiragino Kaku Gothic ProN',sans-serif;font-size:18px;font-weight:400;line-height:1.6;color:#5C5A57;">
-    <em style="font-style:normal;color:#1A1A1A;font-weight:500;">今朝の$article_count本。</em>静かな朝の読みもの。
+    $standfirst_html
   </section>
 
   $articles_html

--- a/tests/test_edition_meta.py
+++ b/tests/test_edition_meta.py
@@ -1,0 +1,244 @@
+"""Tests for `daily_news.generate_edition_meta` (Issue #53).
+
+Covered behaviors:
+- 正常系: Claude が valid JSON を返したとき、parsed standfirst / daily_title
+  をそのまま返す。
+- 異常系1: Claude が JSON でない文字列を返したとき、フォールバック値
+  (``今朝のN本。`` / titles joined by ``" / "``) が返る。
+- 異常系2: Claude API 呼び出しが例外を投げたとき、フォールバック値が返る。
+- 異常系3: JSON は parse できるがフィールドが欠けているとき、フォールバック。
+- 境界: articles が空のとき。
+- 後処理ガード: 禁止ワードを含む生成結果は log.warning だけ出て、値は通す。
+
+外部 API (Claude) はモック。実呼び出しテストは増やさない (test-agent.md)。
+"""
+from __future__ import annotations
+
+import logging
+from typing import Callable
+from unittest.mock import MagicMock
+
+import pytest
+
+import daily_news
+
+
+SAMPLE_ARTICLES: list[dict] = [
+    {
+        "title": "Anthropic、Claude Sonnet 4.6 を公開",
+        "summary": "・長文要約とコード生成の精度が向上した。\n"
+                   "・既存 API キーで即時利用可能。\n"
+                   "・開発者向けにバッチ API もベータ提供開始。",
+    },
+    {
+        "title": "CSS Anchor Positioning がブラウザ三社で揃う",
+        "summary": "・Firefox 138 で実装が揃った。\n"
+                   "・Chrome / Safari は既に対応済み。\n"
+                   "・ポップオーバー UI のロジックが簡潔になる。",
+    },
+    {
+        "title": "東京の AI スタートアップ二社が同日に調達発表",
+        "summary": "・Sakana AI 系列のスピンアウトが Series A で十二億円調達。\n"
+                   "・もう一社は seed で三億円。\n"
+                   "・両社とも在日エンジニア採用を強化する。",
+    },
+]
+
+
+def _make_fake_anthropic(text_response: str) -> MagicMock:
+    """``client.messages.create`` を text_response を返すように差し替えた
+    MagicMock を返す。Anthropic SDK の response 構造 (``content[0].text``)
+    を最小限に模倣する。"""
+    fake = MagicMock()
+    fake_message = MagicMock()
+    fake_content = MagicMock()
+    fake_content.text = text_response
+    fake_message.content = [fake_content]
+    fake.messages.create.return_value = fake_message
+    return fake
+
+
+def _make_failing_anthropic(exc: BaseException) -> MagicMock:
+    """``client.messages.create`` が例外を投げるように差し替えた MagicMock。"""
+    fake = MagicMock()
+    fake.messages.create.side_effect = exc
+    return fake
+
+
+# ── 正常系: Claude が valid JSON を返す ────────────────────────────────
+
+
+def test_generate_edition_meta_parses_valid_json() -> None:
+    fake_client = _make_fake_anthropic(
+        '{"standfirst": "今朝の3本。静かな朝の観察。", '
+        '"daily_title": "Claudeと CSS と東京の AI 調達"}'
+    )
+
+    result = daily_news.generate_edition_meta(fake_client, SAMPLE_ARTICLES)
+
+    assert result["standfirst"] == "今朝の3本。静かな朝の観察。"
+    assert result["daily_title"] == "Claudeと CSS と東京の AI 調達"
+    # Claude 呼び出しは正確に 1 回。
+    assert fake_client.messages.create.call_count == 1
+
+
+def test_generate_edition_meta_strips_code_fence_around_json() -> None:
+    """Claude がコードブロックで JSON を囲んでも parse できる。"""
+    fake_client = _make_fake_anthropic(
+        '```json\n'
+        '{"standfirst": "今朝の3本。静かに観察する。", '
+        '"daily_title": "観察的見出し"}\n'
+        '```'
+    )
+
+    result = daily_news.generate_edition_meta(fake_client, SAMPLE_ARTICLES)
+
+    assert result["standfirst"] == "今朝の3本。静かに観察する。"
+    assert result["daily_title"] == "観察的見出し"
+
+
+# ── 異常系: JSON parse 失敗 → フォールバック ─────────────────────────────
+
+
+def test_generate_edition_meta_falls_back_on_invalid_json() -> None:
+    fake_client = _make_fake_anthropic("これは JSON ではありません。")
+
+    result = daily_news.generate_edition_meta(fake_client, SAMPLE_ARTICLES)
+
+    assert result["standfirst"] == f"今朝の{len(SAMPLE_ARTICLES)}本。"
+    assert result["daily_title"] == " / ".join(
+        a["title"] for a in SAMPLE_ARTICLES
+    )
+
+
+def test_generate_edition_meta_falls_back_on_partially_valid_json() -> None:
+    """JSON っぽいが key が欠けている場合もフォールバック。"""
+    fake_client = _make_fake_anthropic('{"standfirst": "今朝の3本。"}')
+
+    result = daily_news.generate_edition_meta(fake_client, SAMPLE_ARTICLES)
+
+    assert result["standfirst"] == f"今朝の{len(SAMPLE_ARTICLES)}本。"
+    assert result["daily_title"] == " / ".join(
+        a["title"] for a in SAMPLE_ARTICLES
+    )
+
+
+def test_generate_edition_meta_falls_back_on_wrong_field_types() -> None:
+    """standfirst が int 等で str ではない場合もフォールバック。"""
+    fake_client = _make_fake_anthropic(
+        '{"standfirst": 123, "daily_title": "title"}'
+    )
+
+    result = daily_news.generate_edition_meta(fake_client, SAMPLE_ARTICLES)
+
+    assert result["standfirst"] == f"今朝の{len(SAMPLE_ARTICLES)}本。"
+    assert result["daily_title"] == " / ".join(
+        a["title"] for a in SAMPLE_ARTICLES
+    )
+
+
+def test_generate_edition_meta_falls_back_on_empty_strings() -> None:
+    """値が空文字なら、フォールバックを使う。"""
+    fake_client = _make_fake_anthropic(
+        '{"standfirst": "  ", "daily_title": ""}'
+    )
+
+    result = daily_news.generate_edition_meta(fake_client, SAMPLE_ARTICLES)
+
+    assert result["standfirst"] == f"今朝の{len(SAMPLE_ARTICLES)}本。"
+    assert result["daily_title"] == " / ".join(
+        a["title"] for a in SAMPLE_ARTICLES
+    )
+
+
+# ── 異常系: Claude API 例外 → フォールバック ─────────────────────────────
+
+
+def test_generate_edition_meta_falls_back_on_claude_exception() -> None:
+    fake_client = _make_failing_anthropic(RuntimeError("timeout"))
+
+    result = daily_news.generate_edition_meta(fake_client, SAMPLE_ARTICLES)
+
+    assert result["standfirst"] == f"今朝の{len(SAMPLE_ARTICLES)}本。"
+    assert result["daily_title"] == " / ".join(
+        a["title"] for a in SAMPLE_ARTICLES
+    )
+    # 例外でもリトライしない (1 回のみ)。Claude quota 浪費防止。
+    assert fake_client.messages.create.call_count == 1
+
+
+# ── 境界: articles が空 ────────────────────────────────────────────────
+
+
+def test_generate_edition_meta_handles_empty_articles() -> None:
+    """空 articles の場合、Claude を呼ばずに固定値を返す。"""
+    fake_client = MagicMock()
+
+    result = daily_news.generate_edition_meta(fake_client, [])
+
+    assert result["standfirst"] == "今朝の0本。"
+    assert result["daily_title"] == ""
+    fake_client.messages.create.assert_not_called()
+
+
+# ── 後処理ガード: 禁止ワード / 絵文字は warn のみで通す ───────────────
+
+
+def test_generate_edition_meta_warns_on_banned_word_but_passes_through(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    fake_client = _make_fake_anthropic(
+        '{"standfirst": "今朝の3本。やばい一日だった。", '
+        '"daily_title": "驚愕の AI 動向"}'
+    )
+    caplog.set_level(logging.WARNING, logger="daily_news")
+
+    result = daily_news.generate_edition_meta(fake_client, SAMPLE_ARTICLES)
+
+    # 値はそのまま通す (block しない)。
+    assert result["standfirst"] == "今朝の3本。やばい一日だった。"
+    assert result["daily_title"] == "驚愕の AI 動向"
+    # warning は 2 件以上出ている。
+    warning_records = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and "banned word" in r.getMessage()
+    ]
+    assert len(warning_records) >= 2
+
+
+def test_generate_edition_meta_warns_on_emoji_but_passes_through(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    fake_client = _make_fake_anthropic(
+        '{"standfirst": "今朝の3本。静かな観察。", '
+        '"daily_title": "AIニュース\\u2705"}'
+    )
+    caplog.set_level(logging.WARNING, logger="daily_news")
+
+    result = daily_news.generate_edition_meta(fake_client, SAMPLE_ARTICLES)
+
+    assert result["daily_title"] == "AIニュース✅"
+    emoji_warnings = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and "emoji" in r.getMessage()
+    ]
+    assert len(emoji_warnings) >= 1
+
+
+# ── 契約: 戻り値は dict[str, str] のキー ────────────────────────────────
+
+
+def test_generate_edition_meta_return_shape_contract() -> None:
+    """常に dict で "standfirst" / "daily_title" の 2 キーのみ。"""
+    fake_client: Callable[[str], MagicMock] = _make_fake_anthropic
+    for text in (
+        '{"standfirst": "今朝の3本。", "daily_title": "t"}',
+        "not json",
+        '{"standfirst": "今朝の3本。"}',
+    ):
+        result = daily_news.generate_edition_meta(
+            fake_client(text), SAMPLE_ARTICLES
+        )
+        assert set(result.keys()) == {"standfirst", "daily_title"}
+        assert isinstance(result["standfirst"], str)
+        assert isinstance(result["daily_title"], str)

--- a/tests/test_email_template.py
+++ b/tests/test_email_template.py
@@ -323,3 +323,79 @@ def test_build_html_large_skipped_count_renders_without_truncation() -> None:
     """Boundary: a two-digit skip count must render verbatim, not bucketed."""
     html = mailer.build_html(SAMPLE_ARTICLES, "2026.05.10", skipped_count=27)
     assert "字幕不足等でスキップ: 27件" in html
+
+
+# ── Standfirst (Issue #53) ─────────────────────────────────────────────
+
+
+def test_build_html_default_standfirst_keeps_legacy_text() -> None:
+    """Without ``standfirst=`` arg, the existing static lead must render."""
+    html = mailer.build_html(SAMPLE_ARTICLES, "2026.05.10")
+    # Legacy: 「今朝のN本。静かな朝の読みもの。」
+    assert "今朝の5本。" in html
+    assert "静かな朝の読みもの。" in html
+
+
+def test_build_html_renders_provided_standfirst_in_masthead_section() -> None:
+    """When ``standfirst`` is provided, it replaces the static lead."""
+    lead = "今朝の5本。観察的な一文がここに入る。"
+    html = mailer.build_html(SAMPLE_ARTICLES, "2026.05.10", standfirst=lead)
+    assert lead in html
+    # 静的フォールバック文は出ない (置換されている)。
+    assert "静かな朝の読みもの。" not in html
+    # Standfirst is rendered inside the .hb-stand section (between masthead
+    # and the first story).
+    stand_idx = html.index(lead)
+    section_open = html.index('class="hb-stand"')
+    first_story_idx = html.index('class="hb-story"')
+    assert section_open < stand_idx < first_story_idx, (
+        "standfirst must sit inside the hb-stand section"
+    )
+
+
+def test_build_html_standfirst_uses_primary_color_token() -> None:
+    """Generated standfirst inherits the existing primary text token."""
+    lead = "今朝の5本。静かに見る。"
+    html = mailer.build_html(SAMPLE_ARTICLES, "2026.05.10", standfirst=lead)
+    # The lead is wrapped in an <em> with color:#1A1A1A (existing token).
+    # We don't pin the exact substring shape, but the lead must sit near
+    # the design-token color reference, not be unstyled.
+    idx = html.index(lead)
+    window = html[max(0, idx - 200): idx + len(lead) + 50]
+    assert "#1A1A1A" in window, (
+        "standfirst must reuse the existing #1A1A1A primary token"
+    )
+
+
+def test_build_html_standfirst_escapes_html_special_chars() -> None:
+    """Standfirst must be HTML-escaped (defense against feed-injected markup
+    or future free-form Claude output)."""
+    lead = '今朝の5本。<script>alert(1)</script> & "quote"'
+    html = mailer.build_html(SAMPLE_ARTICLES, "2026.05.10", standfirst=lead)
+    assert "<script>" not in html
+    assert "&amp;" in html
+    assert "&lt;" in html and "&gt;" in html
+
+
+def test_build_html_empty_standfirst_is_backward_compatible() -> None:
+    """``standfirst=""`` behaves identically to the default-arg path."""
+    html_default = mailer.build_html(SAMPLE_ARTICLES, "2026.05.10")
+    html_empty = mailer.build_html(SAMPLE_ARTICLES, "2026.05.10", standfirst="")
+    assert html_default == html_empty
+
+
+def test_build_html_standfirst_signature_contract() -> None:
+    """Contract: ``standfirst`` is keyword-callable with default ``""``.
+
+    Pins the post-design-system call signature
+    ``build_html(articles, date, skipped_count=0, standfirst="")`` so
+    daily_news.py's call site does not silently break.
+    """
+    sig = inspect.signature(mailer.build_html)
+    params = sig.parameters
+    assert "standfirst" in params
+    assert params["standfirst"].default == ""
+    assert params["standfirst"].kind in (
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    )


### PR DESCRIPTION
## Summary

After the 5 stories are summarized, call Claude one more time to produce the edition's **standfirst** (one-sentence lede for email) and **daily_title** (one-line summary for archive). Both are persisted to the existing `editions.standfirst` / `editions.daily_title` columns (created in migration 004) and the standfirst is inlined into the email masthead.

```
Stage C (existing): summarize 5 stories
        │
Stage D (new):
  ├─ generate_edition_meta(client, articles)
  │     → Claude (1 call, ~$0.005)
  │     → JSON {"standfirst": "...", "daily_title": "..."}
  ├─ update_edition_meta(issue_no, ...) → DB persist
  └─ build_hibi_html(..., standfirst=...) → email render
```

## Why no migration in this PR

Migration `004_editions.sql` already declared the `standfirst` and `daily_title` columns up-front when the editions table was created. No schema change is needed for this PR — the columns are waiting to be populated. The agent had drafted `006_edition_standfirst_title.sql` as a safety net (idempotent `ADD COLUMN IF NOT EXISTS`) but it would have been pure noise in the migrations folder, so I dropped it before pushing.

## Robust failure handling

Every step falls back without breaking the daily delivery:

- Claude exception / non-JSON response / parse error / wrong field types / empty strings → fallback to `standfirst="今朝のN本。"`, `daily_title=" / ".join(titles)`.
- `update_edition_meta()` write failure → `log.warning`, email still sends.
- Voice violations in the model output → `log.warning`, persist as-is (matches the warn-only philosophy from #57).

## Test plan

- [x] `pytest tests/` → **44/44 PASS** (17 new: 11 for `generate_edition_meta`, 6 for `build_html` standfirst path; 27 existing untouched)
- [x] JSON parse covers naked, code-fenced, partially-valid, and malformed responses
- [x] `build_html(articles, date)` (no standfirst kwarg) keeps the legacy static lede → backwards compatible
- [x] HTML special chars in standfirst are escaped before injection
- [x] `inspect.signature(build_html).parameters['standfirst'].default == ""` contract test
- [ ] After merge: confirm next 13:17 UTC delivery's `editions.standfirst` is non-NULL in Neon
- [ ] Email's masthead area renders the Claude-generated lede instead of the static fallback

## Out of scope

- Retroactive backfill for past editions (separate issue if wanted)
- A/B variants of the lede prompt
- Display of `daily_title` in the email — that ships with the archive index work (#41 / #42)

## Status flags

- **Pytest Passed** (44/44)
- **Dry-run Not Run** (the new function is mocked end-to-end; an actual Claude call against prod data is not needed pre-merge)
- **Migration N/A** (004 already provides the columns)

Closes #53
Related: #39 (epic), #51 (closed — editions table), #57 (open — shares the voice rule shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)