### PR TITLE
feat(pr-creation): force epic branch as PR base when child branch detected

### DIFF
--- a/.claude/commands/pr-creation.md
+++ b/.claude/commands/pr-creation.md
@@ -1,10 +1,24 @@
 # /pr-creation
 
-現在のブランチから `main` への PR を作成するコマンド。
+現在のブランチから **適切な base ブランチ** (epic ブランチがあればそれ、無ければ `main`) への PR を作成するコマンド。
 
 ## Role
 
-変更ファイルを確認し、PR テンプレートを埋めて、MCP github (`mcp__github__create_pull_request`) で main への PR を作る。MCP server が無い環境では Bash の `gh pr create` でフォールバックする。
+変更ファイルを確認し、PR テンプレートを埋めて、MCP github (`mcp__github__create_pull_request`) で適切な base への PR を作る。MCP server が無い環境では Bash の `gh pr create` でフォールバックする。
+
+## Base ブランチ判定 (絶対ルール)
+
+**epic ブランチが存在する場合は必ず epic ブランチを base にする。main を base にしない。**
+
+判定ロジック:
+
+1. 現在のブランチ名を取得 (`git rev-parse --abbrev-ref HEAD`)
+2. パターン `^epic/\d+-.*-child-\d+$` (例: `epic/134-epic-child-136`) にマッチするか確認
+3. マッチする場合: `-child-\d+` を除いた部分を epic ブランチとする (例: `epic/134-epic`)
+4. epic ブランチが存在 (`git rev-parse --verify <epic-branch>` または `origin/<epic-branch>`) する場合: それを base にする
+5. それ以外: base は `main`
+
+子 PR を main に向けると `git rebase` / `merge` 衝突 + epic 統合 PR でのレビュー範囲膨張 + 子 commit が main 履歴を直接汚す問題が起きるので、これを防ぐためのルール。
 
 ## Inputs
 
@@ -21,6 +35,7 @@
 - 人間への確認なしに merge しない
 - force push をしない
 - `main` ブランチに直接コミット・push しない
+- **epic ブランチが存在するのに `main` を base にして PR を作らない** (絶対ルール、上記「Base ブランチ判定」参照)
 - `.env` / 鍵 / トークン / `*.json` の credentials を stage しない
 - レビュアーの判定が `fix before merge` のまま PR を作らない
 - HMAC シークレット rotation を伴う変更は main への直接 push をしない（必ずブランチ + PR + 運用窓説明）
@@ -42,7 +57,7 @@
 ### Step 2: 変更ファイルを確認
 
 ```bash
-git diff --name-only main...HEAD
+git diff --name-only <base>...HEAD   # <base> は「Base ブランチ判定」で決めた値 (epic ブランチ or main)
 ```
 
 | パス | フラグ |
@@ -85,7 +100,7 @@ git diff --name-only main...HEAD
 引数:
 
 - `owner` / `repo` は現在のリポジトリ
-- `base`: `main`
+- `base`: 「Base ブランチ判定」で決めた値 (epic ブランチ or `main`)
 - `head`: 現在のブランチ
 - `title`: concise summary（PR Title Format に従う）
 - `body`: 埋めたテンプレート
@@ -93,8 +108,9 @@ git diff --name-only main...HEAD
 **フォールバック** (MCP github が利用できない環境のみ):
 
 ```bash
+BASE=$(... 「Base ブランチ判定」で決めた値、epic ブランチがあればそれ、無ければ main ...)
 gh pr create \
-  --base main \
+  --base "$BASE" \
   --head <current-branch> \
   --title "<concise summary>" \
   --body "<filled-in template>"


### PR DESCRIPTION
## Summary

`/pr-creation` slash command が `--base main` ハードコードだったため、子 issue の PR が main を向き、誤って merge される事故が発生 (epic #134 / PR #141)。

子ブランチ名のパターン `^epic/\d+-.*-child-\d+$` (例: `epic/134-epic-child-136`) を検知した場合、`-child-\d+` を除いた部分を base ブランチとして使うルールを追加。

これにより:

- 子 PR が初手から正しい base (epic ブランチ) を向く
- Manager の retarget soft-fail (`gh pr edit --base`) に依存しなくなる
- 子 PR を main に直接 merge する事故を構造的に防げる

## Test plan

- [ ] 子ブランチ作成後 `/pr-creation` を実行し、base が epic ブランチになることを目視確認
- [ ] epic ブランチが存在しないブランチで `/pr-creation` を実行し、base が main にフォールバックすることを確認
- [ ] `.claude/commands/pr-creation.md` の文言 (Forbidden / Base ブランチ判定セクション) のレビュー

## Related

- Epic #134
- 事故元 PR #141 (main に誤 merge 済)
- `feedback_pr_base_epic.md` (memory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)