### PR TITLE
feat(backend): stats_summary view (editions / stories / sources count) (#54)

### DIFF
--- a/db.py
+++ b/db.py
@@ -173,3 +173,27 @@ def update_edition_meta(
             (standfirst, daily_title, issue_no),
         )
         conn.commit()
+
+
+def get_stats_summary() -> dict[str, int]:
+    """`stats_summary` VIEW を 1 行読み出す (Issue #54).
+
+    Returns:
+        ``{"editions_count": int, "stories_count": int, "sources_count": int}``
+
+    呼び元は web archive masthead の集計表示 (#58)。view 側で 3 列を
+    1 行にまとめているので、 read は常に 1 行・1 RTT。
+    """
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "select editions_count, stories_count, sources_count "
+            "from stats_summary"
+        )
+        row = cur.fetchone()
+        if row is None:
+            return {"editions_count": 0, "stories_count": 0, "sources_count": 0}
+        return {
+            "editions_count": int(row[0]),
+            "stories_count": int(row[1]),
+            "sources_count": int(row[2]),
+        }

--- a/migrations/006_stats_summary_view.sql
+++ b/migrations/006_stats_summary_view.sql
@@ -1,0 +1,31 @@
+-- ================================================================
+-- stats_summary VIEW (Issue #54)
+--
+-- design-system の web archive masthead が表示する 3 集計を 1 行に
+-- まとめる。プレーン VIEW にしてあるので毎回再評価される (= 配信が
+-- 走ればその場で最新値が見える)。pg トラフィックが増えたら materialized
+-- view + cron refresh に昇格する想定。
+--
+--   * editions_count: editions テーブルの行数 = 配信回数。
+--   * stories_count : articles テーブルの行数 = 累計記事数。
+--   * sources_count : 直近 30 日に 1 件以上の記事を提供したソース数。
+--                     issue #54 案 B「運用中の証明として強い」を採用。
+--                     `articles.source_name` の DISTINCT を直近 30 日で
+--                     取る。`editions.sources_scanned` JSONB ではなく
+--                     articles 側を使うのは、JSONB は「fetch を試みた」
+--                     の記録で、「実際に記事を提供した」とはズレるため。
+--
+-- 2 回流しても壊れないよう REPLACE で書く。
+--
+-- 関連: epic #39 / issue #54
+-- ================================================================
+
+CREATE OR REPLACE VIEW stats_summary AS
+SELECT
+    (SELECT count(*) FROM editions)::int AS editions_count,
+    (SELECT count(*) FROM articles)::int AS stories_count,
+    (
+        SELECT count(DISTINCT source_name)
+        FROM articles
+        WHERE created_at >= now() - INTERVAL '30 days'
+    )::int AS sources_count;

--- a/tests/test_stats_summary.py
+++ b/tests/test_stats_summary.py
@@ -1,0 +1,107 @@
+"""Unit tests for db.get_stats_summary (Issue #54).
+
+The actual VIEW lives in migrations/006_stats_summary_view.sql and is
+applied to Neon out-of-band. These tests only verify the Python wrapper:
+- it issues the expected query against ``stats_summary``,
+- it maps the 3-column row to a typed dict,
+- it returns zeros when the view returns no rows (defensive — should not
+  happen in practice because the VIEW always projects exactly 1 row).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import db
+
+
+class _FakeCursor:
+    def __init__(self, row: tuple[int, int, int] | None) -> None:
+        self.row = row
+        self.executed: list[tuple[str, tuple[Any, ...] | None]] = []
+
+    def __enter__(self) -> "_FakeCursor":
+        return self
+
+    def __exit__(self, *_a: object) -> None:
+        return None
+
+    def execute(self, sql: str, params: tuple[Any, ...] | None = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> tuple[int, int, int] | None:
+        return self.row
+
+
+class _FakeConn:
+    def __init__(self, cursor: _FakeCursor) -> None:
+        self._cursor = cursor
+
+    def __enter__(self) -> "_FakeConn":
+        return self
+
+    def __exit__(self, *_a: object) -> None:
+        return None
+
+    def cursor(self) -> _FakeCursor:
+        return self._cursor
+
+
+def _patch_get_conn(monkeypatch, cursor: _FakeCursor) -> None:
+    monkeypatch.setattr(db, "get_conn", lambda: _FakeConn(cursor))
+
+
+def test_returns_typed_dict_from_view_row(monkeypatch) -> None:
+    cursor = _FakeCursor(row=(142, 710, 28))
+    _patch_get_conn(monkeypatch, cursor)
+
+    out = db.get_stats_summary()
+
+    assert out == {
+        "editions_count": 142,
+        "stories_count": 710,
+        "sources_count": 28,
+    }
+
+
+def test_query_targets_stats_summary_view(monkeypatch) -> None:
+    cursor = _FakeCursor(row=(0, 0, 0))
+    _patch_get_conn(monkeypatch, cursor)
+
+    db.get_stats_summary()
+
+    assert len(cursor.executed) == 1
+    sql, _ = cursor.executed[0]
+    assert "stats_summary" in sql
+    # All three projected columns are read out.
+    for col in ("editions_count", "stories_count", "sources_count"):
+        assert col in sql
+
+
+def test_returns_zeros_when_view_returns_no_row(monkeypatch) -> None:
+    """Defensive: the view always returns 1 row in practice, but if the
+    DB call returns None (e.g. transient transport oddity), do not crash —
+    the masthead can render zeros without 500-ing."""
+    cursor = _FakeCursor(row=None)
+    _patch_get_conn(monkeypatch, cursor)
+
+    out = db.get_stats_summary()
+
+    assert out == {
+        "editions_count": 0,
+        "stories_count": 0,
+        "sources_count": 0,
+    }
+
+
+def test_coerces_view_values_to_int(monkeypatch) -> None:
+    """The view casts to ::int already, but psycopg may return numerics in
+    some drivers — make sure the wrapper coerces uniformly."""
+    cursor = _FakeCursor(row=(MagicMock(__int__=lambda _self: 5), 9, 2))
+    _patch_get_conn(monkeypatch, cursor)
+
+    out = db.get_stats_summary()
+
+    assert out["editions_count"] == 5
+    assert isinstance(out["editions_count"], int)


### PR DESCRIPTION
## Summary

Add a plain SQL `VIEW` that exposes the three numbers Hibi's web archive masthead wants in one row, plus a thin Python wrapper.

| Column | Source |
|---|---|
| `editions_count` | `count(*) FROM editions` |
| `stories_count` | `count(*) FROM articles` |
| `sources_count` | `count(DISTINCT source_name) FROM articles WHERE created_at >= now() - INTERVAL '30 days'` |

For `sources_count` I went with **option B** from the issue ("過去 30 日に 1 件以上記事を提供したソース数") because that's what "currently operating" means in the masthead context. I sourced it from `articles.source_name`, not `editions.sources_scanned`, because the JSONB column records "fetch was attempted" while we want "actually produced a story" — those diverge when a source errors all month.

## Files

- `migrations/006_stats_summary_view.sql` (new) — `CREATE OR REPLACE VIEW`, idempotent.
- `db.py` — `get_stats_summary() -> dict[str, int]` reads the view in 1 round-trip. Falls back to zeros if the row is missing (defensive — should not happen since a `VIEW` always projects one row, but keeps the masthead from 500-ing on a transient cold-start hiccup).
- `tests/test_stats_summary.py` (new, 4 cases) — verifies the typed dict shape, the SELECT targets the view by name and reads all three columns, the zero-fallback path, and int coercion at the wrapper boundary.

## Test plan

- [x] `pytest tests/test_stats_summary.py -v` → **4/4 PASS**
- [x] `pytest tests/` → **86/86 PASS** (no regression on the 82 existing tests after rebase onto current main)
- [ ] After merge: apply `006_stats_summary_view.sql` to Neon, then run `select * from stats_summary;` to verify values look right.

## Out of scope

- Display of these counts in the web — `#58` (landing page) consumes this view.
- Materialized view + cron refresh — kept as a plain VIEW so it always reads fresh. Promote when traffic warrants.
- Sub-day granularity / time-series — explicitly YAGNI per the issue.

## Status flags

- **Pytest Passed** (86/86)
- **Migration Pending** — `migrations/006_stats_summary_view.sql` to be applied to Neon post-merge.

Closes #54
Related: #39 (epic), #51 (closed), #58 (open — consumer of this view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)