### PR TITLE
fix(manager): accept backtick-wrapped Recommendation values in plan parser

### DIFF
--- a/manager/parsers/plan.py
+++ b/manager/parsers/plan.py
@@ -6,7 +6,7 @@ from . import ParseError
 from ..types import PlanRecommendation
 
 _REC_RE = re.compile(
-    r"#\s*Recommendation\s*\n+\s*-?\s*(proceed with caution|confirm first|proceed)\b",
+    r"#\s*Recommendation\s*\n+\s*-?\s*`?(proceed with caution|confirm first|proceed)`?\b",
     re.IGNORECASE,
 )
 

--- a/manager/tests/fixtures/plan_proceed_with_caution_backticked.md
+++ b/manager/tests/fixtures/plan_proceed_with_caution_backticked.md
@@ -1,0 +1,12 @@
+# Goal
+add Better Auth schema migration
+
+# Acceptance Criteria
+- migration is idempotent
+- snake_case columns
+
+# Minimal Plan
+- new file migrations/007_better_auth_schema.sql
+
+# Recommendation
+`proceed with caution`

--- a/manager/tests/test_parsers.py
+++ b/manager/tests/test_parsers.py
@@ -56,6 +56,15 @@ def test_parse_plan_confirm(fixtures_dir: Path) -> None:
     assert parse_plan(_read(fixtures_dir, "plan_confirm.md")) == "confirm first"
 
 
+def test_parse_plan_proceed_with_caution_backticked(fixtures_dir: Path) -> None:
+    # /spec-architect は Recommendation 行の値を markdown コードスタイルで
+    # 囲うことがある (`proceed with caution`)。バッククォートを許容する。
+    assert (
+        parse_plan(_read(fixtures_dir, "plan_proceed_with_caution_backticked.md"))
+        == "proceed with caution"
+    )
+
+
 def test_parse_plan_missing_raises() -> None:
     with pytest.raises(ParseError):
         parse_plan("# Goal\nnothing")


### PR DESCRIPTION
## Summary

- `/spec-architect` outputs the Recommendation value with markdown code formatting (e.g. \`proceed with caution\`)
- the plan parser's regex required a bare token and threw \"Recommendation 行が見つからない\", halting the manager run after PLAN_MAX_ATTEMPTS=2 retries
- allow optional backtick on either side of the value
- add fixture \`plan_proceed_with_caution_backticked.md\` + test case capturing the real output shape

## Why

Discovered during \`/manager run --live 109\` (epic-109 PLAN stage). #103 produced a complete, parseable plan but tripped the regex because of decorative backticks. 3 PLAN attempts × ~\$0.45 = ~\$1.35 burned on a parser issue rather than a real architecture problem.

## Test plan

- [x] \`pytest manager/tests/test_parsers.py\` — 15/15 pass (new test exercises backtick variant)
- [x] regex still rejects unrelated text (existing \`test_parse_plan_missing_raises\` still passes)
- [ ] after merge, re-run \`/manager run --live 109\` and confirm #103 PLAN now parses