### PR TITLE
chore: switch Claude model from Sonnet 4.6 to Haiku 4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ GitHub Actions（毎朝 UTC 13:00 = Vancouver 6:00 AM PDT）
        ├─ 本文取得
        │    ├─ YouTube: youtube-transcript-api（WebShare proxy 経由）
        │    └─ RSS: trafilatura（本文抽出 + robots.txt 尊重）
-       ├─ Claude Sonnet 4.6（日本語3行要約、要約不能時は空文字返却）
+       ├─ Claude Haiku 4.5（日本語3行要約、要約不能時は空文字返却）
        └─ Gmail API（OAuth2）→ 受信トレイへ配信（目標 5 本）
 ```
 
@@ -82,7 +82,7 @@ python scripts/test_neon_connection.py
 
 | サービス | コスト |
 |---|---|
-| Claude Sonnet 4.6 | 約 $0.05 / 日（9動画 × 15,000 chars） |
+| Claude Haiku 4.5 | 約 $0.02 / 日（9動画 × 15,000 chars。Sonnet 比 約 1/3）|
 | YouTube Data API v3 | 無料枠内（約 60 units / 日、上限 10,000） |
 | Gmail API | 無料 |
 

--- a/daily_news.py
+++ b/daily_news.py
@@ -51,7 +51,7 @@ MAX_VIDEOS_PER_RUN = 5  # 1回の配信で要約・送信する最大本数（�
 MAX_ATTEMPTS = 30  # 1回の実行で試行する最大候補数（無限試行防止）
 MIN_CONTENT_CHARS = 500  # transcript/記事本文がこれ未満なら失敗扱い
 MIN_SUMMARY_CHARS = 10  # Claude が防御プロンプトに従って空を返したケースを弾く閾値
-CLAUDE_MODEL = "claude-sonnet-4-6"
+CLAUDE_MODEL = "claude-haiku-4-5-20251001"
 CONTENT_CHAR_LIMIT = 15000  # Claude に渡す本文の上限（コスト制御）
 EMBEDDING_MODEL = "text-embedding-3-small"  # OpenAI; 1536 dim。差し替える時は 003 migration も見直す
 


### PR DESCRIPTION
## Summary

Switch Hibi's summarization model from \`claude-sonnet-4-6\` to \`claude-haiku-4-5-20251001\`.

- \`daily_news.py\`: \`CLAUDE_MODEL\` constant
- \`README.md\`: flow diagram + cost table

## Why

Hibi's summarize task is a fixed-format 3-line Japanese summary from pre-cleaned transcript/article text. Haiku 4.5 is sufficient for that shape and runs at roughly **1/3 the per-token cost of Sonnet 4.6**. Aligns with the single-user, no-public-surface posture in \`docs/legal-posture.md\` — minimum spend, minimum surface.

## Rollback

If summary quality drops noticeably in the next 5–7 daily runs, revert this one-line change.

## Test plan

- [x] Diff is minimal (3 lines across 2 files)
- [ ] Tomorrow's run: spot-check 3 summaries for hallucination / awkward Japanese; revert if degraded

Note: independent of PR #132 (web/service drop). Both can land in either order.