### PR TITLE
feat(idea-mining): Apple iTunes RSS fetcher → voices table (#136)

### DIFF
--- a/.github/workflows/idea-mining-weekly.yml
+++ b/.github/workflows/idea-mining-weekly.yml
@@ -1,0 +1,42 @@
+name: Idea Mining Weekly
+
+# idea-mining 用の private fetcher を週次で走らせる。
+#
+# 現状は Apple iTunes RSS (★1-4 customer reviews → voices) のみ。
+# newspaper pipeline (`daily-news.yml`) とは完全に分離していて、
+# 失敗してもニュースレターには影響しない。
+#
+# 関連: Issue #136, idea_mining/fetchers/apple_rss.py, migration 008.
+
+on:
+  schedule:
+    # 毎週月曜 14:00 UTC (= JST 23:00) — daily-news (13:17 UTC) と十分離す。
+    - cron: "0 14 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  apple_rss:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - run: pip install -r requirements.txt
+
+      - run: python -m idea_mining.fetchers.apple_rss
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          # Optional — if SENTRY_DSN is unset the fetcher still runs;
+          # 5-consecutive-failure alerts simply log to stderr.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          HIBI_RELEASE: ${{ github.sha }}
+          HIBI_ENV: production

--- a/idea_mining/fetchers/__init__.py
+++ b/idea_mining/fetchers/__init__.py
@@ -1,0 +1,5 @@
+"""idea_mining fetchers package.
+
+Newspaper pipeline (`fetchers/`) と独立した、idea-mining 専用の fetcher 群を
+収める。書き込み先は `voices` テーブル (private)。`articles` には触れない。
+"""

--- a/idea_mining/fetchers/apple_rss.py
+++ b/idea_mining/fetchers/apple_rss.py
@@ -1,0 +1,426 @@
+"""Apple iTunes RSS fetcher — ★1-4 customer reviews into `voices`.
+
+各 (country, app_id) について Apple 公式 RSS customer-reviews endpoint を
+叩き、★1-4 のレビューだけを `voices` テーブルに insert する。★5 は
+INSERT 前に除外し、元の rating は `meta.rating` (1-5) に保持する。
+
+newspaper pipeline (`daily_news.py` / `articles` / mailer / archive) からは
+独立した経路。失敗してもニュースレターには影響しない。
+
+Idempotency:
+    INSERT は `ON CONFLICT (source, source_id) DO NOTHING` で、同一 (source,
+    review_id) の再 insert は NoOp になる (migration 008 の UNIQUE 制約)。
+
+Retry / Failure:
+    HTTP 失敗時は exp backoff 1s,2s,4s,8s,16s で最大 5 回リトライ
+    (1 初期 + 5 retries = 6 attempts)。5 回連続で retry が失敗したら
+    Sentry alert を発火し、当該アプリ × country を skip して次へ進む。
+
+CLI entry-point:
+    `python -m idea_mining.fetchers.apple_rss` を idea-mining-weekly
+    workflow から呼ぶ。`DATABASE_URL` 必須。`SENTRY_DSN` は任意。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Final
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import psycopg
+import sentry_sdk
+import yaml
+from psycopg.types.json import Jsonb
+
+log = logging.getLogger(__name__)
+
+SOURCE_NAME: Final[str] = "apple_rss"
+
+APPLE_RSS_URL_FMT: Final[str] = (
+    "https://itunes.apple.com/{country}/rss/customerreviews/"
+    "id={app_id}/sortby=mostrecent/json"
+)
+USER_AGENT: Final[str] = (
+    "HibiIdeaMiningBot/1.0 (+https://github.com/kazuki-0418/hibi)"
+)
+HTTP_TIMEOUT_SECONDS: Final[int] = 30
+
+# 1 initial attempt + 5 retries with these inter-attempt delays.
+# After all retries are exhausted (5 consecutive failures), Sentry alert + skip.
+RETRY_DELAYS_SECONDS: Final[tuple[int, ...]] = (1, 2, 4, 8, 16)
+
+# country → BCP-47 lang lookup. Apple feed の本文は country の主要言語に
+# 倣う前提 (本文判定は行わない)。MVP では jp のみ運用。
+LANG_BY_COUNTRY: Final[dict[str, str]] = {
+    "jp": "ja",
+    "us": "en",
+    "gb": "en",
+    "ca": "en",
+    "au": "en",
+}
+
+
+# ----------------------------------------------------------------------
+# Config (sources.yaml)
+# ----------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AppleApp:
+    """sources.yaml の apple_apps セクション 1 件分。"""
+
+    name: str
+    app_id: str
+    countries: tuple[str, ...]
+    enabled: bool = True
+
+
+def load_apple_apps(sources_yaml_path: str | Path) -> list[AppleApp]:
+    """`sources.yaml` から有効な apple_apps エントリを返す。
+
+    既存 `sources:` / `channels` / `rss` セクションには触れない。
+    """
+    with open(sources_yaml_path, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+
+    raw_apps = data.get("apple_apps") or []
+    apps: list[AppleApp] = []
+    for entry in raw_apps:
+        if not entry.get("enabled", True):
+            continue
+        countries_raw = entry.get("country") or []
+        if not isinstance(countries_raw, list) or not countries_raw:
+            log.warning(
+                "apple_rss: skip %r — country must be a non-empty list",
+                entry.get("name"),
+            )
+            continue
+        apps.append(
+            AppleApp(
+                name=str(entry["name"]),
+                app_id=str(entry["app_id"]),
+                countries=tuple(str(c) for c in countries_raw),
+                enabled=True,
+            )
+        )
+    return apps
+
+
+# ----------------------------------------------------------------------
+# HTTP fetch with retry + backoff
+# ----------------------------------------------------------------------
+
+
+HttpGet = Callable[[str], dict]
+
+
+def _default_http_get(url: str) -> dict:
+    """Default JSON GET. Raises URLError / HTTPError / JSONDecodeError / TimeoutError."""
+    req = Request(url, headers={"User-Agent": USER_AGENT})
+    with urlopen(req, timeout=HTTP_TIMEOUT_SECONDS) as resp:
+        payload = resp.read()
+    return json.loads(payload.decode("utf-8"))
+
+
+_RETRYABLE_EXC: tuple[type[BaseException], ...] = (
+    URLError,
+    HTTPError,
+    TimeoutError,
+    json.JSONDecodeError,
+    ConnectionError,
+)
+
+
+def fetch_one(
+    country: str,
+    app_id: str,
+    *,
+    http_get: HttpGet = _default_http_get,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> dict | None:
+    """Fetch 1 (country, app_id) feed with exp-backoff retry.
+
+    Returns the decoded JSON dict on success, or ``None`` if all retries
+    were exhausted. On exhaustion, sends a Sentry alert and returns
+    ``None`` so the caller can skip and move on.
+    """
+    url = APPLE_RSS_URL_FMT.format(country=country, app_id=app_id)
+    last_err: BaseException | None = None
+
+    try:
+        return http_get(url)
+    except _RETRYABLE_EXC as e:
+        last_err = e
+        log.warning("apple_rss: initial fetch failed for %s/%s: %r", country, app_id, e)
+
+    for retry_n, delay in enumerate(RETRY_DELAYS_SECONDS, start=1):
+        sleep_fn(delay)
+        try:
+            return http_get(url)
+        except _RETRYABLE_EXC as e:
+            last_err = e
+            log.warning(
+                "apple_rss: retry %d/%d failed for %s/%s: %r",
+                retry_n,
+                len(RETRY_DELAYS_SECONDS),
+                country,
+                app_id,
+                e,
+            )
+
+    sentry_sdk.capture_message(
+        f"apple_rss: 5 consecutive retries exhausted for {country}/{app_id}: {last_err!r}",
+        level="error",
+    )
+    return None
+
+
+# ----------------------------------------------------------------------
+# Parser (Apple RSS JSON → voice rows)
+# ----------------------------------------------------------------------
+
+
+def _entry_field(entry: dict, key: str) -> str | None:
+    """Apple feed の `{label: ...}` 構造を 1 段剥がす。欠落時 None."""
+    node = entry.get(key)
+    if not isinstance(node, dict):
+        return None
+    label = node.get("label")
+    return str(label) if label is not None else None
+
+
+def _entry_author(entry: dict) -> str | None:
+    author = entry.get("author")
+    if not isinstance(author, dict):
+        return None
+    name = author.get("name")
+    if isinstance(name, dict):
+        label = name.get("label")
+        return str(label) if label is not None else None
+    return None
+
+
+def _parse_rating(raw: str | None) -> int | None:
+    """`im:rating.label` を int に。失敗時 None (= 不正エントリは捨てる)。"""
+    if raw is None:
+        return None
+    try:
+        v = int(raw)
+    except ValueError:
+        return None
+    if v < 1 or v > 5:
+        return None
+    return v
+
+
+def parse_review_entries(
+    payload: dict,
+    *,
+    country: str,
+    app_id: str,
+) -> list[dict]:
+    """Apple RSS JSON を voice row dict のリストに整形。★5 は除外。
+
+    Returns:
+        list of dicts with keys:
+            source     — fixed 'apple_rss'
+            source_id  — review id (str)
+            posted_at  — ISO timestamp (str)
+            title      — review title (str | None)
+            body       — review content (str | None)
+            meta       — {version, author, country, lang, rating}
+    """
+    feed = payload.get("feed") or {}
+    entries_raw = feed.get("entry")
+    if entries_raw is None:
+        return []
+    if isinstance(entries_raw, dict):
+        entries_raw = [entries_raw]
+    if not isinstance(entries_raw, list):
+        return []
+
+    lang = LANG_BY_COUNTRY.get(country, country)
+    rows: list[dict] = []
+    for entry in entries_raw:
+        if not isinstance(entry, dict):
+            continue
+        rating = _parse_rating(_entry_field(entry, "im:rating"))
+        if rating is None:
+            # No rating → app metadata entry or malformed; skip.
+            continue
+        if rating == 5:
+            # ★5 は idea-mining 対象外 (positive bias / spam)。
+            continue
+        review_id = _entry_field(entry, "id")
+        if not review_id:
+            continue
+        posted_at = _entry_field(entry, "updated")
+        if not posted_at:
+            continue
+        rows.append(
+            {
+                "source": SOURCE_NAME,
+                "source_id": review_id,
+                "posted_at": posted_at,
+                "title": _entry_field(entry, "title"),
+                "body": _entry_field(entry, "content"),
+                "meta": {
+                    "version": _entry_field(entry, "im:version"),
+                    "author": _entry_author(entry),
+                    "country": country,
+                    "lang": lang,
+                    "rating": rating,
+                    "app_id": app_id,
+                },
+            }
+        )
+    return rows
+
+
+# ----------------------------------------------------------------------
+# DB insert
+# ----------------------------------------------------------------------
+
+
+INSERT_SQL: Final[str] = """
+    INSERT INTO voices (source, source_id, posted_at, title, body, meta)
+    VALUES (%(source)s, %(source_id)s, %(posted_at)s, %(title)s, %(body)s, %(meta)s)
+    ON CONFLICT (source, source_id) DO NOTHING
+"""
+
+
+def insert_voices(conn: psycopg.Connection, rows: list[dict]) -> int:
+    """Bulk-insert voice rows. Returns the number of rows the DB reports
+    as actually inserted (ON CONFLICT skips do not count).
+    """
+    if not rows:
+        return 0
+    inserted = 0
+    with conn.cursor() as cur:
+        for row in rows:
+            params = {
+                "source": row["source"],
+                "source_id": row["source_id"],
+                "posted_at": row["posted_at"],
+                "title": row.get("title"),
+                "body": row.get("body"),
+                "meta": Jsonb(row.get("meta") or {}),
+            }
+            cur.execute(INSERT_SQL, params)
+            inserted += cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
+    conn.commit()
+    return inserted
+
+
+# ----------------------------------------------------------------------
+# Orchestration
+# ----------------------------------------------------------------------
+
+
+@dataclass
+class RunStats:
+    apps_total: int = 0
+    pairs_total: int = 0
+    pairs_skipped: int = 0
+    rows_parsed: int = 0
+    rows_inserted: int = 0
+    failures: list[str] = field(default_factory=list)
+
+
+def run_once(
+    apps: list[AppleApp],
+    *,
+    conn: psycopg.Connection,
+    http_get: HttpGet = _default_http_get,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> RunStats:
+    """Drive (app × country) iteration end-to-end. Single-process, sync."""
+    stats = RunStats(apps_total=len(apps))
+    for app in apps:
+        for country in app.countries:
+            stats.pairs_total += 1
+            payload = fetch_one(
+                country, app.app_id, http_get=http_get, sleep_fn=sleep_fn
+            )
+            if payload is None:
+                stats.pairs_skipped += 1
+                stats.failures.append(f"{country}/{app.app_id}")
+                continue
+            rows = parse_review_entries(
+                payload, country=country, app_id=app.app_id
+            )
+            stats.rows_parsed += len(rows)
+            stats.rows_inserted += insert_voices(conn, rows)
+    return stats
+
+
+# ----------------------------------------------------------------------
+# CLI entry-point (invoked by .github/workflows/idea-mining-weekly.yml)
+# ----------------------------------------------------------------------
+
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
+DEFAULT_SOURCES_YAML: Final[Path] = REPO_ROOT / "sources.yaml"
+
+
+def _init_sentry() -> None:
+    """Sentry を `observability.init_sentry_from_env` と同じ env で初期化。"""
+    dsn = os.environ.get("SENTRY_DSN")
+    if not dsn:
+        log.info("apple_rss: SENTRY_DSN unset — failure alerts disabled")
+        return
+    sentry_sdk.init(
+        dsn=dsn,
+        release=os.environ.get("HIBI_RELEASE", "dev"),
+        environment=os.environ.get("HIBI_ENV", "production"),
+        traces_sample_rate=0.0,
+        send_default_pii=False,
+    )
+    sentry_sdk.set_tag("pipeline", "idea_mining_apple_rss")
+
+
+def _connect() -> psycopg.Connection:
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        print("ERROR: DATABASE_URL is not set", file=sys.stderr)
+        sys.exit(1)
+    return psycopg.connect(url)
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    _init_sentry()
+
+    apps = load_apple_apps(DEFAULT_SOURCES_YAML)
+    log.info("apple_rss: %d enabled apps loaded", len(apps))
+    if not apps:
+        log.info("apple_rss: no enabled apps — nothing to do")
+        return 0
+
+    with _connect() as conn:
+        stats = run_once(apps, conn=conn)
+
+    log.info(
+        "apple_rss: done apps=%d pairs=%d skipped=%d parsed=%d inserted=%d failures=%s",
+        stats.apps_total,
+        stats.pairs_total,
+        stats.pairs_skipped,
+        stats.rows_parsed,
+        stats.rows_inserted,
+        stats.failures,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/migrations/008_voices.sql
+++ b/migrations/008_voices.sql
@@ -1,0 +1,60 @@
+-- ================================================================
+-- voices table (Issue #136, child of epic #134 — idea mining)
+--
+-- 製品レビューやユーザーの声 (UGC) を idea-mining 用に蓄積する
+-- private テーブル。newspaper pipeline (`articles` / `is_sent` /
+-- ranking / embedding) からは独立しており、daily newsletter / web
+-- archive にも露出しない。
+--
+-- 初期 fetcher は Apple iTunes RSS (`idea_mining/fetchers/apple_rss.py`)
+-- で、★1-4 のレビューのみを source='apple_rss' として insert する。
+-- ★5 は INSERT 前にコード側で除外する (rating は meta JSONB に保持)。
+--
+-- ## カラム
+--
+--   * id          — UUID PK
+--   * source      — fetcher 名 (e.g. 'apple_rss')。将来 Reddit / HN を
+--                   追加するときは別 source 値で並列に積む。
+--   * source_id   — fetcher 内で一意な ID (Apple RSS の review id)。
+--   * posted_at   — レビュー投稿日時 (Apple feed の `updated`)。
+--   * title       — レビュータイトル (Apple feed の `title`)。
+--   * body        — レビュー本文 (Apple feed の `content`)。
+--   * meta        — JSONB: { version, author, country, lang, rating, ... }。
+--                   スキーマは fetcher ごとに緩く、追加フィールドは将来
+--                   ALTER 無しで足せる。
+--   * created_at  — 取り込み時刻。
+--
+-- ## 制約
+--
+--   * UNIQUE (source, source_id) — 再実行で同一レビューが重複しない
+--     ように。INSERT 側は ON CONFLICT (source, source_id) DO NOTHING で
+--     冪等にする。
+--   * idx_voices_source_posted — 「最近のレビュー」クエリ用。
+--
+-- ## 非対応
+--
+--   * daily newsletter / archive への露出 (private のまま)
+--   * embedding / pgvector 適用 (Issue #136 では out-of-scope)
+--   * 評価 UI / 削除 UI
+--   * `clicks.user_id` 連携 (1 人運用前提)
+--
+-- 2 回流しても壊れないよう全部 idempotent (IF NOT EXISTS)。
+-- 手動 apply: Neon SQL Editor で実行する。
+-- ================================================================
+
+CREATE TABLE IF NOT EXISTS voices (
+    id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    source      text        NOT NULL,
+    source_id   text        NOT NULL,
+    posted_at   timestamptz NOT NULL,
+    title       text,
+    body        text,
+    meta        jsonb       NOT NULL DEFAULT '{}'::jsonb,
+    created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS voices_source_source_id_uidx
+    ON voices (source, source_id);
+
+CREATE INDEX IF NOT EXISTS idx_voices_source_posted
+    ON voices (source, posted_at DESC);

--- a/sources.yaml
+++ b/sources.yaml
@@ -239,3 +239,34 @@ sources:
     feed_url: https://hnrss.org/frontpage
     why: テック業界のリアルタイム話題集約。
     url: https://news.ycombinator.com
+
+# ============================================================
+# apple_apps — Apple iTunes RSS (★1-4 customer reviews → voices)
+#
+# idea-mining 用の private シグナル源。`daily_news.py` / newsletter /
+# web archive とは無関係で、`voices` テーブルにのみ書き込む。
+#
+# Issue #136 では country MVP として jp のみ運用。us/gb の追加は
+# 別 issue で判断 (out-of-scope)。
+#
+# fetcher: idea_mining/fetchers/apple_rss.py
+# workflow: .github/workflows/idea-mining-weekly.yml (毎週月 14:00 UTC)
+# ============================================================
+apple_apps:
+  - name: Notion
+    app_id: "1232780281"
+    country: [jp]
+    enabled: true
+    why: 個人の生産性ツール市場での pain point 観測 (knowledge mgmt + AI 機能)。
+
+  - name: Obsidian
+    app_id: "1557175442"
+    country: [jp]
+    enabled: true
+    why: ローカル / Markdown / plugin 系の note-taking pain point 観測。
+
+  - name: MoneyForward
+    app_id: "459683577"
+    country: [jp]
+    enabled: true
+    why: 日本市場の家計簿 / マネー系 SaaS の継続課金 / UI pain 観測。

--- a/tests/idea_mining/fetchers/test_apple_rss.py
+++ b/tests/idea_mining/fetchers/test_apple_rss.py
@@ -1,0 +1,443 @@
+"""Tests for `idea_mining.fetchers.apple_rss`.
+
+Apple iTunes RSS fetcher の挙動 (★5 除外 / meta JSONB / ON CONFLICT NoOp /
+retry & Sentry alert / sources.yaml パース / migration 008) を最小限の
+スコープで検証する。
+
+外部 HTTP / DB / Sentry は dependency-inject や monkeypatch で全部モック
+する。実 Neon / 実 Apple API は叩かない。
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from idea_mining.fetchers import apple_rss
+from idea_mining.fetchers.apple_rss import (
+    APPLE_RSS_URL_FMT,
+    INSERT_SQL,
+    LANG_BY_COUNTRY,
+    RETRY_DELAYS_SECONDS,
+    SOURCE_NAME,
+    AppleApp,
+    fetch_one,
+    insert_voices,
+    load_apple_apps,
+    parse_review_entries,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+# ----------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------
+
+
+def _entry(rating: str, review_id: str, **overrides: Any) -> dict:
+    base = {
+        "id": {"label": review_id},
+        "title": {"label": f"title-{review_id}"},
+        "content": {"label": f"body-{review_id}"},
+        "im:rating": {"label": rating},
+        "im:version": {"label": "1.2.3"},
+        "author": {"name": {"label": f"user-{review_id}"}},
+        "updated": {"label": "2026-05-19T12:34:56-07:00"},
+    }
+    base.update(overrides)
+    return base
+
+
+def _payload(*entries: dict) -> dict:
+    return {"feed": {"entry": list(entries)}}
+
+
+# ----------------------------------------------------------------------
+# Parser tests
+# ----------------------------------------------------------------------
+
+
+def test_parse_drops_rating_5_and_keeps_1_through_4() -> None:
+    payload = _payload(
+        _entry("1", "r1"),
+        _entry("2", "r2"),
+        _entry("3", "r3"),
+        _entry("4", "r4"),
+        _entry("5", "r5"),  # excluded
+    )
+
+    rows = parse_review_entries(payload, country="jp", app_id="1232780281")
+
+    ratings = sorted(r["meta"]["rating"] for r in rows)
+    assert ratings == [1, 2, 3, 4]
+    assert all(r["source"] == SOURCE_NAME for r in rows)
+    assert "r5" not in {r["source_id"] for r in rows}
+
+
+def test_parse_meta_has_required_fields() -> None:
+    payload = _payload(_entry("2", "r1"))
+
+    [row] = parse_review_entries(payload, country="jp", app_id="1232780281")
+
+    meta = row["meta"]
+    for key in ("version", "author", "country", "lang", "rating"):
+        assert key in meta, f"meta missing required key: {key}"
+    assert meta["version"] == "1.2.3"
+    assert meta["author"] == "user-r1"
+    assert meta["country"] == "jp"
+    assert meta["lang"] == "ja"
+    assert meta["rating"] == 2
+
+
+def test_parse_country_jp_yields_meta_lang_ja() -> None:
+    payload = _payload(_entry("3", "r1"))
+
+    [row] = parse_review_entries(payload, country="jp", app_id="1")
+
+    assert row["meta"]["country"] == "jp"
+    assert row["meta"]["lang"] == "ja"
+
+
+def test_parse_country_us_yields_meta_lang_en() -> None:
+    # `LANG_BY_COUNTRY` で us → en にマップされていることの sanity check.
+    # 運用上は jp のみだが、lookup ロジックの境界として確認。
+    payload = _payload(_entry("3", "r1"))
+
+    [row] = parse_review_entries(payload, country="us", app_id="1")
+
+    assert row["meta"]["lang"] == "en"
+
+
+def test_parse_handles_single_entry_dict() -> None:
+    # Apple feed は entries が 1 件のとき list ではなく dict になるケースがある。
+    payload = {"feed": {"entry": _entry("2", "r1")}}
+
+    rows = parse_review_entries(payload, country="jp", app_id="1")
+
+    assert len(rows) == 1
+    assert rows[0]["source_id"] == "r1"
+
+
+def test_parse_handles_missing_entry_field() -> None:
+    # feed.entry が無い場合 (= レビューゼロ) は空リスト。
+    assert parse_review_entries({"feed": {}}, country="jp", app_id="1") == []
+
+
+def test_parse_skips_entry_without_rating() -> None:
+    # `im:rating` を欠くエントリは app metadata 等として skip する。
+    payload = _payload({"id": {"label": "metadata"}}, _entry("4", "r1"))
+
+    rows = parse_review_entries(payload, country="jp", app_id="1")
+
+    assert len(rows) == 1
+    assert rows[0]["source_id"] == "r1"
+
+
+def test_parse_review_body_and_title_preserved() -> None:
+    payload = _payload(_entry("1", "r99"))
+
+    [row] = parse_review_entries(payload, country="jp", app_id="1")
+
+    assert row["title"] == "title-r99"
+    assert row["body"] == "body-r99"
+    assert row["posted_at"] == "2026-05-19T12:34:56-07:00"
+
+
+# ----------------------------------------------------------------------
+# Retry / backoff / Sentry alert
+# ----------------------------------------------------------------------
+
+
+def test_fetch_one_succeeds_on_first_try() -> None:
+    payload = _payload(_entry("2", "r1"))
+    calls: list[str] = []
+
+    def http_get(url: str) -> dict:
+        calls.append(url)
+        return payload
+
+    sleeps: list[float] = []
+
+    result = fetch_one(
+        "jp", "1", http_get=http_get, sleep_fn=lambda s: sleeps.append(s)
+    )
+
+    assert result is payload
+    assert len(calls) == 1
+    assert sleeps == []
+    assert calls[0] == APPLE_RSS_URL_FMT.format(country="jp", app_id="1")
+
+
+def test_fetch_one_retries_with_exp_backoff_then_sentry_on_exhaustion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """初期1 + 5 retries が全部失敗したら Sentry alert を発火し None を返す。"""
+    calls: list[str] = []
+
+    def always_fail(url: str) -> dict:
+        calls.append(url)
+        raise TimeoutError("simulated")
+
+    sleeps: list[float] = []
+    sentry_calls: list[tuple[str, dict]] = []
+
+    def fake_capture_message(msg: str, **kwargs: Any) -> None:
+        sentry_calls.append((msg, kwargs))
+
+    monkeypatch.setattr(
+        apple_rss.sentry_sdk, "capture_message", fake_capture_message
+    )
+
+    result = fetch_one(
+        "jp",
+        "999",
+        http_get=always_fail,
+        sleep_fn=lambda s: sleeps.append(s),
+    )
+
+    assert result is None
+    # 1 initial + 5 retries
+    assert len(calls) == 1 + len(RETRY_DELAYS_SECONDS)
+    # Sleeps happen between each retry — 5 total, matching the constant.
+    assert sleeps == list(RETRY_DELAYS_SECONDS)
+    # Exactly one Sentry alert with level=error and app coords in the body.
+    assert len(sentry_calls) == 1
+    msg, kwargs = sentry_calls[0]
+    assert "jp/999" in msg
+    assert kwargs.get("level") == "error"
+
+
+def test_fetch_one_recovers_mid_retry() -> None:
+    """途中で復旧したら Sentry alert は発火せず正常 payload を返す。"""
+    payload = _payload(_entry("3", "r1"))
+    attempt_counter = {"n": 0}
+
+    def flaky(url: str) -> dict:
+        attempt_counter["n"] += 1
+        if attempt_counter["n"] < 3:
+            raise TimeoutError("flaky")
+        return payload
+
+    sleeps: list[float] = []
+
+    result = fetch_one(
+        "jp", "1", http_get=flaky, sleep_fn=lambda s: sleeps.append(s)
+    )
+
+    assert result is payload
+    # 1 initial + 2 retries = succeed on 3rd attempt
+    assert attempt_counter["n"] == 3
+    # Sleeps happened only between failed attempts.
+    assert sleeps == [1, 2]
+
+
+# ----------------------------------------------------------------------
+# INSERT SQL contract — ON CONFLICT DO NOTHING
+# ----------------------------------------------------------------------
+
+
+def test_insert_sql_uses_on_conflict_source_source_id_do_nothing() -> None:
+    """同一 (source, source_id) の再 insert が NoOp になることを SQL レベルで保証。"""
+    normalized = re.sub(r"\s+", " ", INSERT_SQL).strip().lower()
+    assert "insert into voices" in normalized
+    assert "on conflict (source, source_id) do nothing" in normalized
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, dict]] = []
+        self.rowcount = 1
+
+    def execute(self, sql: str, params: dict) -> None:
+        self.executed.append((sql, params))
+
+    def __enter__(self) -> "_FakeCursor":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        self.cur = _FakeCursor()
+        self.commits = 0
+
+    def cursor(self) -> _FakeCursor:
+        return self.cur
+
+    def commit(self) -> None:
+        self.commits += 1
+
+
+def test_insert_voices_passes_meta_as_jsonb_and_uses_conflict_sql() -> None:
+    conn = _FakeConn()
+    rows = [
+        {
+            "source": SOURCE_NAME,
+            "source_id": "r1",
+            "posted_at": "2026-05-19T12:34:56-07:00",
+            "title": "t",
+            "body": "b",
+            "meta": {
+                "version": "1.0",
+                "author": "u",
+                "country": "jp",
+                "lang": "ja",
+                "rating": 3,
+            },
+        },
+    ]
+
+    inserted = insert_voices(conn, rows)  # type: ignore[arg-type]
+
+    assert inserted == 1
+    assert conn.commits == 1
+    assert len(conn.cur.executed) == 1
+    sql, params = conn.cur.executed[0]
+    normalized = re.sub(r"\s+", " ", sql).strip().lower()
+    assert "on conflict (source, source_id) do nothing" in normalized
+    # meta must be wrapped for psycopg JSONB serialization.
+    from psycopg.types.json import Jsonb
+
+    assert isinstance(params["meta"], Jsonb)
+
+
+def test_insert_voices_treats_rowcount_zero_as_noop() -> None:
+    """ON CONFLICT skip 時は cur.rowcount=0 → inserted カウントを増やさない."""
+    conn = _FakeConn()
+    conn.cur.rowcount = 0
+    rows = [
+        {
+            "source": SOURCE_NAME,
+            "source_id": "dup",
+            "posted_at": "2026-05-19T12:34:56-07:00",
+            "title": None,
+            "body": None,
+            "meta": {"rating": 1, "country": "jp", "lang": "ja"},
+        }
+    ]
+
+    inserted = insert_voices(conn, rows)  # type: ignore[arg-type]
+
+    assert inserted == 0
+
+
+# ----------------------------------------------------------------------
+# sources.yaml apple_apps parsing
+# ----------------------------------------------------------------------
+
+
+def test_load_apple_apps_reads_real_sources_yaml() -> None:
+    apps = load_apple_apps(REPO_ROOT / "sources.yaml")
+
+    by_name = {a.name: a for a in apps}
+    for required in ("Notion", "Obsidian", "MoneyForward"):
+        assert required in by_name, f"sources.yaml missing apple_apps entry: {required}"
+        assert by_name[required].countries == ("jp",)
+        assert by_name[required].enabled is True
+        # app_id is a string ID (Apple uses numeric strings).
+        assert by_name[required].app_id.isdigit()
+
+
+def test_load_apple_apps_skips_disabled(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "sources.yaml"
+    yaml_path.write_text(
+        yaml.safe_dump(
+            {
+                "sources": [],
+                "apple_apps": [
+                    {
+                        "name": "Notion",
+                        "app_id": "1",
+                        "country": ["jp"],
+                        "enabled": True,
+                    },
+                    {
+                        "name": "Disabled",
+                        "app_id": "2",
+                        "country": ["jp"],
+                        "enabled": False,
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    apps = load_apple_apps(yaml_path)
+
+    assert [a.name for a in apps] == ["Notion"]
+
+
+def test_load_apple_apps_does_not_require_apple_apps_key(tmp_path: Path) -> None:
+    # 既存 sources.yaml (apple_apps セクション無し) でも壊れない。
+    yaml_path = tmp_path / "sources.yaml"
+    yaml_path.write_text(yaml.safe_dump({"sources": []}), encoding="utf-8")
+
+    assert load_apple_apps(yaml_path) == []
+
+
+def test_load_apple_apps_skips_entries_with_empty_country(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "sources.yaml"
+    yaml_path.write_text(
+        yaml.safe_dump(
+            {
+                "apple_apps": [
+                    {"name": "NoCountry", "app_id": "1", "country": [], "enabled": True},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert load_apple_apps(yaml_path) == []
+
+
+# ----------------------------------------------------------------------
+# Migration 008 schema check (text-level)
+# ----------------------------------------------------------------------
+
+
+def test_migration_008_defines_voices_table_with_unique_and_index() -> None:
+    sql_path = REPO_ROOT / "migrations" / "008_voices.sql"
+    sql = sql_path.read_text(encoding="utf-8").lower()
+
+    # Table itself.
+    assert "create table if not exists voices" in sql
+    # Required columns referenced in the fetcher's INSERT.
+    for col in ("source", "source_id", "posted_at", "meta"):
+        assert col in sql
+
+    # UNIQUE (source, source_id) — required for ON CONFLICT idempotency.
+    assert re.search(
+        r"create unique index.*?voices.*?\(\s*source\s*,\s*source_id\s*\)",
+        sql,
+        flags=re.DOTALL,
+    ), "voices_source_source_id_uidx not found"
+
+    # idx_voices_source_posted — explicitly named in the acceptance criteria.
+    assert "idx_voices_source_posted" in sql
+
+
+# ----------------------------------------------------------------------
+# Module-level constants sanity
+# ----------------------------------------------------------------------
+
+
+def test_retry_delays_constant_matches_spec() -> None:
+    assert RETRY_DELAYS_SECONDS == (1, 2, 4, 8, 16)
+
+
+def test_lang_lookup_jp_is_ja() -> None:
+    assert LANG_BY_COUNTRY["jp"] == "ja"
+
+
+def test_apple_app_dataclass_is_frozen() -> None:
+    app = AppleApp(name="x", app_id="1", countries=("jp",))
+    with pytest.raises(Exception):
+        app.app_id = "2"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Apple iTunes RSS から ★1-4 のアプリレビューを取得し、新規 `voices` テーブルに private に蓄積する idea-mining 専用 fetcher。週次 cron (毎週月曜 14:00 UTC) で起動。

- `migrations/008_voices.sql`: voices テーブル + UNIQUE(source, source_id) + idx_voices_source_posted
- `sources.yaml`: apple_apps セクション (Notion / Obsidian / MoneyForward、country=[jp])
- `idea_mining/fetchers/apple_rss.py`: iTunes RSS fetch + ★1-4 フィルタ + exp backoff + Sentry alert
- `.github/workflows/idea-mining-weekly.yml`: 週次 cron (Mon 14:00 UTC)
- `tests/idea_mining/fetchers/test_apple_rss.py`: 22 tests (pytest 116 passed)

Verdict: **confirm before merge** (manager subagent 判定)

確認事項:
- Apple feed schema は production 環境で `workflow_dispatch` 1 回起動で実 fetch 検証 → `voices` に jp × 3 app のレビューが入ること、★5 が混じらないこと、`meta` JSONB の 5 fields が揃うこと
- Retry count 解釈: AC 上「最大 5 回リトライ = 1 initial + 5 retries = 6 attempts」で実装、tests も `1 + len(RETRY_DELAYS_SECONDS) = 6` で assert

Legal: `docs/legal-posture.md` §5.5 (idea-mining は newspaper パイプライン外、保留対象外) の根拠で着手。

Closes #136

## Test plan

- [ ] CI で pytest pass 確認
- [ ] Neon SQL Editor で `migrations/008_voices.sql` 手動 apply (idempotent)
- [ ] workflow_dispatch で 1 回起動 → Sentry alert 無し / voices に行が入る / 重複時 ON CONFLICT で skip
- [ ] ★5 レビューが voices に現れないこと目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)