### PR TITLE
fix(manager): accept short '# Verdict' and backtick-wrapped value in dev-loop parser

### DIFF
--- a/manager/parsers/dev_loop.py
+++ b/manager/parsers/dev_loop.py
@@ -7,7 +7,7 @@ from . import ParseError
 from ..types import ReviewVerdict
 
 _VERDICT_RE = re.compile(
-    r"#\s*Review Verdict\s*\n+\s*-?\s*(safe to merge|fix before merge|confirm before merge)\b",
+    r"#\s*(?:Review\s+)?Verdict\s*\n+\s*-?\s*`?(safe to merge|fix before merge|confirm before merge)`?\b",
     re.IGNORECASE,
 )
 _PYTEST_RE = re.compile(

--- a/manager/tests/fixtures/dev_loop_safe_short_verdict_backticked.md
+++ b/manager/tests/fixtures/dev_loop_safe_short_verdict_backticked.md
@@ -1,0 +1,27 @@
+# Verdict
+
+`safe to merge`
+
+# Critical Issues
+
+なし。
+
+# High Issues
+
+なし。
+
+# Medium Issues
+
+なし。
+
+# Low Issues
+
+- minor wording suggestion only
+
+# Missing Tests
+
+なし。
+
+# Missing Docs
+
+なし。

--- a/manager/tests/test_parsers.py
+++ b/manager/tests/test_parsers.py
@@ -70,6 +70,17 @@ def test_parse_plan_missing_raises() -> None:
         parse_plan("# Goal\nnothing")
 
 
+def test_parse_dev_loop_safe_short_verdict_backticked(fixtures_dir: Path) -> None:
+    # /run-dev-loop は header を `# Verdict` (公式 `# Review Verdict` を短縮)
+    # かつ値を markdown コードスタイル (`safe to merge`) で出力することがある。
+    # 両方を許容する。
+    outcome = parse_dev_loop(
+        _read(fixtures_dir, "dev_loop_safe_short_verdict_backticked.md")
+    )
+    assert outcome.verdict == "safe to merge"
+    assert outcome.blocked is False
+
+
 def test_parse_dev_loop_safe(fixtures_dir: Path) -> None:
     outcome = parse_dev_loop(_read(fixtures_dir, "dev_loop_safe.md"))
     assert outcome.verdict == "safe to merge"


### PR DESCRIPTION
## Summary

- /run-dev-loop spec dictates \`# Review Verdict\` header + bare token value
- subagent commonly emits \`# Verdict\` with the value backtick-wrapped (\`safe to merge\`)
- strict regex threw \"Review Verdict 行が見つからない\" and halted the manager mid-IMPLEMENT
- make the \"Review\" prefix optional and allow optional backticks on either side of the value
- add fixture \`dev_loop_safe_short_verdict_backticked.md\` + parser test

## Why

Discovered during \`/manager run --live 109\` (epic-109 IMPLEMENT stage for #103). The subagent produced a complete review with verdict \`safe to merge\` and zero critical/high issues, but the parser rejected it on header/value formatting. Companion of #119 which applied the same kind of fix to the plan parser.

## Test plan

- [x] \`pytest manager/tests/test_parsers.py\` — 16/16 pass (new test exercises the short+backticked variant)
- [x] existing \`test_parse_dev_loop_safe\` still passes (long header + bullet form still accepted)
- [x] \`test_parse_dev_loop_missing_verdict_raises\` still passes (regex still rejects unrelated text)
- [ ] after merge, re-run \`/manager run --live 109\` and confirm #103 IMPLEMENT now parses