### PR TITLE
epic(idea-mining): Phase 0 全 6 子 issue 統合 (#134)

### DIFF
--- a/.claude/commands/pr-creation.md
+++ b/.claude/commands/pr-creation.md
@@ -6,19 +6,41 @@
 
 変更ファイルを確認し、PR テンプレートを埋めて、MCP github (`mcp__github__create_pull_request`) で適切な base への PR を作る。MCP server が無い環境では Bash の `gh pr create` でフォールバックする。
 
-## Base ブランチ判定 (絶対ルール)
+## Base ブランチ判定 (絶対ルール — stacked design)
 
-**epic ブランチが存在する場合は必ず epic ブランチを base にする。main を base にしない。**
+**子 PR は「直前の sibling child branch があればそれ、無ければ epic ブランチ、それも無ければ main」を base にする。** 親 epic を飛び越えて main を直接 base にしない。
 
 判定ロジック:
 
 1. 現在のブランチ名を取得 (`git rev-parse --abbrev-ref HEAD`)
-2. パターン `^epic/\d+-.*-child-\d+$` (例: `epic/134-epic-child-136`) にマッチするか確認
-3. マッチする場合: `-child-\d+` を除いた部分を epic ブランチとする (例: `epic/134-epic`)
-4. epic ブランチが存在 (`git rev-parse --verify <epic-branch>` または `origin/<epic-branch>`) する場合: それを base にする
-5. それ以外: base は `main`
+2. パターン `^(epic/\d+-.*)-child-(\d+)$` にマッチするか確認 (例: `epic/134-epic-child-138` → epic prefix `epic/134-epic`, child number `138`)
+3. マッチした場合の **stacked base 検索**:
+   - 同 epic prefix の sibling 子ブランチ `<epic-prefix>-child-<N>` を `git for-each-ref` で列挙し、現在の child number より小さい `N` の中で **最大の `N`** を選ぶ
+   - その branch が local (or origin) に存在すれば `base` = そのブランチ (例: 現在 `child-138`、`child-137` が存在 → `base = epic/134-epic-child-137`)
+   - 存在しない (= merge 後に削除済) なら fallback して epic prefix そのものを base にする (例: `epic/134-epic`)
+4. epic prefix にもブランチが無い (= マッチしない / 単独ブランチ) → `base` = `main`
 
-子 PR を main に向けると `git rebase` / `merge` 衝突 + epic 統合 PR でのレビュー範囲膨張 + 子 commit が main 履歴を直接汚す問題が起きるので、これを防ぐためのルール。
+理由: 子 #N の PR base を一つ前の子 #N-1 にすることで、PR を stacked PR の連鎖にし、人手 merge を待たずに次の子を進められる。merge は最終的に下から (#N-1 → #N → ... の順で kazuki が承認)。
+
+検出例 (`epic/134-epic-child-138` で発火):
+
+```bash
+CURRENT=$(git rev-parse --abbrev-ref HEAD)
+[[ "$CURRENT" =~ ^(epic/.+)-child-([0-9]+)$ ]] || { BASE="main"; exit 0; }
+EPIC="${BASH_REMATCH[1]}"
+CHILD_N="${BASH_REMATCH[2]}"
+# Find highest sibling with lower number
+PREV=$(git for-each-ref "refs/heads/${EPIC}-child-*" --format='%(refname:short)' \
+       | awk -F'-child-' -v cur="$CHILD_N" '$2 < cur {print $0}' \
+       | sort -t- -k4 -n | tail -1)
+if [[ -n "$PREV" ]] && git rev-parse --verify "$PREV" >/dev/null 2>&1; then
+  BASE="$PREV"
+elif git rev-parse --verify "$EPIC" >/dev/null 2>&1; then
+  BASE="$EPIC"
+else
+  BASE="main"
+fi
+```
 
 ## Inputs
 
@@ -35,7 +57,7 @@
 - 人間への確認なしに merge しない
 - force push をしない
 - `main` ブランチに直接コミット・push しない
-- **epic ブランチが存在するのに `main` を base にして PR を作らない** (絶対ルール、上記「Base ブランチ判定」参照)
+- **stacked design に違反して `main` / 過去 sibling より上 (低い number の child) を base にしない** (絶対ルール、上記「Base ブランチ判定」参照)。直前の sibling → epic → main の優先順を守る
 - `.env` / 鍵 / トークン / `*.json` の credentials を stage しない
 - レビュアーの判定が `fix before merge` のまま PR を作らない
 - HMAC シークレット rotation を伴う変更は main への直接 push をしない（必ずブランチ + PR + 運用窓説明）

--- a/.claude/commands/pr-creation.md
+++ b/.claude/commands/pr-creation.md
@@ -6,37 +6,35 @@
 
 変更ファイルを確認し、PR テンプレートを埋めて、MCP github (`mcp__github__create_pull_request`) で適切な base への PR を作る。MCP server が無い環境では Bash の `gh pr create` でフォールバックする。
 
-## Base ブランチ判定 (絶対ルール — stacked design)
+## Base ブランチ判定 (絶対ルール — flat PR design)
 
-**子 PR は「直前の sibling child branch があればそれ、無ければ epic ブランチ、それも無ければ main」を base にする。** 親 epic を飛び越えて main を直接 base にしない。
+**子 PR は常に親 epic ブランチを base にする。epic が無ければ main。sibling child branch を base にしない。**
+
+設計分離:
+- **ブランチ作成**: stacked (child-N は child-N-1 の tip から派生 → 前の子の成果物が見える)
+- **PR の merge 先**: flat (常に epic、stacked PR は作らない)
 
 判定ロジック:
 
 1. 現在のブランチ名を取得 (`git rev-parse --abbrev-ref HEAD`)
-2. パターン `^(epic/\d+-.*)-child-(\d+)$` にマッチするか確認 (例: `epic/134-epic-child-138` → epic prefix `epic/134-epic`, child number `138`)
-3. マッチした場合の **stacked base 検索**:
-   - 同 epic prefix の sibling 子ブランチ `<epic-prefix>-child-<N>` を `git for-each-ref` で列挙し、現在の child number より小さい `N` の中で **最大の `N`** を選ぶ
-   - その branch が local (or origin) に存在すれば `base` = そのブランチ (例: 現在 `child-138`、`child-137` が存在 → `base = epic/134-epic-child-137`)
-   - 存在しない (= merge 後に削除済) なら fallback して epic prefix そのものを base にする (例: `epic/134-epic`)
-4. epic prefix にもブランチが無い (= マッチしない / 単独ブランチ) → `base` = `main`
+2. パターン `^(epic/\d+-.*)-child-(\d+)$` にマッチするか確認 (例: `epic/134-epic-child-138` → epic prefix `epic/134-epic`)
+3. マッチした場合: epic prefix (`epic/134-epic`) が local or origin に存在すれば `base` = それ、無ければ `base` = `main`
+4. マッチしない (= 単独ブランチ) → `base` = `main`
 
-理由: 子 #N の PR base を一つ前の子 #N-1 にすることで、PR を stacked PR の連鎖にし、人手 merge を待たずに次の子を進められる。merge は最終的に下から (#N-1 → #N → ... の順で kazuki が承認)。
+理由: stacked PR は graphite 等のツール前提で GitHub native レビューが煩雑になる。kazuki は GitHub UI で素直に merge したい (上から順、PR 単独で完結)。PR diff が膨らむのは epic から先に merge する運用で自然に縮む (GitHub の base 引き算)。
 
-検出例 (`epic/134-epic-child-138` で発火):
+検出例 (`epic/134-epic-child-139` で発火):
 
 ```bash
 CURRENT=$(git rev-parse --abbrev-ref HEAD)
-[[ "$CURRENT" =~ ^(epic/.+)-child-([0-9]+)$ ]] || { BASE="main"; exit 0; }
-EPIC="${BASH_REMATCH[1]}"
-CHILD_N="${BASH_REMATCH[2]}"
-# Find highest sibling with lower number
-PREV=$(git for-each-ref "refs/heads/${EPIC}-child-*" --format='%(refname:short)' \
-       | awk -F'-child-' -v cur="$CHILD_N" '$2 < cur {print $0}' \
-       | sort -t- -k4 -n | tail -1)
-if [[ -n "$PREV" ]] && git rev-parse --verify "$PREV" >/dev/null 2>&1; then
-  BASE="$PREV"
-elif git rev-parse --verify "$EPIC" >/dev/null 2>&1; then
-  BASE="$EPIC"
+if [[ "$CURRENT" =~ ^(epic/.+)-child-[0-9]+$ ]]; then
+  EPIC="${BASH_REMATCH[1]}"
+  if git rev-parse --verify "$EPIC" >/dev/null 2>&1 || \
+     git rev-parse --verify "origin/$EPIC" >/dev/null 2>&1; then
+    BASE="$EPIC"
+  else
+    BASE="main"
+  fi
 else
   BASE="main"
 fi
@@ -57,7 +55,7 @@ fi
 - 人間への確認なしに merge しない
 - force push をしない
 - `main` ブランチに直接コミット・push しない
-- **stacked design に違反して `main` / 過去 sibling より上 (低い number の child) を base にしない** (絶対ルール、上記「Base ブランチ判定」参照)。直前の sibling → epic → main の優先順を守る
+- **child ブランチで PR を作る時、base に sibling child を選ばない** (絶対ルール、上記「Base ブランチ判定」参照)。epic prefix が存在すれば必ず epic、無ければ main。stacked PR チェーンを作らない
 - `.env` / 鍵 / トークン / `*.json` の credentials を stage しない
 - レビュアーの判定が `fix before merge` のまま PR を作らない
 - HMAC シークレット rotation を伴う変更は main への直接 push をしない（必ずブランチ + PR + 運用窓説明）

--- a/.github/workflows/idea-mining-critic.yml
+++ b/.github/workflows/idea-mining-critic.yml
@@ -1,0 +1,45 @@
+name: Idea Mining Critic
+
+# candidates テーブルの `critic_verdict IS NULL` 行を Sonnet
+# (`claude-sonnet-4-6`) で adversarial 評価し、verdict と JSONB meta
+# を UPDATE する。
+#
+# - 初期は手動 (`workflow_dispatch`) のみ。cron スケジュールの追加は
+#   別 issue で決める (Issue #139 Decisions §E)。
+# - newspaper pipeline (`daily-news.yml`) や他の idea-mining レーン
+#   (`idea-mining-extractor.yml`, `idea-mining-weekly.yml`) からは独立。
+#   失敗してもニュースレターには影響しない。
+#
+# 関連: Issue #139 (Critic), Epic #134, migrations/010_create_candidates.sql,
+#       idea_mining/critic.py.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  critic:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - run: pip install -r requirements.txt
+
+      - run: python -m idea_mining.critic
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          # Optional — if SENTRY_DSN is unset the critic still runs;
+          # malformed-JSON warnings simply log to stderr.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          HIBI_RELEASE: ${{ github.sha }}
+          HIBI_ENV: production

--- a/.github/workflows/idea-mining-digest.yml
+++ b/.github/workflows/idea-mining-digest.yml
@@ -1,0 +1,60 @@
+name: Idea Mining Digest
+
+# 週次 idea-digest メールを毎週月曜 00:00 UTC (= 09:00 JST) に配信する。
+#
+# - 対象週の `patterns` (frequency 降順 Top 3) + 各 pattern の verdict 付き
+#   `candidates` (GO 最大 2 / KILL 最大 1) を読み、Gmail OAuth2 で
+#   ``RECIPIENT_EMAIL`` 1 アドレス宛に HTML + plain text を配信する。
+# - newspaper pipeline (`daily-news.yml`, 13:17 UTC) や他の idea-mining
+#   レーン (`idea-mining-extractor.yml`, 03:00 UTC 火/木/土;
+#   `idea-mining-weekly.yml`, Mon 14:00 UTC) と時刻が衝突しないよう Mon
+#   00:00 UTC に固定。
+# - patterns / verdict 付き candidates がゼロのときは送信スキップしログ
+#   のみ残す (exit 0)。
+#
+# 関連: Issue #140 (digest), Epic #134, migrations/009_patterns.sql,
+#       migrations/010_create_candidates.sql, idea_mining/digest.py.
+
+on:
+  schedule:
+    # 毎週月曜 00:00 UTC (= 09:00 JST). daily-news (13:17 UTC) と離れている。
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Render and print to stdout; skip Gmail send."
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+permissions:
+  contents: read
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    # acceptance: workflow timeout 10 分以内
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - run: pip install -r requirements.txt
+
+      - run: python -m idea_mining.digest
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          RECIPIENT_EMAIL: ${{ secrets.RECIPIENT_EMAIL }}
+          GMAIL_CLIENT_ID: ${{ secrets.GMAIL_CLIENT_ID }}
+          GMAIL_CLIENT_SECRET: ${{ secrets.GMAIL_CLIENT_SECRET }}
+          GMAIL_REFRESH_TOKEN: ${{ secrets.GMAIL_REFRESH_TOKEN }}
+          # workflow_dispatch input → "1" / "" (digest.py reads `DIGEST_DRY_RUN==1`).
+          DIGEST_DRY_RUN: ${{ github.event.inputs.dry_run == 'true' && '1' || '' }}

--- a/.github/workflows/idea-mining-extractor.yml
+++ b/.github/workflows/idea-mining-extractor.yml
@@ -1,0 +1,48 @@
+name: Idea Mining Extractor
+
+# voices → patterns 抽出を週 3 回 (火 / 木 / 土 03:00 UTC) 走らせる。
+#
+# - 直近 7 日の `voices` (Apple iTunes ★1-4 reviews 等) を Haiku で
+#   クラスタリングし、頻度 3+ の構造的ペインを `patterns` テーブルに
+#   UPSERT する。
+# - newspaper pipeline (`daily-news.yml`, 13:17 UTC) や collector
+#   (`idea-mining-weekly.yml`, Mon 14:00 UTC) と時刻が衝突しないよう
+#   03:00 UTC に固定。
+# - 失敗してもニュースレターには影響しない (idea-mining レーンは
+#   newspaper と独立)。
+#
+# 関連: Issue #134 (epic), migration 009, idea_mining/extractor.py.
+
+on:
+  schedule:
+    # 火 / 木 / 土 03:00 UTC.
+    - cron: "0 3 * * 2,4,6"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  extractor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - run: pip install -r requirements.txt
+
+      - run: python -m idea_mining.extractor
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          # Optional — if SENTRY_DSN is unset the extractor still runs;
+          # malformed-JSON warnings simply log to stderr.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          HIBI_RELEASE: ${{ github.sha }}
+          HIBI_ENV: production

--- a/.github/workflows/idea-mining-weekly.yml
+++ b/.github/workflows/idea-mining-weekly.yml
@@ -1,0 +1,42 @@
+name: Idea Mining Weekly
+
+# idea-mining 用の private fetcher を週次で走らせる。
+#
+# 現状は Apple iTunes RSS (★1-4 customer reviews → voices) のみ。
+# newspaper pipeline (`daily-news.yml`) とは完全に分離していて、
+# 失敗してもニュースレターには影響しない。
+#
+# 関連: Issue #136, idea_mining/fetchers/apple_rss.py, migration 008.
+
+on:
+  schedule:
+    # 毎週月曜 14:00 UTC (= JST 23:00) — daily-news (13:17 UTC) と十分離す。
+    - cron: "0 14 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  apple_rss:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - run: pip install -r requirements.txt
+
+      - run: python -m idea_mining.fetchers.apple_rss
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          # Optional — if SENTRY_DSN is unset the fetcher still runs;
+          # 5-consecutive-failure alerts simply log to stderr.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          HIBI_RELEASE: ${{ github.sha }}
+          HIBI_ENV: production

--- a/daily_news.py
+++ b/daily_news.py
@@ -13,17 +13,16 @@ import random
 import re
 import sys
 from datetime import datetime, timedelta, timezone
-from email.mime.text import MIMEText
 from urllib.parse import quote
 
 import sentry_sdk
 import yaml
 from googleapiclient.discovery import build
-from google.oauth2.credentials import Credentials
 from youtube_transcript_api import YouTubeTranscriptApi
 from youtube_transcript_api.proxies import WebshareProxyConfig
 from anthropic import Anthropic
 
+import email_sender
 from db import (
     get_conn,
     get_or_create_edition_for_today,
@@ -516,22 +515,10 @@ def rank_candidates(
 # Gmail send
 # ============================================================
 def send_email(subject: str, html_body: str, to: str):
-    creds = Credentials(
-        token=None,
-        refresh_token=os.environ["GMAIL_REFRESH_TOKEN"],
-        client_id=os.environ["GMAIL_CLIENT_ID"],
-        client_secret=os.environ["GMAIL_CLIENT_SECRET"],
-        token_uri="https://oauth2.googleapis.com/token",
-        scopes=["https://www.googleapis.com/auth/gmail.send"],
-    )
-    service = build("gmail", "v1", credentials=creds)
-
-    msg = MIMEText(html_body, "html")
-    msg["to"] = to
-    msg["subject"] = subject
-    raw = base64.urlsafe_b64encode(msg.as_bytes()).decode()
-
-    service.users().messages().send(userId="me", body={"raw": raw}).execute()
+    # Gmail OAuth2 send path is shared with idea_mining.digest via
+    # `email_sender`. Signature is preserved (positional) so existing callers
+    # keep working unchanged.
+    email_sender.send_email(subject=subject, to=to, html_body=html_body)
     print(f"✅ Email sent to {to}")
 
 

--- a/docs/legal-posture.md
+++ b/docs/legal-posture.md
@@ -71,6 +71,15 @@ epic #124 で 5 件の防衛 issue を起こした(2026-05-14、Hibi 着手前)�
 - 公開 web archive (`hibi-news.com`) は読み取り専用、signup 動線なし。
 - OSS 配布 (#74) / VS Code 拡張 (#77) / CLI (#76) / MCP (#75) は **設計検討のみ**。公開配布しない。
 
+## 5.5 idea-mining は別パイプライン (保留対象外)
+
+`idea_mining/` (Apple iTunes RSS 等の製品レビュー / ideation ソース) は newspaper 配信パイプライン (`daily_news.py` / `fetchers/rss.py` / `articles`) の外側に存在し、§5 の「新規メディアソース追加」保留対象には該当しない。
+
+判断根拠:
+- ニュース記事ではなく Apple 公式 RSS API + UGC (アプリレビュー)、§2 の 4 争点 (robots.txt / 本文複製 / paywall / 信用毀損) いずれにも該当しない
+- メール配信 / archive 公開なし、`voices` テーブルに private で保管
+- 将来 idea-mining 用に news サイト RSS を追加する場合は本除外対象外、§5 に従って判決後再判断
+
 ## 6. 再開シグナル
 
 以下のうち **どれかが起きたら本ドキュメントを再開し、#124 相当の防衛 issue を再起票** する候補とする:

--- a/email_sender.py
+++ b/email_sender.py
@@ -1,0 +1,81 @@
+"""Shared Gmail OAuth2 email sender.
+
+`daily_news.send_email` と `idea_mining.digest.send_email` の両方が利用する
+共通モジュール。OAuth2 refresh_token を使う認証経路 (existing scope:
+`https://www.googleapis.com/auth/gmail.send`) を 1 箇所に集約し、HTML 単体 /
+HTML+plain text multipart のどちらでも構築できるようにする。
+
+スコープ追加は **行わない** (Issue #140 stop_condition)。configuration は
+``GMAIL_CLIENT_ID`` / ``GMAIL_CLIENT_SECRET`` / ``GMAIL_REFRESH_TOKEN`` の
+3 環境変数のみ。`RECIPIENT_EMAIL` は呼び出し側で決める。
+"""
+from __future__ import annotations
+
+import base64
+import os
+from email.message import Message
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+
+GMAIL_SEND_SCOPE = "https://www.googleapis.com/auth/gmail.send"
+TOKEN_URI = "https://oauth2.googleapis.com/token"
+
+
+def build_message(
+    *,
+    subject: str,
+    to: str,
+    html_body: str,
+    text_body: str | None = None,
+) -> Message:
+    """Compose a MIME message for Gmail's `messages.send` API.
+
+    When ``text_body`` is ``None`` the result is a single ``text/html`` part
+    (preserves the byte-for-byte shape `daily_news.send_email` historically
+    produced). When ``text_body`` is provided, the result is a
+    ``multipart/alternative`` with the ``text/plain`` part attached *first*
+    so MUAs that prefer plain text get it as the primary body (RFC 2046).
+    """
+    if text_body is None:
+        msg: Message = MIMEText(html_body, "html")
+    else:
+        multipart = MIMEMultipart("alternative")
+        multipart.attach(MIMEText(text_body, "plain"))
+        multipart.attach(MIMEText(html_body, "html"))
+        msg = multipart
+    msg["to"] = to
+    msg["subject"] = subject
+    return msg
+
+
+def _build_gmail_service():
+    creds = Credentials(
+        token=None,
+        refresh_token=os.environ["GMAIL_REFRESH_TOKEN"],
+        client_id=os.environ["GMAIL_CLIENT_ID"],
+        client_secret=os.environ["GMAIL_CLIENT_SECRET"],
+        token_uri=TOKEN_URI,
+        scopes=[GMAIL_SEND_SCOPE],
+    )
+    return build("gmail", "v1", credentials=creds)
+
+
+def send_email(
+    *,
+    subject: str,
+    to: str,
+    html_body: str,
+    text_body: str | None = None,
+) -> None:
+    """Send an email through Gmail (OAuth2 refresh_token)."""
+    msg = build_message(
+        subject=subject, to=to, html_body=html_body, text_body=text_body
+    )
+    raw = base64.urlsafe_b64encode(msg.as_bytes()).decode()
+    service = _build_gmail_service()
+    service.users().messages().send(
+        userId="me", body={"raw": raw}
+    ).execute()

--- a/idea_mining/critic.py
+++ b/idea_mining/critic.py
@@ -1,0 +1,408 @@
+"""Idea-mining Critic — candidates → critic_verdict via Anthropic Sonnet.
+
+Issue #139 (Epic #134) の実装。`candidates` テーブルで `critic_verdict IS NULL`
+の行を Sonnet (`claude-sonnet-4-6`) で adversarial 評価し、verdict
+('GO' / 'PENDING' / 'KILL') と JSONB の critic_meta を UPDATE する。
+
+特徴:
+    * Ideator (#138) の出力を後段で評価するレーン。同テーブルへの新規 INSERT
+      は行わず UPDATE のみ。
+    * profile/user-constraints + negative-examples を system prompt 先頭に注入
+      する (`prompts._profile_block.profile_block()`)。
+    * Decisions §4 の RUBRIC テキストを system prompt 末尾に verbatim 含む
+      (`prompts.critic.SYSTEM_PROMPT_TEMPLATE`)。
+    * 1 row 1 commit。`critic_verdict IS NULL` を snapshot し、その id 列を
+      iterate するため同 batch 内で同一 row を 2 度 UPDATE しない。
+    * 1 row の Sonnet 応答が malformed JSON でも他 row の UPDATE は巻き戻らない
+      (raise / retry せず sentry capture + warning ログで skip)。
+
+CLI:
+    python -m idea_mining.critic
+
+Required env:
+    DATABASE_URL          — Neon (psycopg 3.x)
+    ANTHROPIC_API_KEY     — Sonnet access
+    OBSIDIAN_VAULT_ROOT   — profile/*.md の置かれた Vault clone
+
+Optional env:
+    SENTRY_DSN            — failure alerts (`idea_mining.critic` tag)
+    HIBI_RELEASE          — sentry release
+    HIBI_ENV              — sentry environment
+    HIBI_VAULT_OPTIONAL=1 — profile_loader を空文字で fall through (テスト用、
+                            本番では絶対 set しない)。CLI 側でも空 profile は
+                            fails-closed (exit 1) として扱う。
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from typing import Final
+
+import psycopg
+import sentry_sdk
+from anthropic import Anthropic
+
+from idea_mining.prompts._profile_block import profile_block
+from idea_mining.prompts.critic import SYSTEM_PROMPT_TEMPLATE
+
+log = logging.getLogger(__name__)
+
+SONNET_MODEL: Final[str] = "claude-sonnet-4-6"
+MAX_TOKENS: Final[int] = 4000
+
+ALLOWED_VERDICTS: Final[frozenset[str]] = frozenset({"GO", "PENDING", "KILL"})
+
+# critic_meta JSONB に必ず含める鍵。Sonnet 応答に欠落していれば JSON null として
+# 保存する (downstream で .get(...) しやすいよう、空ではなく欠落鍵を null で
+# 明示する方針)。
+REQUIRED_META_KEYS: Final[tuple[str, ...]] = (
+    "five_forces",
+    "pestle",
+    "kill_flags",
+    "llm_moat_conditions",
+    "killer_scenarios",
+    "cited_competitors",
+    "kill_reasons",
+)
+
+SELECT_CANDIDATE_IDS_SQL: Final[str] = """
+    SELECT id
+    FROM candidates
+    WHERE critic_verdict IS NULL
+    ORDER BY id
+"""
+
+SELECT_CANDIDATE_SQL: Final[str] = """
+    SELECT id, name, one_liner, target_user, monetization,
+           llm_moat_conditions, why_different, estimated_mvp_hours,
+           killer_use_case
+    FROM candidates
+    WHERE id = %s
+"""
+
+UPDATE_CRITIC_SQL: Final[str] = """
+    UPDATE candidates
+    SET critic_verdict = %s,
+        critic_meta = %s::jsonb
+    WHERE id = %s
+      AND critic_verdict IS NULL
+"""
+
+
+# ----------------------------------------------------------------------
+# Prompt assembly
+# ----------------------------------------------------------------------
+
+
+def build_system_prompt(profile: str) -> str:
+    """Inject the profile block at the head of the Critic system prompt.
+
+    Raises:
+        ValueError: when ``profile`` is empty. The Critic must never call
+            Sonnet without user-constraints + negative-examples in the
+            prompt (Issue #139 acceptance criterion).
+    """
+    if not profile.strip():
+        raise ValueError(
+            "profile_block is empty; refusing to build prompt without "
+            "user-constraints + negative-examples"
+        )
+    return SYSTEM_PROMPT_TEMPLATE.format(profile_block=profile)
+
+
+def build_user_message(candidate: dict[str, object]) -> str:
+    """Render the candidate as the user-message body for Sonnet."""
+    return (
+        "Candidate を 1 件評価してください。\n\n"
+        f"name: {candidate['name']!r}\n"
+        f"one_liner: {candidate.get('one_liner')!r}\n"
+        f"target_user: {candidate.get('target_user')!r}\n"
+        f"monetization: {candidate.get('monetization')!r}\n"
+        f"llm_moat_conditions: {candidate.get('llm_moat_conditions')!r}\n"
+        f"why_different: {candidate.get('why_different')!r}\n"
+        f"estimated_mvp_hours: {candidate.get('estimated_mvp_hours')!r}\n"
+        f"killer_use_case: {candidate.get('killer_use_case')!r}\n\n"
+        'JSON のみで {"verdict": ..., "five_forces": ..., ...} を返してください。'
+    )
+
+
+# ----------------------------------------------------------------------
+# Sonnet call + parsing
+# ----------------------------------------------------------------------
+
+
+def call_sonnet(
+    client: Anthropic, *, system_prompt: str, user_message: str
+) -> str:
+    """Call Sonnet and return the raw text response."""
+    response = client.messages.create(
+        model=SONNET_MODEL,
+        max_tokens=MAX_TOKENS,
+        system=system_prompt,
+        messages=[{"role": "user", "content": user_message}],
+    )
+    return response.content[0].text.strip()
+
+
+def parse_sonnet_response(raw_text: str) -> dict[str, object]:
+    """Parse Sonnet's JSON output into a top-level dict.
+
+    Raises:
+        ValueError: malformed JSON or non-object top-level.
+    """
+    start = raw_text.find("{")
+    end = raw_text.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        raise ValueError(f"no JSON object in response: {raw_text!r}")
+    try:
+        parsed = json.loads(raw_text[start : end + 1])
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"JSON decode failed: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError(f"top-level JSON is not an object: {parsed!r}")
+    return parsed
+
+
+def extract_verdict_and_meta(
+    parsed: dict[str, object],
+) -> tuple[str, dict[str, object]]:
+    """Pull verdict + REQUIRED_META_KEYS out of a parsed Sonnet response.
+
+    Returns ``(verdict, meta)``.
+
+    Raises:
+        ValueError: when ``verdict`` is missing, non-str, or not in
+            ``ALLOWED_VERDICTS``.
+    """
+    verdict_raw = parsed.get("verdict")
+    if not isinstance(verdict_raw, str):
+        raise ValueError(f"verdict must be str: {verdict_raw!r}")
+    verdict = verdict_raw.strip().upper()
+    if verdict not in ALLOWED_VERDICTS:
+        raise ValueError(f"invalid verdict: {verdict_raw!r}")
+    meta: dict[str, object] = {key: parsed.get(key) for key in REQUIRED_META_KEYS}
+    return verdict, meta
+
+
+# ----------------------------------------------------------------------
+# DB I/O
+# ----------------------------------------------------------------------
+
+
+def fetch_candidate_ids(conn: psycopg.Connection) -> list[int]:
+    """Snapshot the ids of candidates where critic_verdict IS NULL."""
+    with conn.cursor() as cur:
+        cur.execute(SELECT_CANDIDATE_IDS_SQL)
+        rows = cur.fetchall()
+    return [int(row[0]) for row in rows]
+
+
+def fetch_candidate(
+    conn: psycopg.Connection, candidate_id: int
+) -> dict[str, object] | None:
+    """Load a single candidate row by id, or None if not present."""
+    with conn.cursor() as cur:
+        cur.execute(SELECT_CANDIDATE_SQL, (candidate_id,))
+        row = cur.fetchone()
+    if row is None:
+        return None
+    moat_raw = row[5]
+    moat: list[str] = (
+        [str(m) for m in moat_raw] if isinstance(moat_raw, list) else []
+    )
+    return {
+        "id": int(row[0]),
+        "name": row[1],
+        "one_liner": row[2],
+        "target_user": row[3],
+        "monetization": row[4],
+        "llm_moat_conditions": moat,
+        "why_different": row[6],
+        "estimated_mvp_hours": row[7],
+        "killer_use_case": row[8],
+    }
+
+
+def update_critic_verdict(
+    conn: psycopg.Connection,
+    *,
+    candidate_id: int,
+    verdict: str,
+    meta: dict[str, object],
+) -> int:
+    """UPDATE one candidate's verdict + meta, commit, return rowcount.
+
+    Commits immediately so a downstream row failing does not roll back
+    rows that already succeeded (Issue #139 D: row-level transaction).
+    The ``WHERE critic_verdict IS NULL`` clause is defense-in-depth
+    against double-UPDATE within the same batch.
+    """
+    meta_json = json.dumps(meta, ensure_ascii=False)
+    with conn.cursor() as cur:
+        cur.execute(UPDATE_CRITIC_SQL, (verdict, meta_json, candidate_id))
+        rowcount = cur.rowcount
+    conn.commit()
+    return rowcount
+
+
+# ----------------------------------------------------------------------
+# Orchestration (single candidate)
+# ----------------------------------------------------------------------
+
+
+def run_for_candidate(
+    conn: psycopg.Connection,
+    client: Anthropic,
+    *,
+    candidate_id: int,
+    profile: str,
+) -> bool:
+    """End-to-end: fetch → Sonnet → parse → UPDATE for one candidate.
+
+    Returns True on UPDATE success, False on any skip (row gone, malformed
+    JSON, invalid verdict). Skips never raise; they log + sentry capture.
+    """
+    candidate = fetch_candidate(conn, candidate_id)
+    if candidate is None:
+        log.warning(
+            "critic: candidate not found: %d — skipping", candidate_id
+        )
+        sentry_sdk.capture_message(
+            f"critic: candidate not found: {candidate_id}",
+            level="warning",
+        )
+        return False
+
+    system_prompt = build_system_prompt(profile)
+    user_message = build_user_message(candidate)
+    raw_text = call_sonnet(
+        client, system_prompt=system_prompt, user_message=user_message
+    )
+
+    try:
+        parsed = parse_sonnet_response(raw_text)
+        verdict, meta = extract_verdict_and_meta(parsed)
+    except ValueError as exc:
+        log.warning(
+            "critic: malformed Sonnet JSON for candidate %d: %s",
+            candidate_id,
+            exc,
+        )
+        sentry_sdk.capture_message(
+            (
+                f"critic: malformed Sonnet JSON for candidate "
+                f"{candidate_id}: {exc}"
+            ),
+            level="warning",
+        )
+        return False
+
+    rowcount = update_critic_verdict(
+        conn,
+        candidate_id=candidate_id,
+        verdict=verdict,
+        meta=meta,
+    )
+    log.info(
+        "critic: candidate %d → verdict=%s (rowcount=%d)",
+        candidate_id,
+        verdict,
+        rowcount,
+    )
+    return True
+
+
+# ----------------------------------------------------------------------
+# CLI entry-point
+# ----------------------------------------------------------------------
+
+
+def _init_sentry() -> None:
+    dsn = os.environ.get("SENTRY_DSN")
+    if not dsn:
+        log.info("critic: SENTRY_DSN unset — failure alerts disabled")
+        return
+    sentry_sdk.init(
+        dsn=dsn,
+        release=os.environ.get("HIBI_RELEASE", "dev"),
+        environment=os.environ.get("HIBI_ENV", "production"),
+        traces_sample_rate=0.0,
+        send_default_pii=False,
+    )
+    sentry_sdk.set_tag("pipeline", "idea_mining_critic")
+
+
+def _connect() -> psycopg.Connection:
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        print("ERROR: DATABASE_URL is not set", file=sys.stderr)
+        sys.exit(1)
+    return psycopg.connect(url)
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    _init_sentry()
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("ERROR: ANTHROPIC_API_KEY is not set", file=sys.stderr)
+        return 1
+
+    try:
+        profile = profile_block()
+    except RuntimeError as exc:
+        print(f"ERROR: profile load failed: {exc}", file=sys.stderr)
+        return 1
+    if not profile.strip():
+        print(
+            "ERROR: profile is empty. Set OBSIDIAN_VAULT_ROOT and ensure "
+            "profile/user-constraints.md and profile/negative-examples.md "
+            "exist. (HIBI_VAULT_OPTIONAL is for tests only.)",
+            file=sys.stderr,
+        )
+        return 1
+
+    client = Anthropic(api_key=api_key)
+
+    total_updated = 0
+    total_skipped = 0
+    with _connect() as conn:
+        candidate_ids = fetch_candidate_ids(conn)
+        log.info(
+            "critic: %d candidate(s) to evaluate", len(candidate_ids)
+        )
+        for cid in candidate_ids:
+            try:
+                ok = run_for_candidate(
+                    conn,
+                    client,
+                    candidate_id=cid,
+                    profile=profile,
+                )
+            except Exception as exc:  # noqa: BLE001 — per-row fence
+                log.exception("critic: candidate %d failed: %s", cid, exc)
+                sentry_sdk.capture_exception(exc)
+                total_skipped += 1
+                continue
+            if ok:
+                total_updated += 1
+            else:
+                total_skipped += 1
+
+    log.info(
+        "critic: done. updated=%d skipped=%d total=%d",
+        total_updated,
+        total_skipped,
+        len(candidate_ids),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/idea_mining/digest.py
+++ b/idea_mining/digest.py
@@ -1,0 +1,645 @@
+"""Weekly idea-digest mailer.
+
+Issue #140 (Epic #134): 毎週月曜 00:00 UTC (= 09:00 JST) に直近 ISO 週の
+`patterns` (frequency 降順 Top 3) と各 pattern に紐づく Critic verdict 付き
+`candidates` (GO 最大 2 件 / KILL 最大 1 件) を Gmail で配信する。
+
+newspaper pipeline (`daily_news.py` / `articles` / ranking / mailer) からは
+独立した経路。`patterns` / `candidates` テーブルは **read-only** で扱う。
+配信先は ``RECIPIENT_EMAIL`` 1 アドレス固定 (multi-tenant 化しない)。
+
+Failure modes:
+    * 対象週の patterns ゼロ / 表示候補ゼロ → 送信スキップ (exit 0)。
+    * DB / Gmail 例外は raise する。workflow が failure として扱う。
+
+DRY_RUN:
+    env ``DIGEST_DRY_RUN=1`` または workflow_dispatch 入力で有効化。
+    stdout に subject + plain text 本文を出して終わる (Gmail 呼び出しなし)。
+
+CLI:
+    python -m idea_mining.digest
+
+Required env:
+    DATABASE_URL          — Neon (psycopg 3.x)
+    RECIPIENT_EMAIL       — 配信先 (kazuki 固定)
+    GMAIL_CLIENT_ID       — OAuth2
+    GMAIL_CLIENT_SECRET   — OAuth2
+    GMAIL_REFRESH_TOKEN   — OAuth2 (Production consent screen 前提)
+
+Optional env:
+    DIGEST_DRY_RUN=1      — stdout 出力のみ、送信しない
+    DIGEST_WEEK_ISO       — 強制的に対象週 (YYYY-Www) を上書き (テスト用)
+    DIGEST_VAULT_NAME     — obsidian:// link の vault 名上書き (default:
+                            ``Obsidan-workspace``、Issue #140 spec のまま)
+"""
+from __future__ import annotations
+
+import html
+import logging
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Final
+from urllib.parse import quote
+
+import psycopg
+
+import email_sender
+
+log = logging.getLogger(__name__)
+
+# 既存 vault clone は `Obsidan-workspace` (typo はリポ名に由来。本 Issue
+# spec の obsidian://open?vault=Obsidan-workspace&file=... と一致)。
+DEFAULT_VAULT_NAME: Final[str] = "Obsidan-workspace"
+
+# Vault 内で「週次 pattern note」を置く慣習パス。
+# `${OBSIDIAN_VAULT_ROOT}/10_projects/hibi/idea-mining/profile/` が
+# 既存基盤なので、その隣に patterns/<week>/<slug>.md を置く想定。
+VAULT_PATTERN_DIR: Final[str] = "10_projects/hibi/idea-mining/patterns"
+
+# 表示件数 (acceptance criteria より固定)。
+TOP_PATTERNS: Final[int] = 3
+MAX_GO_PER_PATTERN: Final[int] = 2
+MAX_KILL_PER_PATTERN: Final[int] = 1
+
+DRY_RUN_ENV: Final[str] = "DIGEST_DRY_RUN"
+WEEK_ISO_ENV: Final[str] = "DIGEST_WEEK_ISO"
+VAULT_NAME_ENV: Final[str] = "DIGEST_VAULT_NAME"
+
+SELECT_TOP_PATTERNS_SQL: Final[str] = """
+    SELECT id, pain, categories, frequency, source_diversity, confidence
+    FROM patterns
+    WHERE week_iso = %s
+    ORDER BY frequency DESC, pain ASC
+    LIMIT %s
+"""
+
+# verdict が NULL の候補は除外 (acceptance: 「verdict 付き candidates」のみ
+# 表示)。GO は最新を優先、KILL も最新を優先。同一 pattern 内で何件来ても、
+# 呼び出し側で GO 2 件 / KILL 1 件にトリムする。
+SELECT_VERDICT_CANDIDATES_SQL: Final[str] = """
+    SELECT id, name, one_liner, target_user, monetization, why_different,
+           killer_use_case, critic_verdict, critic_meta
+    FROM candidates
+    WHERE pattern_id = %s
+      AND critic_verdict IS NOT NULL
+    ORDER BY generated_at DESC, id DESC
+"""
+
+
+# ----------------------------------------------------------------------
+# Data classes
+# ----------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Pattern:
+    id: str  # uuid stringified
+    pain: str
+    categories: list[str]
+    frequency: int
+    source_diversity: int
+    confidence: float
+
+
+@dataclass(frozen=True)
+class Candidate:
+    id: int
+    name: str
+    one_liner: str | None
+    target_user: str | None
+    monetization: str | None
+    why_different: str | None
+    killer_use_case: str | None
+    critic_verdict: str  # 'GO' / 'PENDING' / 'KILL'
+    kill_reasons: list[str]
+
+
+@dataclass(frozen=True)
+class DigestSection:
+    pattern: Pattern
+    obsidian_url: str
+    go_candidates: list[Candidate] = field(default_factory=list)
+    kill_candidates: list[Candidate] = field(default_factory=list)
+
+    @property
+    def displayed_count(self) -> int:
+        return len(self.go_candidates) + len(self.kill_candidates)
+
+
+@dataclass(frozen=True)
+class Digest:
+    week_iso: str
+    sections: list[DigestSection]
+
+    @property
+    def total_candidates(self) -> int:
+        return sum(s.displayed_count for s in self.sections)
+
+    @property
+    def should_skip(self) -> bool:
+        # patterns が無い、または verdict 付き候補が 1 件も displayable で
+        # ないなら配信スキップ (acceptance criteria より)。
+        return not self.sections or self.total_candidates == 0
+
+
+# ----------------------------------------------------------------------
+# Week / vault helpers
+# ----------------------------------------------------------------------
+
+
+def current_week_iso(now: datetime | None = None) -> str:
+    """Return ISO week as ``YYYY-Www`` (zero-padded week)."""
+    if now is None:
+        now = datetime.now(timezone.utc)
+    iso = now.isocalendar()
+    return f"{iso.year:04d}-W{iso.week:02d}"
+
+
+_SLUG_NON_ALNUM = re.compile(r"[^0-9A-Za-z぀-ヿ㐀-鿿]+")
+
+
+def _slugify_pain(pain: str) -> str:
+    """Return a filesystem-safe slug for a `pain` label.
+
+    Strips leading/trailing separators and collapses runs to a single ``-``.
+    Keeps ASCII alphanumerics and CJK so the Obsidian link is still readable
+    in Japanese. Falls back to ``pattern`` if the result is empty.
+    """
+    cleaned = _SLUG_NON_ALNUM.sub("-", pain).strip("-")
+    return cleaned or "pattern"
+
+
+def build_obsidian_link(
+    week_iso: str, pain: str, *, vault_name: str = DEFAULT_VAULT_NAME
+) -> str:
+    """Build an ``obsidian://open?vault=...&file=...`` URL for a pattern note.
+
+    File path convention (Issue #140; aligned with existing
+    ``10_projects/hibi/idea-mining/profile/`` layout):
+
+        10_projects/hibi/idea-mining/patterns/<week_iso>/<slug>.md
+    """
+    slug = _slugify_pain(pain)
+    file_path = f"{VAULT_PATTERN_DIR}/{week_iso}/{slug}.md"
+    return (
+        f"obsidian://open?vault={quote(vault_name, safe='')}"
+        f"&file={quote(file_path, safe='')}"
+    )
+
+
+# ----------------------------------------------------------------------
+# DB I/O
+# ----------------------------------------------------------------------
+
+
+def fetch_top_patterns(
+    conn: psycopg.Connection, week_iso: str, *, limit: int = TOP_PATTERNS
+) -> list[Pattern]:
+    """Return top patterns for ``week_iso`` ordered by frequency DESC."""
+    with conn.cursor() as cur:
+        cur.execute(SELECT_TOP_PATTERNS_SQL, (week_iso, limit))
+        rows = cur.fetchall()
+    out: list[Pattern] = []
+    for row in rows:
+        pattern_id, pain, categories, frequency, source_diversity, confidence = row
+        out.append(
+            Pattern(
+                id=str(pattern_id),
+                pain=str(pain),
+                categories=list(categories) if categories else [],
+                frequency=int(frequency),
+                source_diversity=int(source_diversity),
+                confidence=float(confidence),
+            )
+        )
+    return out
+
+
+def _extract_kill_reasons(critic_meta: object) -> list[str]:
+    """Pull ``kill_reasons`` out of the JSONB blob, tolerating shape drift."""
+    if not isinstance(critic_meta, dict):
+        return []
+    raw = critic_meta.get("kill_reasons")
+    if not isinstance(raw, list):
+        return []
+    return [str(r) for r in raw if isinstance(r, str) and r.strip()]
+
+
+def fetch_verdict_candidates(
+    conn: psycopg.Connection, pattern_id: str
+) -> list[Candidate]:
+    """Return candidates for ``pattern_id`` where critic_verdict IS NOT NULL."""
+    with conn.cursor() as cur:
+        cur.execute(SELECT_VERDICT_CANDIDATES_SQL, (pattern_id,))
+        rows = cur.fetchall()
+    out: list[Candidate] = []
+    for row in rows:
+        (
+            cid,
+            name,
+            one_liner,
+            target_user,
+            monetization,
+            why_different,
+            killer_use_case,
+            verdict,
+            critic_meta,
+        ) = row
+        out.append(
+            Candidate(
+                id=int(cid),
+                name=str(name),
+                one_liner=None if one_liner is None else str(one_liner),
+                target_user=None if target_user is None else str(target_user),
+                monetization=None if monetization is None else str(monetization),
+                why_different=None if why_different is None else str(why_different),
+                killer_use_case=(
+                    None if killer_use_case is None else str(killer_use_case)
+                ),
+                critic_verdict=str(verdict),
+                kill_reasons=_extract_kill_reasons(critic_meta),
+            )
+        )
+    return out
+
+
+# ----------------------------------------------------------------------
+# Digest assembly
+# ----------------------------------------------------------------------
+
+
+def _trim_for_display(
+    candidates: list[Candidate],
+) -> tuple[list[Candidate], list[Candidate]]:
+    """Pick up to 2 GO + 1 KILL, preserving DB ordering (newest-first)."""
+    go = [c for c in candidates if c.critic_verdict == "GO"][:MAX_GO_PER_PATTERN]
+    kill = [c for c in candidates if c.critic_verdict == "KILL"][:MAX_KILL_PER_PATTERN]
+    return go, kill
+
+
+def build_digest(
+    conn: psycopg.Connection,
+    week_iso: str,
+    *,
+    vault_name: str = DEFAULT_VAULT_NAME,
+) -> Digest:
+    """Assemble the digest payload for ``week_iso``."""
+    patterns = fetch_top_patterns(conn, week_iso)
+    sections: list[DigestSection] = []
+    for p in patterns:
+        candidates = fetch_verdict_candidates(conn, p.id)
+        go, kill = _trim_for_display(candidates)
+        sections.append(
+            DigestSection(
+                pattern=p,
+                obsidian_url=build_obsidian_link(
+                    week_iso, p.pain, vault_name=vault_name
+                ),
+                go_candidates=go,
+                kill_candidates=kill,
+            )
+        )
+    return Digest(week_iso=week_iso, sections=sections)
+
+
+# ----------------------------------------------------------------------
+# Rendering — subject + plain text + HTML
+# ----------------------------------------------------------------------
+
+
+def format_subject(digest: Digest) -> str:
+    """``[Hibi] 今週のアイデア候補 N 件 (YYYY-Www)`` (N = displayed)."""
+    return (
+        f"[Hibi] 今週のアイデア候補 {digest.total_candidates} 件 "
+        f"({digest.week_iso})"
+    )
+
+
+def _format_go_text(c: Candidate) -> str:
+    lines = [f"  ▸ GO: {c.name}"]
+    if c.one_liner:
+        lines.append(f"    {c.one_liner}")
+    if c.target_user:
+        lines.append(f"    対象: {c.target_user}")
+    return "\n".join(lines)
+
+
+def _format_kill_text(c: Candidate) -> str:
+    lines = [f"  ▸ KILL: {c.name}"]
+    if c.one_liner:
+        lines.append(f"    {c.one_liner}")
+    if c.kill_reasons:
+        for reason in c.kill_reasons:
+            lines.append(f"    理由: {reason}")
+    else:
+        lines.append("    理由: (critic_meta に kill_reasons 未収載)")
+    return "\n".join(lines)
+
+
+def render_plain_text(digest: Digest) -> str:
+    """Render the digest as plain text (multipart/alternative の text part)."""
+    parts: list[str] = []
+    parts.append(format_subject(digest))
+    parts.append("")
+    for i, section in enumerate(digest.sections, 1):
+        p = section.pattern
+        parts.append(
+            f"## {i:02d}. {p.pain}  "
+            f"(frequency: {p.frequency}, sources: {p.source_diversity})"
+        )
+        parts.append(f"Vault: {section.obsidian_url}")
+        parts.append("")
+        if not section.go_candidates and not section.kill_candidates:
+            parts.append("  (verdict 付き候補なし)")
+        for c in section.go_candidates:
+            parts.append(_format_go_text(c))
+        for c in section.kill_candidates:
+            parts.append(_format_kill_text(c))
+        parts.append("")
+    return "\n".join(parts).rstrip() + "\n"
+
+
+# Hibi design-system tokens (`design-system/colors_and_type.css` の値を inline。
+# Email クライアントは外部 CSS を引かないため `colors_and_type.css` を直接
+# 参照できず、token 値をここに固定する必要がある。値が変わったら
+# design-system 側の単一の真実に追従する)。
+_FONT_JP = (
+    "'Noto Sans JP',system-ui,-apple-system,"
+    "'Yu Gothic','Hiragino Kaku Gothic ProN',sans-serif"
+)
+_FONT_EN = "'Inter',system-ui,-apple-system,sans-serif"
+_TEXT_PRIMARY = "#1A1A1A"
+_TEXT_MUTED = "#5C5A57"
+_TEXT_DIM = "#9B9894"
+_HAIRLINE = "#E8E6E1"
+_BG = "#FAFAF7"
+
+_BODY_STYLE = (
+    f"background:{_BG};margin:0;padding:0;"
+    f"font-family:{_FONT_JP};color:{_TEXT_PRIMARY};"
+)
+_CONTAINER_STYLE = (
+    "max-width:680px;margin:0 auto;padding:32px 24px;background:#fff;"
+)
+_H1_STYLE = (
+    f"font-family:{_FONT_JP};font-size:22px;font-weight:700;line-height:1.4;"
+    f"color:{_TEXT_PRIMARY};margin:0 0 4px;letter-spacing:-0.01em;"
+)
+_LEDE_STYLE = (
+    f"font-family:{_FONT_EN};font-size:11px;letter-spacing:0.25em;"
+    f"text-transform:uppercase;color:{_TEXT_DIM};margin:0 0 32px;"
+)
+_SECTION_STYLE = (
+    f"padding:24px 0;border-top:1px solid {_HAIRLINE};"
+)
+_PATTERN_NUM_STYLE = (
+    f"font-family:{_FONT_EN};font-variant-numeric:tabular-nums;"
+    f"font-size:13px;letter-spacing:0.2em;color:{_TEXT_DIM};margin:0 0 6px;"
+)
+_PATTERN_H2_STYLE = (
+    f"font-family:{_FONT_JP};font-size:18px;font-weight:700;line-height:1.4;"
+    f"color:{_TEXT_PRIMARY};margin:0 0 8px;"
+)
+_PATTERN_META_STYLE = (
+    f"font-family:{_FONT_EN};font-size:11px;letter-spacing:0.15em;"
+    f"text-transform:uppercase;color:{_TEXT_DIM};margin:0 0 12px;"
+)
+_VAULT_LINK_STYLE = (
+    f"font-family:{_FONT_EN};font-size:12px;color:{_TEXT_PRIMARY};"
+    f"border-bottom:1px solid {_TEXT_PRIMARY};text-decoration:none;"
+)
+_VERDICT_LABEL_GO_STYLE = (
+    f"display:inline-block;font-family:{_FONT_EN};font-size:11px;"
+    f"letter-spacing:0.2em;color:{_TEXT_PRIMARY};border:1px solid "
+    f"{_TEXT_PRIMARY};padding:1px 6px;margin-right:8px;"
+)
+_VERDICT_LABEL_KILL_STYLE = (
+    f"display:inline-block;font-family:{_FONT_EN};font-size:11px;"
+    f"letter-spacing:0.2em;color:{_TEXT_MUTED};border:1px solid "
+    f"{_TEXT_MUTED};padding:1px 6px;margin-right:8px;"
+)
+_CAND_NAME_STYLE = (
+    f"font-family:{_FONT_JP};font-size:15px;font-weight:600;"
+    f"color:{_TEXT_PRIMARY};"
+)
+_CAND_LINE_STYLE = (
+    f"font-family:{_FONT_JP};font-size:14px;line-height:1.7;"
+    f"color:{_TEXT_MUTED};margin:4px 0 0;"
+)
+_REASON_STYLE = (
+    f"font-family:{_FONT_JP};font-size:13px;line-height:1.7;"
+    f"color:{_TEXT_MUTED};margin:4px 0 0;"
+)
+_EMPTY_NOTE_STYLE = (
+    f"font-family:{_FONT_JP};font-size:13px;color:{_TEXT_DIM};margin:8px 0 0;"
+)
+_FOOTER_STYLE = (
+    f"font-family:{_FONT_EN};font-size:10px;letter-spacing:0.2em;"
+    f"text-transform:uppercase;color:{_TEXT_DIM};margin:40px 0 0;"
+    f"padding-top:24px;border-top:1px solid {_HAIRLINE};"
+)
+
+
+def _render_candidate_html(c: Candidate, label: str, label_style: str) -> str:
+    name = html.escape(c.name)
+    pieces: list[str] = [
+        f'<div style="margin:14px 0 0;">'
+        f'<span style="{label_style}">{label}</span>'
+        f'<span style="{_CAND_NAME_STYLE}">{name}</span>'
+        f'</div>'
+    ]
+    if c.one_liner:
+        pieces.append(
+            f'<p style="{_CAND_LINE_STYLE}">{html.escape(c.one_liner)}</p>'
+        )
+    if c.target_user and label == "GO":
+        pieces.append(
+            f'<p style="{_CAND_LINE_STYLE}">対象: {html.escape(c.target_user)}</p>'
+        )
+    if label == "KILL":
+        reasons = c.kill_reasons or ["(critic_meta に kill_reasons 未収載)"]
+        for reason in reasons:
+            pieces.append(
+                f'<p style="{_REASON_STYLE}">理由: {html.escape(reason)}</p>'
+            )
+    return "".join(pieces)
+
+
+def _render_section_html(index: int, section: DigestSection) -> str:
+    p = section.pattern
+    parts: list[str] = [f'<section style="{_SECTION_STYLE}">']
+    parts.append(f'<p style="{_PATTERN_NUM_STYLE}">PATTERN {index:02d}</p>')
+    parts.append(f'<h2 style="{_PATTERN_H2_STYLE}">{html.escape(p.pain)}</h2>')
+    parts.append(
+        f'<p style="{_PATTERN_META_STYLE}">'
+        f'frequency {p.frequency} · sources {p.source_diversity}'
+        f'</p>'
+    )
+    parts.append(
+        f'<p style="margin:0 0 8px;">'
+        f'<a href="{html.escape(section.obsidian_url, quote=True)}" '
+        f'style="{_VAULT_LINK_STYLE}">Vault note を開く</a>'
+        f'</p>'
+    )
+    if not section.go_candidates and not section.kill_candidates:
+        parts.append(
+            f'<p style="{_EMPTY_NOTE_STYLE}">verdict 付き候補なし。</p>'
+        )
+    for c in section.go_candidates:
+        parts.append(_render_candidate_html(c, "GO", _VERDICT_LABEL_GO_STYLE))
+    for c in section.kill_candidates:
+        parts.append(
+            _render_candidate_html(c, "KILL", _VERDICT_LABEL_KILL_STYLE)
+        )
+    parts.append("</section>")
+    return "".join(parts)
+
+
+def render_html(digest: Digest) -> str:
+    """Render the digest as Hibi-design HTML body."""
+    sections_html = "".join(
+        _render_section_html(i, s) for i, s in enumerate(digest.sections, 1)
+    )
+    return (
+        '<!doctype html>'
+        '<html lang="ja"><head>'
+        '<meta charset="utf-8">'
+        f'<title>{html.escape(format_subject(digest))}</title>'
+        '</head>'
+        f'<body style="{_BODY_STYLE}">'
+        f'<div style="{_CONTAINER_STYLE}">'
+        f'<h1 style="{_H1_STYLE}">今週のアイデア候補</h1>'
+        f'<p style="{_LEDE_STYLE}">'
+        f"Hibi idea mining · {html.escape(digest.week_iso)} · "
+        f"{digest.total_candidates} candidates"
+        f'</p>'
+        f'{sections_html}'
+        f'<p style="{_FOOTER_STYLE}">'
+        f"Hibi · private digest"
+        f'</p>'
+        '</div></body></html>'
+    )
+
+
+# ----------------------------------------------------------------------
+# Orchestration
+# ----------------------------------------------------------------------
+
+
+def _dry_run_enabled() -> bool:
+    return os.environ.get(DRY_RUN_ENV) == "1"
+
+
+def run(
+    conn: psycopg.Connection,
+    *,
+    week_iso: str,
+    recipient: str,
+    dry_run: bool,
+    vault_name: str = DEFAULT_VAULT_NAME,
+) -> str:
+    """End-to-end one-shot run. Returns the outcome label for logging.
+
+    Outcome labels:
+        ``"sent"``     — email queued via Gmail.
+        ``"dry_run"``  — DRY_RUN; rendered email printed to stdout.
+        ``"skipped"``  — no patterns or no verdict candidates; nothing sent.
+    """
+    digest = build_digest(conn, week_iso, vault_name=vault_name)
+    log.info(
+        "digest: week=%s patterns=%d candidates=%d",
+        digest.week_iso,
+        len(digest.sections),
+        digest.total_candidates,
+    )
+
+    if digest.should_skip:
+        log.info(
+            "digest: skip (patterns=%d candidates=%d) — no send",
+            len(digest.sections),
+            digest.total_candidates,
+        )
+        return "skipped"
+
+    subject = format_subject(digest)
+    text_body = render_plain_text(digest)
+    html_body = render_html(digest)
+
+    if dry_run:
+        print(f"Subject: {subject}\nTo: {recipient}\n")
+        print(text_body)
+        return "dry_run"
+
+    email_sender.send_email(
+        subject=subject,
+        to=recipient,
+        html_body=html_body,
+        text_body=text_body,
+    )
+    log.info("digest: sent to %s (subject=%r)", recipient, subject)
+    return "sent"
+
+
+# ----------------------------------------------------------------------
+# CLI entry-point
+# ----------------------------------------------------------------------
+
+
+def _connect() -> psycopg.Connection:
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        print("ERROR: DATABASE_URL is not set", file=sys.stderr)
+        sys.exit(1)
+    return psycopg.connect(url)
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    recipient = os.environ.get("RECIPIENT_EMAIL")
+    if not recipient:
+        print("ERROR: RECIPIENT_EMAIL is not set", file=sys.stderr)
+        return 1
+
+    dry_run = _dry_run_enabled()
+    if not dry_run:
+        missing = [
+            k
+            for k in (
+                "GMAIL_CLIENT_ID",
+                "GMAIL_CLIENT_SECRET",
+                "GMAIL_REFRESH_TOKEN",
+            )
+            if not os.environ.get(k)
+        ]
+        if missing:
+            print(
+                f"ERROR: missing Gmail env vars: {', '.join(missing)}",
+                file=sys.stderr,
+            )
+            return 1
+
+    week_iso = os.environ.get(WEEK_ISO_ENV) or current_week_iso()
+    vault_name = os.environ.get(VAULT_NAME_ENV) or DEFAULT_VAULT_NAME
+    log.info("digest: week_iso=%s dry_run=%s", week_iso, dry_run)
+
+    with _connect() as conn:
+        outcome = run(
+            conn,
+            week_iso=week_iso,
+            recipient=recipient,
+            dry_run=dry_run,
+            vault_name=vault_name,
+        )
+    log.info("digest: done outcome=%s", outcome)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/idea_mining/extractor.py
+++ b/idea_mining/extractor.py
@@ -1,0 +1,405 @@
+"""Idea-mining extractor — voices → patterns via Haiku.
+
+直近 7 日の `voices` (Apple iTunes ★1-4 customer reviews 等) を読み、
+Haiku でクラスタリングして構造的ペインを `patterns` テーブルに UPSERT
+する週 3 回 (火 / 木 / 土 03:00 UTC) cron バッチ。
+
+newspaper pipeline (`daily_news.py` / `articles` / ranking / mailer /
+archive) からは独立した経路。失敗してもニュースレターには影響しない。
+
+Idempotency:
+    INSERT は `ON CONFLICT (week_iso, pain) DO UPDATE` で、同一 (週, pain)
+    が既にあれば frequency / source_diversity / representative_voices /
+    confidence / categories / meta / updated_at を refresh する。古い週の
+    row は削除しない (歴史記録として残す)。
+
+Failure modes:
+    Haiku が malformed JSON を返した場合は sentry_sdk.capture_message +
+    log.warning を発火し、insert ゼロのまま exit 0 で終わる (raise しない、
+    自動 retry もしない)。voices が 0 件 / Apple のみでも exit 0。
+
+CLI entry-point:
+    `python -m idea_mining.extractor` を idea-mining-extractor workflow
+    から呼ぶ。`DATABASE_URL` と `ANTHROPIC_API_KEY` が必須。`SENTRY_DSN`
+    は任意。
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Final
+from uuid import UUID
+
+import psycopg
+import sentry_sdk
+from anthropic import Anthropic
+from psycopg.types.json import Jsonb
+
+from idea_mining.prompts.extractor import SYSTEM_PROMPT
+
+log = logging.getLogger(__name__)
+
+CLAUDE_MODEL: Final[str] = "claude-haiku-4-5-20251001"
+MAX_TOKENS: Final[int] = 2000
+MIN_FREQUENCY: Final[int] = 3
+LOW_DIVERSITY_THRESHOLD: Final[int] = 2
+LOW_DIVERSITY_CONFIDENCE_CAP: Final[float] = 0.5
+
+SELECT_RECENT_VOICES_SQL: Final[str] = """
+    SELECT id, source, posted_at, title, body, meta
+    FROM voices
+    WHERE posted_at >= NOW() - INTERVAL '7 days'
+    ORDER BY posted_at ASC
+"""
+
+UPSERT_PATTERN_SQL: Final[str] = """
+    INSERT INTO patterns (
+        week_iso, pain, categories, frequency, source_diversity,
+        representative_voices, confidence, meta
+    )
+    VALUES (
+        %(week_iso)s, %(pain)s, %(categories)s, %(frequency)s,
+        %(source_diversity)s, %(representative_voices)s::uuid[],
+        %(confidence)s, %(meta)s
+    )
+    ON CONFLICT (week_iso, pain) DO UPDATE SET
+        categories = EXCLUDED.categories,
+        frequency = EXCLUDED.frequency,
+        source_diversity = EXCLUDED.source_diversity,
+        representative_voices = EXCLUDED.representative_voices,
+        confidence = EXCLUDED.confidence,
+        meta = EXCLUDED.meta,
+        updated_at = now()
+"""
+
+
+# ----------------------------------------------------------------------
+# Week ISO
+# ----------------------------------------------------------------------
+
+
+def current_week_iso(now: datetime | None = None) -> str:
+    """Return ISO week as `YYYY-Www` (zero-padded week)."""
+    if now is None:
+        now = datetime.now(timezone.utc)
+    iso = now.isocalendar()
+    return f"{iso.year:04d}-W{iso.week:02d}"
+
+
+# ----------------------------------------------------------------------
+# Voices fetch
+# ----------------------------------------------------------------------
+
+
+def fetch_recent_voices(conn: psycopg.Connection) -> list[dict[str, object]]:
+    """Return all `voices` rows with posted_at within the last 7 days."""
+    with conn.cursor() as cur:
+        cur.execute(SELECT_RECENT_VOICES_SQL)
+        rows = cur.fetchall()
+    out: list[dict[str, object]] = []
+    for row in rows:
+        voice_id, source, posted_at, title, body, meta = row
+        rating: int | None = None
+        if isinstance(meta, dict):
+            raw_rating = meta.get("rating")
+            if isinstance(raw_rating, int):
+                rating = raw_rating
+        out.append(
+            {
+                "id": str(voice_id),
+                "source": source,
+                "posted_at": posted_at.isoformat() if posted_at else None,
+                "title": title,
+                "body": body,
+                "rating": rating,
+            }
+        )
+    return out
+
+
+# ----------------------------------------------------------------------
+# Haiku call + parsing
+# ----------------------------------------------------------------------
+
+
+def build_user_message(voices: list[dict[str, object]]) -> str:
+    """Render the voice list as the user-message body for Haiku."""
+    payload = {"voices": voices}
+    return (
+        "以下は直近 7 日の `voices` の一覧 (JSON) です。"
+        " SYSTEM で指示された JSON スキーマで `patterns` を返してください。\n\n"
+        f"{json.dumps(payload, ensure_ascii=False)}"
+    )
+
+
+def call_haiku(
+    client: Anthropic, voices: list[dict[str, object]]
+) -> str:
+    """Call Haiku and return the raw text response."""
+    response = client.messages.create(
+        model=CLAUDE_MODEL,
+        max_tokens=MAX_TOKENS,
+        system=SYSTEM_PROMPT,
+        messages=[{"role": "user", "content": build_user_message(voices)}],
+    )
+    return response.content[0].text.strip()
+
+
+def _is_valid_uuid(candidate: object) -> bool:
+    if not isinstance(candidate, str):
+        return False
+    try:
+        UUID(candidate)
+    except ValueError:
+        return False
+    return True
+
+
+def parse_haiku_response(
+    raw_text: str, *, voice_ids: set[str]
+) -> list[dict[str, object]]:
+    """Parse Haiku's JSON output into a normalized list of pattern dicts.
+
+    Raises:
+        ValueError: malformed JSON, wrong shape, or any required field
+            missing/wrong-typed. Caller is expected to handle and exit 0.
+
+    Returns:
+        Validated pattern dicts. Caller still has to apply the
+        `frequency >= 3` filter and the low-diversity confidence clamp.
+    """
+    start = raw_text.find("{")
+    end = raw_text.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        raise ValueError(f"no JSON object in response: {raw_text!r}")
+
+    try:
+        parsed = json.loads(raw_text[start : end + 1])
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"JSON decode failed: {exc}") from exc
+
+    if not isinstance(parsed, dict):
+        raise ValueError(f"top-level JSON is not an object: {parsed!r}")
+    patterns_raw = parsed.get("patterns")
+    if not isinstance(patterns_raw, list):
+        raise ValueError(f"`patterns` must be a list: {patterns_raw!r}")
+
+    out: list[dict[str, object]] = []
+    for i, p in enumerate(patterns_raw):
+        if not isinstance(p, dict):
+            raise ValueError(f"pattern[{i}] not an object: {p!r}")
+        pain = p.get("pain")
+        if not isinstance(pain, str) or not pain.strip():
+            raise ValueError(f"pattern[{i}].pain missing/empty: {p!r}")
+        categories_raw = p.get("categories", [])
+        if not isinstance(categories_raw, list) or not all(
+            isinstance(c, str) for c in categories_raw
+        ):
+            raise ValueError(
+                f"pattern[{i}].categories must be a list[str]: {categories_raw!r}"
+            )
+        frequency = p.get("frequency")
+        if not isinstance(frequency, int) or frequency < 0:
+            raise ValueError(
+                f"pattern[{i}].frequency must be a non-negative int: {frequency!r}"
+            )
+        source_diversity = p.get("source_diversity")
+        if not isinstance(source_diversity, int) or source_diversity < 0:
+            raise ValueError(
+                f"pattern[{i}].source_diversity must be a non-negative int:"
+                f" {source_diversity!r}"
+            )
+        rep_voices_raw = p.get("representative_voices", [])
+        if not isinstance(rep_voices_raw, list) or not all(
+            _is_valid_uuid(v) for v in rep_voices_raw
+        ):
+            raise ValueError(
+                f"pattern[{i}].representative_voices must be a list[uuid]:"
+                f" {rep_voices_raw!r}"
+            )
+        confidence_raw = p.get("confidence")
+        if not isinstance(confidence_raw, (int, float)):
+            raise ValueError(
+                f"pattern[{i}].confidence must be a number: {confidence_raw!r}"
+            )
+        confidence = float(confidence_raw)
+        if confidence < 0.0 or confidence > 1.0:
+            raise ValueError(
+                f"pattern[{i}].confidence out of [0, 1]: {confidence!r}"
+            )
+        rep_voices = [v for v in rep_voices_raw if v in voice_ids]
+        out.append(
+            {
+                "pain": pain.strip(),
+                "categories": list(categories_raw),
+                "frequency": frequency,
+                "source_diversity": source_diversity,
+                "representative_voices": rep_voices,
+                "confidence": confidence,
+            }
+        )
+    return out
+
+
+# ----------------------------------------------------------------------
+# Filtering + clamping
+# ----------------------------------------------------------------------
+
+
+def filter_and_clamp(
+    patterns: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    """Drop frequency < 3 and clamp confidence when source_diversity < 2."""
+    out: list[dict[str, object]] = []
+    for p in patterns:
+        frequency = p["frequency"]
+        source_diversity = p["source_diversity"]
+        assert isinstance(frequency, int)
+        assert isinstance(source_diversity, int)
+        if frequency < MIN_FREQUENCY:
+            continue
+        confidence = p["confidence"]
+        assert isinstance(confidence, float)
+        if source_diversity < LOW_DIVERSITY_THRESHOLD:
+            confidence = min(confidence, LOW_DIVERSITY_CONFIDENCE_CAP)
+        out.append({**p, "confidence": confidence})
+    return out
+
+
+# ----------------------------------------------------------------------
+# UPSERT
+# ----------------------------------------------------------------------
+
+
+def upsert_patterns(
+    conn: psycopg.Connection,
+    patterns: list[dict[str, object]],
+    *,
+    week_iso: str,
+    raw_response_snippet: str,
+) -> int:
+    """UPSERT pattern rows. Returns the number of rows touched (insert or update)."""
+    if not patterns:
+        return 0
+    affected = 0
+    with conn.cursor() as cur:
+        for p in patterns:
+            params = {
+                "week_iso": week_iso,
+                "pain": p["pain"],
+                "categories": list(p["categories"]),  # type: ignore[arg-type]
+                "frequency": p["frequency"],
+                "source_diversity": p["source_diversity"],
+                "representative_voices": list(p["representative_voices"]),  # type: ignore[arg-type]
+                "confidence": p["confidence"],
+                "meta": Jsonb(
+                    {
+                        "model": CLAUDE_MODEL,
+                        "raw_response_snippet": raw_response_snippet[:500],
+                    }
+                ),
+            }
+            cur.execute(UPSERT_PATTERN_SQL, params)
+            affected += cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
+    conn.commit()
+    return affected
+
+
+# ----------------------------------------------------------------------
+# Orchestration
+# ----------------------------------------------------------------------
+
+
+def run_once(
+    conn: psycopg.Connection,
+    client: Anthropic,
+    *,
+    week_iso: str,
+) -> int:
+    """End-to-end one-shot extraction. Returns rows upserted (0 on any soft fail)."""
+    voices = fetch_recent_voices(conn)
+    log.info("extractor: %d voices in last 7 days", len(voices))
+    if not voices:
+        log.info("extractor: no voices — nothing to do")
+        return 0
+
+    raw_text = call_haiku(client, voices)
+    voice_ids = {str(v["id"]) for v in voices}
+    try:
+        parsed = parse_haiku_response(raw_text, voice_ids=voice_ids)
+    except ValueError as exc:
+        log.warning("extractor: malformed Haiku response: %s", exc)
+        sentry_sdk.capture_message(
+            f"extractor: malformed Haiku JSON response: {exc}",
+            level="warning",
+        )
+        return 0
+
+    filtered = filter_and_clamp(parsed)
+    log.info(
+        "extractor: Haiku returned %d patterns, %d after frequency/diversity filter",
+        len(parsed),
+        len(filtered),
+    )
+    if not filtered:
+        return 0
+    return upsert_patterns(
+        conn, filtered, week_iso=week_iso, raw_response_snippet=raw_text
+    )
+
+
+# ----------------------------------------------------------------------
+# CLI entry-point
+# ----------------------------------------------------------------------
+
+
+def _init_sentry() -> None:
+    dsn = os.environ.get("SENTRY_DSN")
+    if not dsn:
+        log.info("extractor: SENTRY_DSN unset — failure alerts disabled")
+        return
+    sentry_sdk.init(
+        dsn=dsn,
+        release=os.environ.get("HIBI_RELEASE", "dev"),
+        environment=os.environ.get("HIBI_ENV", "production"),
+        traces_sample_rate=0.0,
+        send_default_pii=False,
+    )
+    sentry_sdk.set_tag("pipeline", "idea_mining_extractor")
+
+
+def _connect() -> psycopg.Connection:
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        print("ERROR: DATABASE_URL is not set", file=sys.stderr)
+        sys.exit(1)
+    return psycopg.connect(url)
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    _init_sentry()
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("ERROR: ANTHROPIC_API_KEY is not set", file=sys.stderr)
+        sys.exit(1)
+    client = Anthropic(api_key=api_key)
+    week_iso = current_week_iso()
+    log.info("extractor: week_iso=%s", week_iso)
+
+    with _connect() as conn:
+        upserted = run_once(conn, client, week_iso=week_iso)
+
+    log.info("extractor: done week_iso=%s upserted=%d", week_iso, upserted)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/idea_mining/fetchers/__init__.py
+++ b/idea_mining/fetchers/__init__.py
@@ -1,0 +1,5 @@
+"""idea_mining fetchers package.
+
+Newspaper pipeline (`fetchers/`) と独立した、idea-mining 専用の fetcher 群を
+収める。書き込み先は `voices` テーブル (private)。`articles` には触れない。
+"""

--- a/idea_mining/fetchers/apple_rss.py
+++ b/idea_mining/fetchers/apple_rss.py
@@ -1,0 +1,426 @@
+"""Apple iTunes RSS fetcher — ★1-4 customer reviews into `voices`.
+
+各 (country, app_id) について Apple 公式 RSS customer-reviews endpoint を
+叩き、★1-4 のレビューだけを `voices` テーブルに insert する。★5 は
+INSERT 前に除外し、元の rating は `meta.rating` (1-5) に保持する。
+
+newspaper pipeline (`daily_news.py` / `articles` / mailer / archive) からは
+独立した経路。失敗してもニュースレターには影響しない。
+
+Idempotency:
+    INSERT は `ON CONFLICT (source, source_id) DO NOTHING` で、同一 (source,
+    review_id) の再 insert は NoOp になる (migration 008 の UNIQUE 制約)。
+
+Retry / Failure:
+    HTTP 失敗時は exp backoff 1s,2s,4s,8s,16s で最大 5 回リトライ
+    (1 初期 + 5 retries = 6 attempts)。5 回連続で retry が失敗したら
+    Sentry alert を発火し、当該アプリ × country を skip して次へ進む。
+
+CLI entry-point:
+    `python -m idea_mining.fetchers.apple_rss` を idea-mining-weekly
+    workflow から呼ぶ。`DATABASE_URL` 必須。`SENTRY_DSN` は任意。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Final
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import psycopg
+import sentry_sdk
+import yaml
+from psycopg.types.json import Jsonb
+
+log = logging.getLogger(__name__)
+
+SOURCE_NAME: Final[str] = "apple_rss"
+
+APPLE_RSS_URL_FMT: Final[str] = (
+    "https://itunes.apple.com/{country}/rss/customerreviews/"
+    "id={app_id}/sortby=mostrecent/json"
+)
+USER_AGENT: Final[str] = (
+    "HibiIdeaMiningBot/1.0 (+https://github.com/kazuki-0418/hibi)"
+)
+HTTP_TIMEOUT_SECONDS: Final[int] = 30
+
+# 1 initial attempt + 5 retries with these inter-attempt delays.
+# After all retries are exhausted (5 consecutive failures), Sentry alert + skip.
+RETRY_DELAYS_SECONDS: Final[tuple[int, ...]] = (1, 2, 4, 8, 16)
+
+# country → BCP-47 lang lookup. Apple feed の本文は country の主要言語に
+# 倣う前提 (本文判定は行わない)。MVP では jp のみ運用。
+LANG_BY_COUNTRY: Final[dict[str, str]] = {
+    "jp": "ja",
+    "us": "en",
+    "gb": "en",
+    "ca": "en",
+    "au": "en",
+}
+
+
+# ----------------------------------------------------------------------
+# Config (sources.yaml)
+# ----------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AppleApp:
+    """sources.yaml の apple_apps セクション 1 件分。"""
+
+    name: str
+    app_id: str
+    countries: tuple[str, ...]
+    enabled: bool = True
+
+
+def load_apple_apps(sources_yaml_path: str | Path) -> list[AppleApp]:
+    """`sources.yaml` から有効な apple_apps エントリを返す。
+
+    既存 `sources:` / `channels` / `rss` セクションには触れない。
+    """
+    with open(sources_yaml_path, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+
+    raw_apps = data.get("apple_apps") or []
+    apps: list[AppleApp] = []
+    for entry in raw_apps:
+        if not entry.get("enabled", True):
+            continue
+        countries_raw = entry.get("country") or []
+        if not isinstance(countries_raw, list) or not countries_raw:
+            log.warning(
+                "apple_rss: skip %r — country must be a non-empty list",
+                entry.get("name"),
+            )
+            continue
+        apps.append(
+            AppleApp(
+                name=str(entry["name"]),
+                app_id=str(entry["app_id"]),
+                countries=tuple(str(c) for c in countries_raw),
+                enabled=True,
+            )
+        )
+    return apps
+
+
+# ----------------------------------------------------------------------
+# HTTP fetch with retry + backoff
+# ----------------------------------------------------------------------
+
+
+HttpGet = Callable[[str], dict]
+
+
+def _default_http_get(url: str) -> dict:
+    """Default JSON GET. Raises URLError / HTTPError / JSONDecodeError / TimeoutError."""
+    req = Request(url, headers={"User-Agent": USER_AGENT})
+    with urlopen(req, timeout=HTTP_TIMEOUT_SECONDS) as resp:
+        payload = resp.read()
+    return json.loads(payload.decode("utf-8"))
+
+
+_RETRYABLE_EXC: tuple[type[BaseException], ...] = (
+    URLError,
+    HTTPError,
+    TimeoutError,
+    json.JSONDecodeError,
+    ConnectionError,
+)
+
+
+def fetch_one(
+    country: str,
+    app_id: str,
+    *,
+    http_get: HttpGet = _default_http_get,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> dict | None:
+    """Fetch 1 (country, app_id) feed with exp-backoff retry.
+
+    Returns the decoded JSON dict on success, or ``None`` if all retries
+    were exhausted. On exhaustion, sends a Sentry alert and returns
+    ``None`` so the caller can skip and move on.
+    """
+    url = APPLE_RSS_URL_FMT.format(country=country, app_id=app_id)
+    last_err: BaseException | None = None
+
+    try:
+        return http_get(url)
+    except _RETRYABLE_EXC as e:
+        last_err = e
+        log.warning("apple_rss: initial fetch failed for %s/%s: %r", country, app_id, e)
+
+    for retry_n, delay in enumerate(RETRY_DELAYS_SECONDS, start=1):
+        sleep_fn(delay)
+        try:
+            return http_get(url)
+        except _RETRYABLE_EXC as e:
+            last_err = e
+            log.warning(
+                "apple_rss: retry %d/%d failed for %s/%s: %r",
+                retry_n,
+                len(RETRY_DELAYS_SECONDS),
+                country,
+                app_id,
+                e,
+            )
+
+    sentry_sdk.capture_message(
+        f"apple_rss: 5 consecutive retries exhausted for {country}/{app_id}: {last_err!r}",
+        level="error",
+    )
+    return None
+
+
+# ----------------------------------------------------------------------
+# Parser (Apple RSS JSON → voice rows)
+# ----------------------------------------------------------------------
+
+
+def _entry_field(entry: dict, key: str) -> str | None:
+    """Apple feed の `{label: ...}` 構造を 1 段剥がす。欠落時 None."""
+    node = entry.get(key)
+    if not isinstance(node, dict):
+        return None
+    label = node.get("label")
+    return str(label) if label is not None else None
+
+
+def _entry_author(entry: dict) -> str | None:
+    author = entry.get("author")
+    if not isinstance(author, dict):
+        return None
+    name = author.get("name")
+    if isinstance(name, dict):
+        label = name.get("label")
+        return str(label) if label is not None else None
+    return None
+
+
+def _parse_rating(raw: str | None) -> int | None:
+    """`im:rating.label` を int に。失敗時 None (= 不正エントリは捨てる)。"""
+    if raw is None:
+        return None
+    try:
+        v = int(raw)
+    except ValueError:
+        return None
+    if v < 1 or v > 5:
+        return None
+    return v
+
+
+def parse_review_entries(
+    payload: dict,
+    *,
+    country: str,
+    app_id: str,
+) -> list[dict]:
+    """Apple RSS JSON を voice row dict のリストに整形。★5 は除外。
+
+    Returns:
+        list of dicts with keys:
+            source     — fixed 'apple_rss'
+            source_id  — review id (str)
+            posted_at  — ISO timestamp (str)
+            title      — review title (str | None)
+            body       — review content (str | None)
+            meta       — {version, author, country, lang, rating}
+    """
+    feed = payload.get("feed") or {}
+    entries_raw = feed.get("entry")
+    if entries_raw is None:
+        return []
+    if isinstance(entries_raw, dict):
+        entries_raw = [entries_raw]
+    if not isinstance(entries_raw, list):
+        return []
+
+    lang = LANG_BY_COUNTRY.get(country, country)
+    rows: list[dict] = []
+    for entry in entries_raw:
+        if not isinstance(entry, dict):
+            continue
+        rating = _parse_rating(_entry_field(entry, "im:rating"))
+        if rating is None:
+            # No rating → app metadata entry or malformed; skip.
+            continue
+        if rating == 5:
+            # ★5 は idea-mining 対象外 (positive bias / spam)。
+            continue
+        review_id = _entry_field(entry, "id")
+        if not review_id:
+            continue
+        posted_at = _entry_field(entry, "updated")
+        if not posted_at:
+            continue
+        rows.append(
+            {
+                "source": SOURCE_NAME,
+                "source_id": review_id,
+                "posted_at": posted_at,
+                "title": _entry_field(entry, "title"),
+                "body": _entry_field(entry, "content"),
+                "meta": {
+                    "version": _entry_field(entry, "im:version"),
+                    "author": _entry_author(entry),
+                    "country": country,
+                    "lang": lang,
+                    "rating": rating,
+                    "app_id": app_id,
+                },
+            }
+        )
+    return rows
+
+
+# ----------------------------------------------------------------------
+# DB insert
+# ----------------------------------------------------------------------
+
+
+INSERT_SQL: Final[str] = """
+    INSERT INTO voices (source, source_id, posted_at, title, body, meta)
+    VALUES (%(source)s, %(source_id)s, %(posted_at)s, %(title)s, %(body)s, %(meta)s)
+    ON CONFLICT (source, source_id) DO NOTHING
+"""
+
+
+def insert_voices(conn: psycopg.Connection, rows: list[dict]) -> int:
+    """Bulk-insert voice rows. Returns the number of rows the DB reports
+    as actually inserted (ON CONFLICT skips do not count).
+    """
+    if not rows:
+        return 0
+    inserted = 0
+    with conn.cursor() as cur:
+        for row in rows:
+            params = {
+                "source": row["source"],
+                "source_id": row["source_id"],
+                "posted_at": row["posted_at"],
+                "title": row.get("title"),
+                "body": row.get("body"),
+                "meta": Jsonb(row.get("meta") or {}),
+            }
+            cur.execute(INSERT_SQL, params)
+            inserted += cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
+    conn.commit()
+    return inserted
+
+
+# ----------------------------------------------------------------------
+# Orchestration
+# ----------------------------------------------------------------------
+
+
+@dataclass
+class RunStats:
+    apps_total: int = 0
+    pairs_total: int = 0
+    pairs_skipped: int = 0
+    rows_parsed: int = 0
+    rows_inserted: int = 0
+    failures: list[str] = field(default_factory=list)
+
+
+def run_once(
+    apps: list[AppleApp],
+    *,
+    conn: psycopg.Connection,
+    http_get: HttpGet = _default_http_get,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> RunStats:
+    """Drive (app × country) iteration end-to-end. Single-process, sync."""
+    stats = RunStats(apps_total=len(apps))
+    for app in apps:
+        for country in app.countries:
+            stats.pairs_total += 1
+            payload = fetch_one(
+                country, app.app_id, http_get=http_get, sleep_fn=sleep_fn
+            )
+            if payload is None:
+                stats.pairs_skipped += 1
+                stats.failures.append(f"{country}/{app.app_id}")
+                continue
+            rows = parse_review_entries(
+                payload, country=country, app_id=app.app_id
+            )
+            stats.rows_parsed += len(rows)
+            stats.rows_inserted += insert_voices(conn, rows)
+    return stats
+
+
+# ----------------------------------------------------------------------
+# CLI entry-point (invoked by .github/workflows/idea-mining-weekly.yml)
+# ----------------------------------------------------------------------
+
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
+DEFAULT_SOURCES_YAML: Final[Path] = REPO_ROOT / "sources.yaml"
+
+
+def _init_sentry() -> None:
+    """Sentry を `observability.init_sentry_from_env` と同じ env で初期化。"""
+    dsn = os.environ.get("SENTRY_DSN")
+    if not dsn:
+        log.info("apple_rss: SENTRY_DSN unset — failure alerts disabled")
+        return
+    sentry_sdk.init(
+        dsn=dsn,
+        release=os.environ.get("HIBI_RELEASE", "dev"),
+        environment=os.environ.get("HIBI_ENV", "production"),
+        traces_sample_rate=0.0,
+        send_default_pii=False,
+    )
+    sentry_sdk.set_tag("pipeline", "idea_mining_apple_rss")
+
+
+def _connect() -> psycopg.Connection:
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        print("ERROR: DATABASE_URL is not set", file=sys.stderr)
+        sys.exit(1)
+    return psycopg.connect(url)
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    _init_sentry()
+
+    apps = load_apple_apps(DEFAULT_SOURCES_YAML)
+    log.info("apple_rss: %d enabled apps loaded", len(apps))
+    if not apps:
+        log.info("apple_rss: no enabled apps — nothing to do")
+        return 0
+
+    with _connect() as conn:
+        stats = run_once(apps, conn=conn)
+
+    log.info(
+        "apple_rss: done apps=%d pairs=%d skipped=%d parsed=%d inserted=%d failures=%s",
+        stats.apps_total,
+        stats.pairs_total,
+        stats.pairs_skipped,
+        stats.rows_parsed,
+        stats.rows_inserted,
+        stats.failures,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/idea_mining/ideator.py
+++ b/idea_mining/ideator.py
@@ -1,0 +1,580 @@
+"""Idea-mining Ideator — patterns → candidates via Anthropic Opus.
+
+Issue #138 (Epic #134) の実装。手動指定された patterns 1-3 件を入力に
+Anthropic Opus (`claude-opus-4-7`) で 5-10 件の事業候補を生成し、
+profile/user-constraints + profile/negative-examples を system prompt の
+先頭に必ず注入したうえで、validation を通過した候補だけを `candidates`
+テーブルへ INSERT する。
+
+CLI:
+    python -m idea_mining.ideator --pattern-id <uuid> [--pattern-id <uuid> ...]
+
+最大 3 件まで `--pattern-id` を repeat 可能 (Issue 受入: 1-3 pattern)。
+
+Required env:
+    DATABASE_URL          — Neon (psycopg 3.x)
+    ANTHROPIC_API_KEY     — Opus access
+    OBSIDIAN_VAULT_ROOT   — profile/*.md の置かれた Vault clone
+
+Optional env:
+    SENTRY_DSN            — failure alerts (`idea_mining.ideator` tag)
+    HIBI_RELEASE          — sentry release
+    HIBI_ENV              — sentry environment
+    HIBI_VAULT_OPTIONAL=1 — profile_loader を空文字で fall through (テスト用、
+                            本番では絶対 set しない)。CLI 側でも空 profile は
+                            fails-closed (exit 1) として扱う。
+
+Fails-closed semantics:
+    - profile が空 / 未整備の場合は実行を中断する (Issue 制約)。
+    - patterns(id) 未取得の場合は当該 pattern を skip し、log + Sentry に残す。
+    - Opus が malformed JSON を返した場合は当該 pattern を 0 件で記録し、
+      他 pattern の処理は継続する (raise しない)。
+
+Critic Agent (Issue #139) は本 Issue では呼ばない。`critic_verdict` /
+`critic_meta` は NULL のまま。
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from typing import Final
+from uuid import UUID
+
+import psycopg
+import sentry_sdk
+from anthropic import Anthropic
+
+from idea_mining.profile_loader import load as load_profile
+from idea_mining.prompts.ideator import SYSTEM_PROMPT_TEMPLATE
+
+log = logging.getLogger(__name__)
+
+CLAUDE_MODEL: Final[str] = "claude-opus-4-7"
+MAX_TOKENS: Final[int] = 4000
+MAX_PATTERNS_PER_RUN: Final[int] = 3
+MIN_CANDIDATES_PER_PATTERN: Final[int] = 5
+MAX_CANDIDATES_PER_PATTERN: Final[int] = 10
+
+ALLOWED_MONETIZATION: Final[frozenset[str]] = frozenset(
+    {"subscription", "one-time", "affiliate", "freemium", "b2b"}
+)
+ALLOWED_LLM_MOAT_CONDITIONS: Final[frozenset[str]] = frozenset(
+    {
+        "workflow",
+        "data",
+        "distribution",
+        "trust",
+        "network",
+        "physical",
+        "regulatory",
+    }
+)
+
+SELECT_PATTERN_SQL: Final[str] = """
+    SELECT id, pain
+    FROM patterns
+    WHERE id = %s
+"""
+
+INSERT_CANDIDATE_SQL: Final[str] = """
+    INSERT INTO candidates (
+        spot_id, pattern_id, name, one_liner, target_user, monetization,
+        llm_moat_conditions, why_different, estimated_mvp_hours,
+        killer_use_case
+    ) VALUES (
+        %(spot_id)s, %(pattern_id)s, %(name)s, %(one_liner)s,
+        %(target_user)s, %(monetization)s, %(llm_moat_conditions)s,
+        %(why_different)s, %(estimated_mvp_hours)s, %(killer_use_case)s
+    )
+"""
+
+
+# ----------------------------------------------------------------------
+# Profile / prompt assembly
+# ----------------------------------------------------------------------
+
+
+def build_system_prompt(profile_block: str) -> str:
+    """Inject the profile block at the head of the system prompt.
+
+    Raises:
+        ValueError: when ``profile_block`` is empty. The Ideator must
+            never call Opus without user-constraints + negative-examples
+            in the prompt (Issue #138 acceptance criterion).
+    """
+    if not profile_block.strip():
+        raise ValueError(
+            "profile_block is empty; refusing to build prompt without "
+            "user-constraints + negative-examples"
+        )
+    return SYSTEM_PROMPT_TEMPLATE.format(profile_block=profile_block)
+
+
+def build_user_message(pattern: dict[str, object]) -> str:
+    """Render the pattern as the user-message body for Opus."""
+    pain = pattern["pain"]
+    assert isinstance(pain, str)
+    return (
+        "Pattern を 1 件処理してください。\n\n"
+        f"pattern.pain: {pain}\n\n"
+        'JSON のみで {"candidates": [...]} を返してください。'
+    )
+
+
+def extract_negative_example_names(profile_markdown: str) -> list[str]:
+    """Pull H2 headings under any '# Negative Examples'-like H1 section.
+
+    `profile/negative-examples.md` is concatenated into the loader output
+    after `user-constraints.md`, so we scan for an H1 whose text contains
+    'negative' or the Japanese 'ネガティブ', and harvest the immediately
+    following '## ' headings. Used as an insert-time guard against the
+    Ideator emitting candidates that lexically match KILLed concepts
+    (e.g. 'Aesthetic OS').
+    """
+    names: list[str] = []
+    in_negative_section = False
+    for raw_line in profile_markdown.splitlines():
+        line = raw_line.strip()
+        if line.startswith("# ") and not line.startswith("## "):
+            header = line[2:].strip().lower()
+            in_negative_section = (
+                "negative" in header or "ネガティブ" in header
+            )
+            continue
+        if in_negative_section and line.startswith("## "):
+            name = line[3:].strip()
+            if name:
+                names.append(name)
+    return names
+
+
+def _matches_negative_example(
+    candidate: dict[str, object], forbidden: list[str]
+) -> str | None:
+    """Return the forbidden name that matches, or None.
+
+    Case-insensitive substring match against the candidate's ``name`` and
+    ``one_liner``. Intentionally crude — the prompt is the primary defense;
+    this is just a final cheap gate for slip-throughs.
+    """
+    haystacks: list[str] = []
+    for field in ("name", "one_liner"):
+        value = candidate.get(field)
+        if isinstance(value, str):
+            haystacks.append(value.lower())
+    for forbidden_name in forbidden:
+        needle = forbidden_name.strip().lower()
+        if not needle:
+            continue
+        for hay in haystacks:
+            if needle in hay:
+                return forbidden_name
+    return None
+
+
+# ----------------------------------------------------------------------
+# Opus call + JSON parsing
+# ----------------------------------------------------------------------
+
+
+def call_opus(
+    client: Anthropic, *, system_prompt: str, user_message: str
+) -> str:
+    """Call Opus and return the raw text response."""
+    response = client.messages.create(
+        model=CLAUDE_MODEL,
+        max_tokens=MAX_TOKENS,
+        system=system_prompt,
+        messages=[{"role": "user", "content": user_message}],
+    )
+    return response.content[0].text.strip()
+
+
+def parse_opus_response(raw_text: str) -> list[dict[str, object]]:
+    """Parse Opus' JSON output into a raw list of candidate dicts.
+
+    Field-level validation is NOT done here — see :func:`validate_candidate`.
+
+    Raises:
+        ValueError: malformed JSON, wrong top-level shape, or
+            ``candidates`` not a list.
+    """
+    start = raw_text.find("{")
+    end = raw_text.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        raise ValueError(f"no JSON object in response: {raw_text!r}")
+
+    try:
+        parsed = json.loads(raw_text[start : end + 1])
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"JSON decode failed: {exc}") from exc
+
+    if not isinstance(parsed, dict):
+        raise ValueError(f"top-level JSON is not an object: {parsed!r}")
+    candidates_raw = parsed.get("candidates")
+    if not isinstance(candidates_raw, list):
+        raise ValueError(
+            f"`candidates` must be a list: {candidates_raw!r}"
+        )
+
+    out: list[dict[str, object]] = []
+    for i, c in enumerate(candidates_raw):
+        if not isinstance(c, dict):
+            raise ValueError(f"candidate[{i}] not an object: {c!r}")
+        out.append(c)
+    return out
+
+
+# ----------------------------------------------------------------------
+# Validation
+# ----------------------------------------------------------------------
+
+
+def validate_candidate(
+    raw: dict[str, object],
+    *,
+    negative_names: list[str],
+) -> tuple[dict[str, object] | None, str | None]:
+    """Validate a single candidate dict.
+
+    Returns ``(validated_candidate, None)`` on success or
+    ``(None, reject_reason)`` on failure. The caller logs the reason and
+    drops the row (Issue #138: skip + log, do NOT raise).
+
+    Enforced rules (per Issue #138 acceptance criteria):
+
+    - ``name`` is a non-empty str.
+    - ``monetization`` is in {subscription, one-time, affiliate, freemium, b2b}.
+    - ``llm_moat_conditions`` is a non-empty list[str], every element in
+      {workflow, data, distribution, trust, network, physical, regulatory}.
+    - Optional string fields (``one_liner``, ``target_user``,
+      ``why_different``, ``killer_use_case``) are str-or-null.
+    - ``estimated_mvp_hours`` is int-or-null.
+    - ``name`` / ``one_liner`` do NOT match any item in ``negative_names``
+      (case-insensitive substring match).
+    """
+    name = raw.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return None, "missing or empty name"
+
+    monetization = raw.get("monetization")
+    if (
+        not isinstance(monetization, str)
+        or monetization not in ALLOWED_MONETIZATION
+    ):
+        return None, f"invalid monetization: {monetization!r}"
+
+    moat_raw = raw.get("llm_moat_conditions")
+    if not isinstance(moat_raw, list) or len(moat_raw) == 0:
+        return None, "llm_moat_conditions empty or missing"
+    moat: list[str] = []
+    for m in moat_raw:
+        if not isinstance(m, str):
+            return None, f"non-str moat condition: {m!r}"
+        normalized = m.strip().lower()
+        if normalized not in ALLOWED_LLM_MOAT_CONDITIONS:
+            return None, f"invalid moat condition: {m!r}"
+        moat.append(normalized)
+
+    one_liner = raw.get("one_liner")
+    target_user = raw.get("target_user")
+    why_different = raw.get("why_different")
+    killer_use_case = raw.get("killer_use_case")
+    for field_name, val in (
+        ("one_liner", one_liner),
+        ("target_user", target_user),
+        ("why_different", why_different),
+        ("killer_use_case", killer_use_case),
+    ):
+        if val is not None and not isinstance(val, str):
+            return None, f"{field_name} must be str or null: {val!r}"
+
+    estimated_mvp_hours = raw.get("estimated_mvp_hours")
+    if estimated_mvp_hours is not None and not isinstance(
+        estimated_mvp_hours, int
+    ):
+        return None, (
+            f"estimated_mvp_hours must be int or null: {estimated_mvp_hours!r}"
+        )
+
+    hit = _matches_negative_example(
+        {"name": name, "one_liner": one_liner}, negative_names
+    )
+    if hit is not None:
+        return None, f"matches negative-example: {hit!r}"
+
+    return (
+        {
+            "name": name.strip(),
+            "one_liner": one_liner,
+            "target_user": target_user,
+            "monetization": monetization,
+            "llm_moat_conditions": moat,
+            "why_different": why_different,
+            "estimated_mvp_hours": estimated_mvp_hours,
+            "killer_use_case": killer_use_case,
+        },
+        None,
+    )
+
+
+# ----------------------------------------------------------------------
+# DB I/O
+# ----------------------------------------------------------------------
+
+
+def fetch_pattern(
+    conn: psycopg.Connection, pattern_id: str
+) -> dict[str, object] | None:
+    """Return ``{id, pain}`` for the given patterns(id), or None."""
+    with conn.cursor() as cur:
+        cur.execute(SELECT_PATTERN_SQL, (pattern_id,))
+        row = cur.fetchone()
+    if not row:
+        return None
+    pid, pain = row
+    return {"id": str(pid), "pain": pain}
+
+
+def insert_candidates(
+    conn: psycopg.Connection,
+    candidates: list[dict[str, object]],
+    *,
+    pattern_id: str,
+) -> int:
+    """INSERT each validated candidate. Returns the row count actually written."""
+    if not candidates:
+        return 0
+    inserted = 0
+    with conn.cursor() as cur:
+        for c in candidates:
+            params = {
+                "spot_id": None,
+                "pattern_id": pattern_id,
+                "name": c["name"],
+                "one_liner": c.get("one_liner"),
+                "target_user": c.get("target_user"),
+                "monetization": c["monetization"],
+                "llm_moat_conditions": list(c["llm_moat_conditions"]),  # type: ignore[arg-type]
+                "why_different": c.get("why_different"),
+                "estimated_mvp_hours": c.get("estimated_mvp_hours"),
+                "killer_use_case": c.get("killer_use_case"),
+            }
+            cur.execute(INSERT_CANDIDATE_SQL, params)
+            inserted += 1
+    conn.commit()
+    return inserted
+
+
+# ----------------------------------------------------------------------
+# Orchestration
+# ----------------------------------------------------------------------
+
+
+def run_for_pattern(
+    conn: psycopg.Connection,
+    client: Anthropic,
+    *,
+    pattern_id: str,
+    profile_block: str,
+) -> int:
+    """End-to-end: fetch pattern → Opus → validate → insert. Returns rows inserted."""
+    pattern = fetch_pattern(conn, pattern_id)
+    if pattern is None:
+        log.warning("ideator: pattern not found: %s — skipping", pattern_id)
+        sentry_sdk.capture_message(
+            f"ideator: pattern not found: {pattern_id}",
+            level="warning",
+        )
+        return 0
+
+    log.info(
+        "ideator: pattern_id=%s pain=%r", pattern_id, pattern["pain"]
+    )
+
+    negative_names = extract_negative_example_names(profile_block)
+    log.info(
+        "ideator: negative-example name guards: %d entries", len(negative_names)
+    )
+
+    system_prompt = build_system_prompt(profile_block)
+    user_message = build_user_message(pattern)
+    raw_text = call_opus(
+        client, system_prompt=system_prompt, user_message=user_message
+    )
+
+    try:
+        raw_candidates = parse_opus_response(raw_text)
+    except ValueError as exc:
+        log.warning(
+            "ideator: malformed Opus JSON for pattern %s: %s",
+            pattern_id,
+            exc,
+        )
+        sentry_sdk.capture_message(
+            f"ideator: malformed Opus JSON for pattern {pattern_id}: {exc}",
+            level="warning",
+        )
+        return 0
+
+    log.info(
+        "ideator: Opus returned %d raw candidates for pattern %s",
+        len(raw_candidates),
+        pattern_id,
+    )
+
+    validated: list[dict[str, object]] = []
+    rejected = 0
+    for i, c in enumerate(raw_candidates):
+        v, reason = validate_candidate(c, negative_names=negative_names)
+        if v is None:
+            rejected += 1
+            log.info(
+                "ideator: rejected candidate[%d] (pattern %s): %s",
+                i,
+                pattern_id,
+                reason,
+            )
+            continue
+        validated.append(v)
+
+    log.info(
+        "ideator: pattern %s — %d accepted, %d rejected",
+        pattern_id,
+        len(validated),
+        rejected,
+    )
+
+    if not validated:
+        return 0
+    return insert_candidates(conn, validated, pattern_id=pattern_id)
+
+
+# ----------------------------------------------------------------------
+# CLI entry-point
+# ----------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="idea_mining.ideator",
+        description=(
+            "B-Mode Ideator: 1-3 patterns を入力に Opus が候補を生成し "
+            "candidates テーブルへ insert する。"
+        ),
+    )
+    parser.add_argument(
+        "--pattern-id",
+        action="append",
+        required=True,
+        metavar="UUID",
+        help="patterns.id (UUID). 最大 3 件まで repeat 可能。",
+    )
+    return parser.parse_args(argv)
+
+
+def _validate_pattern_ids(raw_ids: list[str]) -> list[str]:
+    if len(raw_ids) > MAX_PATTERNS_PER_RUN:
+        raise ValueError(
+            f"--pattern-id は最大 {MAX_PATTERNS_PER_RUN} 件まで "
+            f"(received {len(raw_ids)})"
+        )
+    out: list[str] = []
+    for pid in raw_ids:
+        try:
+            UUID(pid)
+        except ValueError as exc:
+            raise ValueError(
+                f"--pattern-id is not a valid UUID: {pid!r}"
+            ) from exc
+        out.append(pid)
+    return out
+
+
+def _init_sentry() -> None:
+    dsn = os.environ.get("SENTRY_DSN")
+    if not dsn:
+        log.info("ideator: SENTRY_DSN unset — failure alerts disabled")
+        return
+    sentry_sdk.init(
+        dsn=dsn,
+        release=os.environ.get("HIBI_RELEASE", "dev"),
+        environment=os.environ.get("HIBI_ENV", "production"),
+        traces_sample_rate=0.0,
+        send_default_pii=False,
+    )
+    sentry_sdk.set_tag("pipeline", "idea_mining_ideator")
+
+
+def _connect() -> psycopg.Connection:
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        print("ERROR: DATABASE_URL is not set", file=sys.stderr)
+        sys.exit(1)
+    return psycopg.connect(url)
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    _init_sentry()
+
+    args = _parse_args(argv)
+    try:
+        pattern_ids = _validate_pattern_ids(args.pattern_id)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("ERROR: ANTHROPIC_API_KEY is not set", file=sys.stderr)
+        return 1
+
+    try:
+        profile_block = load_profile()
+    except RuntimeError as exc:
+        print(f"ERROR: profile load failed: {exc}", file=sys.stderr)
+        return 1
+    if not profile_block.strip():
+        print(
+            "ERROR: profile is empty. Set OBSIDIAN_VAULT_ROOT and ensure "
+            "profile/user-constraints.md and profile/negative-examples.md "
+            "exist. (HIBI_VAULT_OPTIONAL is for tests only.)",
+            file=sys.stderr,
+        )
+        return 1
+
+    client = Anthropic(api_key=api_key)
+
+    total_inserted = 0
+    with _connect() as conn:
+        for pid in pattern_ids:
+            try:
+                inserted = run_for_pattern(
+                    conn,
+                    client,
+                    pattern_id=pid,
+                    profile_block=profile_block,
+                )
+            except Exception as exc:  # noqa: BLE001 — per-pattern fence
+                log.exception("ideator: pattern %s failed: %s", pid, exc)
+                sentry_sdk.capture_exception(exc)
+                continue
+            total_inserted += inserted
+
+    log.info(
+        "ideator: done. patterns=%d total_candidates_inserted=%d",
+        len(pattern_ids),
+        total_inserted,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/idea_mining/prompts/critic.py
+++ b/idea_mining/prompts/critic.py
@@ -1,0 +1,32 @@
+"""System prompt template for the Critic (candidates → critic_verdict via Sonnet).
+
+`SYSTEM_PROMPT_TEMPLATE` には `{profile_block}` を 1 つだけ含む。
+`prompts._profile_block.profile_block()` の戻り値をそのまま貼り付ける前提。
+
+Decisions §4 の RUBRIC テキストおよび §B の system prompt 構造を verbatim 反映
+している。`tests/idea_mining/test_critic.py` の snapshot テストで contract 化
+されているため、editor / formatter で改変しないこと (特に RUBRIC 行は逐語
+比較される)。
+
+`.format(profile_block=...)` を通すため、出力 JSON の説明に含まれる literal
+中括弧 `{`, `}` はすべて `{{`, `}}` でエスケープしている。`[...]` は中括弧
+ではないためエスケープ不要。
+"""
+from __future__ import annotations
+
+from typing import Final
+
+SYSTEM_PROMPT_TEMPLATE: Final[str] = """You are an adversarial product critic for indie developer ideas.
+
+{profile_block}
+
+INPUT: A single candidate (idea / pain / claimed_moat / etc).
+OUTPUT JSON: {{"verdict": "GO|PENDING|KILL", "five_forces": {{...}}, "pestle": {{...}}, "kill_flags": [...], "llm_moat_conditions": [...], "killer_scenarios": [...], "cited_competitors": [...], "kill_reasons": [...]}}
+
+RUBRIC:
+- 5 Forces: 業界構造 (新規参入 / 代替品 / 供給者 / 買い手 / 競合) を評価
+- PESTLE: 政治 / 経済 / 社会 / 技術 / 法 / 環境
+- Pre-Build KILL: 既存 SaaS で 30 分以内に置換できるなら KILL
+- LLM-Moat 7-cond: (1) 専有データ (2) ワークフロー深さ (3) ネットワーク効果 (4) 統合密度 (5) コンプライアンス (6) 製造/物流 (7) ブランド/コミュニティ — 2 つ以上満たさないなら PENDING、いずれも満たさないなら KILL
+- Killer Scenarios: 3 ヶ月以内に競合大手がこの機能を出した場合の生存率
+"""

--- a/idea_mining/prompts/extractor.py
+++ b/idea_mining/prompts/extractor.py
@@ -1,0 +1,52 @@
+"""System prompt for the idea-mining extractor (voices → patterns).
+
+`SYSTEM_PROMPT` は逐語スナップショットテスト (tests/idea_mining/
+test_extractor.py::test_system_prompt_snapshot) で contract 化されている。
+うっかり editor / formatter で改変しないこと。
+"""
+from __future__ import annotations
+
+from typing import Final
+
+SYSTEM_PROMPT: Final[str] = """あなたは Hibi のアイデアマイニング担当のアナリストです。
+
+与えられる入力は、過去 7 日に集めた個人開発者向けプロダクトに対する ★1-4 のユーザーレビュー (`voices`) のリストです。
+各 voice には id (UUID)、source (e.g. 'apple_rss')、posted_at、title、body、rating が含まれます。
+
+あなたのタスクは、これらの voice を「構造的なペイン (pain)」単位でクラスタリングし、JSON のみで返すことです。
+
+クラスタリングの方針:
+- pain は「あるプロダクト名固有の不満」ではなく、「個人開発者が複数のプロダクトで繰り返し直面しうる構造」として抽出する。
+- 同じ構造のペインは違うプロダクト・違う表現でも 1 つの pain にまとめる。
+- 表面的なバグ報告 (e.g. 「クラッシュした」「起動しない」) は構造的ペインではないため除外する。
+- 機能要望そのもの (e.g. 「ダークモードが欲しい」) は構造的ペインではないため除外する。
+
+出力スキーマ (JSON のみ。前後に余計な文字・コードブロックを入れない):
+{
+  "patterns": [
+    {
+      "pain": "短く具体的な日本語ラベル。プロダクト名は入れない。",
+      "categories": ["topical-tag-1", "topical-tag-2"],
+      "frequency": 5,
+      "source_diversity": 2,
+      "representative_voices": ["<voice-uuid-1>", "<voice-uuid-2>", "<voice-uuid-3>"],
+      "confidence": 0.8
+    }
+  ]
+}
+
+各フィールドの意味:
+- pain: その構造的ペインの短文ラベル (日本語)。固有名詞を入れない。
+- categories: pain を分類する topical タグの配列。0 件可。
+- frequency: その pain にまとめた voice の総数 (整数)。
+- source_diversity: その pain にまとめた voice の distinct な source 数 (整数)。
+- representative_voices: その pain を代表する voice の id (UUID) の配列。最大 5 件まで。入力に存在する id のみ使う。
+- confidence: 0.0-1.0 の浮動小数。クラスタの確からしさ。
+
+ルール:
+- frequency が 3 未満になる pain は patterns に含めない (出力から除外する)。
+- source_diversity が 2 未満 (= 1 source のみ) の pain は confidence を 0.5 以下に抑える。
+- 入力 voice が 0 件、あるいは抽出に値する構造的ペインが無い場合は {"patterns": []} を返す。
+- representative_voices の UUID は入力に実在するものから選ぶ。新たに生成しない。
+- JSON 以外の文字 (前置き、後置き、コードフェンス) を絶対に出力しない。
+"""

--- a/idea_mining/prompts/ideator.py
+++ b/idea_mining/prompts/ideator.py
@@ -1,0 +1,62 @@
+"""System prompt template for the Ideator (patterns → candidates via Opus).
+
+`SYSTEM_PROMPT_TEMPLATE` は `{profile_block}` を 1 つだけ含む。
+`profile_loader.load()` (= `prompts._profile_block.profile_block()`) の戻り値を
+そのまま貼り付ける前提。逐語スナップショットテスト
+(`tests/idea_mining/test_ideator_prompt.py::test_system_prompt_template_snapshot`)
+で contract 化されているため、editor / formatter で改変しないこと。
+
+Issue #138 prompt 原案 (Why / What / Acceptance) を逐語反映し、出力 JSON 形式と
+許容値 (monetization / llm_moat_conditions) を明示している。
+"""
+from __future__ import annotations
+
+from typing import Final
+
+SYSTEM_PROMPT_TEMPLATE: Final[str] = """You are a B-Mode ideation partner for an A-type indie developer.
+
+{profile_block}
+
+For the input pattern (single pain statement), generate 5-10 candidates that:
+1. Address the pain described in the pattern.
+2. Satisfy ALL items in user-constraints (above).
+3. AVOID ALL patterns in negative-examples (above), including close variations.
+4. Have at least 2 LLM Moat conditions from this fixed set:
+   workflow / data / distribution / trust / network / physical / regulatory.
+
+For each candidate, provide:
+- name: short product name (no generic 'AI-powered X' phrasing).
+- one_liner: concrete value proposition.
+- target_user: specific persona (no 'everyone' / 'all developers').
+- monetization: exactly one of subscription / one-time / affiliate / freemium / b2b.
+- llm_moat_conditions: list of >= 2 values from the allowed set above.
+- why_different: how this differs from the negative-examples block.
+- estimated_mvp_hours: integer.
+- killer_use_case: one concrete scenario in 1-2 sentences.
+
+THINK BROADLY:
+- Physical / regulatory / network-effect angles.
+- Niche communities, regional plays, B2B micro-segments.
+- Buy-vs-build (consider acquiring an existing micro-SaaS).
+
+CONSTRAINTS:
+- Do not produce LLM-thin-wrapper ideas.
+- Be specific (no generic 'AI-powered X').
+- If only 3 valid candidates exist, output 3 with a short explanation in why_different.
+
+Output schema (JSON ONLY. No code fences, no prose, no trailing commentary):
+{{
+  "candidates": [
+    {{
+      "name": "...",
+      "one_liner": "...",
+      "target_user": "...",
+      "monetization": "subscription",
+      "llm_moat_conditions": ["workflow", "data"],
+      "why_different": "...",
+      "estimated_mvp_hours": 40,
+      "killer_use_case": "..."
+    }}
+  ]
+}}
+"""

--- a/manager/git_ops.py
+++ b/manager/git_ops.py
@@ -14,7 +14,13 @@ class GitOpsError(Exception):
 
 class GitOps(Protocol):
     def create_epic_branch(self, epic_issue: int, slug: str) -> str: ...
-    def create_child_branch(self, epic_branch: str, child_issue: int) -> str: ...
+    def create_child_branch(
+        self,
+        epic_branch: str,
+        child_issue: int,
+        base_branch: str | None = None,
+    ) -> str: ...
+    def branch_exists(self, branch: str) -> bool: ...
     def diff_lines(self, base_branch: str) -> int: ...
     def find_pr_url(self, head_branch: str, base_branch: str) -> str | None: ...
     def retarget_pr(self, pr_url: str, new_base: str) -> bool: ...
@@ -57,11 +63,24 @@ class DummyGitOps:
         self.epic_branches[epic_issue] = branch
         return branch
 
-    def create_child_branch(self, epic_branch: str, child_issue: int) -> str:
+    def create_child_branch(
+        self,
+        epic_branch: str,
+        child_issue: int,
+        base_branch: str | None = None,
+    ) -> str:
         self._maybe_fail("create_child_branch")
         branch = child_branch_name(epic_branch, child_issue)
         self.child_branches[child_issue] = branch
+        # Record the base used so tests can assert stacked-branch behavior.
+        self.last_child_base = base_branch if base_branch else epic_branch
         return branch
+
+    last_child_base: str | None = None
+    existing_branches: set[str] = field(default_factory=set)
+
+    def branch_exists(self, branch: str) -> bool:
+        return branch in self.existing_branches
 
     def diff_lines(self, base_branch: str) -> int:
         return self.diff_lines_value
@@ -180,15 +199,35 @@ class RealGitOps:
             self._git("checkout", "-b", branch, f"origin/{self.base_branch}")
         return branch
 
-    def create_child_branch(self, epic_branch: str, child_issue: int) -> str:
+    def create_child_branch(
+        self,
+        epic_branch: str,
+        child_issue: int,
+        base_branch: str | None = None,
+    ) -> str:
+        """Create or check out the child branch.
+
+        `base_branch` lets the caller override what we branch from. Stacked
+        design: the runner passes the previous done child's branch so each
+        child builds on the prior, instead of always restarting from the
+        epic tip. None falls back to `epic_branch` (initial child or when
+        the previous child's branch was already merged + deleted).
+        """
         branch = child_branch_name(epic_branch, child_issue)
+        base = base_branch if base_branch else epic_branch
         existing = self._git("rev-parse", "--verify", "--quiet", branch, allow_fail=True)
         if existing.exit_code == 0:
             self._git("checkout", branch)
         else:
-            self._git("checkout", epic_branch)
+            self._git("checkout", base)
             self._git("checkout", "-b", branch)
         return branch
+
+    def branch_exists(self, branch: str) -> bool:
+        return (
+            self._git("rev-parse", "--verify", "--quiet", branch, allow_fail=True).exit_code
+            == 0
+        )
 
     def diff_lines(self, base_branch: str) -> int:
         result = self._git(

--- a/manager/parsers/dev_loop.py
+++ b/manager/parsers/dev_loop.py
@@ -7,7 +7,7 @@ from . import ParseError
 from ..types import ReviewVerdict
 
 _VERDICT_RE = re.compile(
-    r"#\s*(?:Review\s+)?Verdict\s*\n+\s*-?\s*`?(safe to merge|fix before merge|confirm before merge)`?\b",
+    r"#\s*(?:Review\s+)?Verdict\s*\n+\s*-?\s*\*{0,2}`?(safe to merge|fix before merge|confirm before merge)`?\*{0,2}\b",
     re.IGNORECASE,
 )
 _PYTEST_RE = re.compile(

--- a/manager/parsers/packet.py
+++ b/manager/parsers/packet.py
@@ -22,8 +22,10 @@ _REQUIRED_KEYS: tuple[str, ...] = (
 )
 
 _FENCE_RE = re.compile(r"```(?:yaml|yml)?\s*\n(.*?)```", re.DOTALL | re.IGNORECASE)
-_LIST_ITEM_RE = re.compile(r"^(\s*-\s+)([^'\"\s].*?)\s*$")
-_YAML_SIGNIFICANT = re.compile(r"(?<!\w):\s|[\[\]`{}#&*!|>%@,]")
+# Match any non-empty `- foo` list item (no restriction on starting char).
+# The fallback path only runs when the initial parse already failed, so we
+# can quote aggressively without worrying about over-quoting valid YAML.
+_LIST_ITEM_RE = re.compile(r"^(\s*-\s+)(.+?)\s*$")
 
 
 def _extract_yaml_block(raw: str) -> str:
@@ -34,18 +36,19 @@ def _extract_yaml_block(raw: str) -> str:
 
 
 def _quote_unsafe_list_items(text: str) -> str:
-    r"""Defensive preprocessor: wrap `- foo` items in single quotes when `foo`
-    contains YAML-significant characters (`: `, `[`, `]`, `\``, etc.).
+    r"""Defensive preprocessor: wrap every `- foo` item in single quotes.
 
     /make-execution-packet outputs free-form Japanese acceptance_criteria that
-    routinely embed `[jp]` / `country: [jp]` / backticked code refs. Plain
-    unquoted scalars then break safe_load. The packet schema only uses lists
-    of strings (not lists of mappings), so quoting list items is safe.
+    routinely embed `[jp]` / `country: [jp]` / backticked code refs / mid-line
+    `"quoted phrases"` continued with more text. Each of these breaks
+    safe_load. The packet schema only uses lists of strings (not lists of
+    mappings), so blanket-quoting list items is safe and covers all
+    YAML-significant-character failure modes in one pass.
     """
     out: list[str] = []
     for line in text.split("\n"):
         m = _LIST_ITEM_RE.match(line)
-        if m and _YAML_SIGNIFICANT.search(m.group(2)):
+        if m:
             content = m.group(2).replace("'", "''")
             out.append(f"{m.group(1)}'{content}'")
         else:

--- a/manager/parsers/packet.py
+++ b/manager/parsers/packet.py
@@ -26,6 +26,15 @@ _FENCE_RE = re.compile(r"```(?:yaml|yml)?\s*\n(.*?)```", re.DOTALL | re.IGNORECA
 # The fallback path only runs when the initial parse already failed, so we
 # can quote aggressively without worrying about over-quoting valid YAML.
 _LIST_ITEM_RE = re.compile(r"^(\s*-\s+)(.+?)\s*$")
+# Top-level scalar string keys (excluding issue_id which is int) — used by
+# fallback to quote inline values that contain YAML-significant chars like
+# `title: feat(idea-mining): Critic` (double colon trips safe_load).
+_TOP_LEVEL_STRING_KEYS: tuple[str, ...] = (
+    "title", "classification", "scope", "goal",
+)
+_TOP_LEVEL_KV_RE = re.compile(
+    r"^(" + "|".join(_TOP_LEVEL_STRING_KEYS) + r"):\s+(.+?)\s*$"
+)
 
 
 def _extract_yaml_block(raw: str) -> str:
@@ -35,24 +44,33 @@ def _extract_yaml_block(raw: str) -> str:
     return raw
 
 
-def _quote_unsafe_list_items(text: str) -> str:
-    r"""Defensive preprocessor: wrap every `- foo` item in single quotes.
+def _quote_unsafe_yaml(text: str) -> str:
+    r"""Defensive preprocessor: wrap list items AND top-level string fields
+    (title / classification / scope / goal) in single quotes.
 
-    /make-execution-packet outputs free-form Japanese acceptance_criteria that
-    routinely embed `[jp]` / `country: [jp]` / backticked code refs / mid-line
-    `"quoted phrases"` continued with more text. Each of these breaks
-    safe_load. The packet schema only uses lists of strings (not lists of
-    mappings), so blanket-quoting list items is safe and covers all
-    YAML-significant-character failure modes in one pass.
+    Failure modes seen in production:
+    - acceptance_criteria 配下の `- country: [jp]` / `- "wrapper" 型...`
+      (list item の中の `: ` / `[...]` / 中途半端な double quote)
+    - top-level `title: feat(idea-mining): Critic ...` (conventional commit
+      prefix の `:` が二重 colon になり mapping 解釈で爆発)
+
+    packet schema は list of strings + top-level scalars (string + int) のみ。
+    list of mappings は無いので blanket quoting で安全。issue_id だけは
+    int として残したいので _TOP_LEVEL_STRING_KEYS から除外。
     """
     out: list[str] = []
     for line in text.split("\n"):
-        m = _LIST_ITEM_RE.match(line)
-        if m:
-            content = m.group(2).replace("'", "''")
-            out.append(f"{m.group(1)}'{content}'")
-        else:
-            out.append(line)
+        m_list = _LIST_ITEM_RE.match(line)
+        if m_list:
+            content = m_list.group(2).replace("'", "''")
+            out.append(f"{m_list.group(1)}'{content}'")
+            continue
+        m_kv = _TOP_LEVEL_KV_RE.match(line)
+        if m_kv:
+            value = m_kv.group(2).replace("'", "''")
+            out.append(f"{m_kv.group(1)}: '{value}'")
+            continue
+        out.append(line)
     return "\n".join(out)
 
 
@@ -62,7 +80,7 @@ def parse_packet(raw: str) -> dict[str, Any]:
         loaded = yaml.safe_load(text)
     except yaml.YAMLError:
         try:
-            loaded = yaml.safe_load(_quote_unsafe_list_items(text))
+            loaded = yaml.safe_load(_quote_unsafe_yaml(text))
         except yaml.YAMLError as exc:
             raise ParseError(f"YAML 解析失敗: {exc}") from exc
     if not isinstance(loaded, dict):

--- a/manager/parsers/packet.py
+++ b/manager/parsers/packet.py
@@ -22,6 +22,8 @@ _REQUIRED_KEYS: tuple[str, ...] = (
 )
 
 _FENCE_RE = re.compile(r"```(?:yaml|yml)?\s*\n(.*?)```", re.DOTALL | re.IGNORECASE)
+_LIST_ITEM_RE = re.compile(r"^(\s*-\s+)([^'\"\s].*?)\s*$")
+_YAML_SIGNIFICANT = re.compile(r"(?<!\w):\s|[\[\]`{}#&*!|>%@,]")
 
 
 def _extract_yaml_block(raw: str) -> str:
@@ -31,12 +33,35 @@ def _extract_yaml_block(raw: str) -> str:
     return raw
 
 
+def _quote_unsafe_list_items(text: str) -> str:
+    r"""Defensive preprocessor: wrap `- foo` items in single quotes when `foo`
+    contains YAML-significant characters (`: `, `[`, `]`, `\``, etc.).
+
+    /make-execution-packet outputs free-form Japanese acceptance_criteria that
+    routinely embed `[jp]` / `country: [jp]` / backticked code refs. Plain
+    unquoted scalars then break safe_load. The packet schema only uses lists
+    of strings (not lists of mappings), so quoting list items is safe.
+    """
+    out: list[str] = []
+    for line in text.split("\n"):
+        m = _LIST_ITEM_RE.match(line)
+        if m and _YAML_SIGNIFICANT.search(m.group(2)):
+            content = m.group(2).replace("'", "''")
+            out.append(f"{m.group(1)}'{content}'")
+        else:
+            out.append(line)
+    return "\n".join(out)
+
+
 def parse_packet(raw: str) -> dict[str, Any]:
     text = _extract_yaml_block(raw)
     try:
         loaded = yaml.safe_load(text)
-    except yaml.YAMLError as exc:
-        raise ParseError(f"YAML 解析失敗: {exc}") from exc
+    except yaml.YAMLError:
+        try:
+            loaded = yaml.safe_load(_quote_unsafe_list_items(text))
+        except yaml.YAMLError as exc:
+            raise ParseError(f"YAML 解析失敗: {exc}") from exc
     if not isinstance(loaded, dict):
         raise ParseError("packet が dict ではない")
     missing = [k for k in _REQUIRED_KEYS if k not in loaded]

--- a/manager/runner.py
+++ b/manager/runner.py
@@ -465,6 +465,12 @@ def _handle_implement(runner: Runner, epic: EpicState, child: ChildState) -> Non
     runner.state_store.save_child(epic["epic_issue_number"], child)
     if outcome.verdict == "safe to merge":
         runner.transition(epic, child, "VERIFY_PR")
+    elif outcome.verdict == "confirm before merge":
+        runner._log(
+            epic["epic_issue_number"],
+            {"child": child["issue_number"], "event": "verdict_caution_accepted"},
+        )
+        runner.transition(epic, child, "VERIFY_PR")
     elif outcome.verdict == "fix before merge":
         _retry_or_escalate(
             runner, epic, child,

--- a/manager/runner.py
+++ b/manager/runner.py
@@ -20,7 +20,7 @@ from .escalate import (
     render_halted,
     render_needs_human,
 )
-from .git_ops import GitOps, GitOpsError
+from .git_ops import GitOps, GitOpsError, child_branch_name
 from .limits import (
     EXIT_HALTED,
     EXIT_NEEDS_HUMAN,
@@ -163,14 +163,22 @@ class Runner:
             # exists it just checks it out.
             if child["status"] not in TERMINAL_STATES:
                 try:
-                    self.git_ops.create_child_branch(epic["epic_branch"], child_issue)
+                    self.git_ops.create_child_branch(
+                        epic["epic_branch"],
+                        child_issue,
+                        base_branch=self._previous_child_base(epic),
+                    )
                 except GitOpsError as exc:
                     child["needs_human_reason"] = f"resume checkout failed: {exc}"
                     self.transition(epic, child, "NEEDS_HUMAN")
                     return "NEEDS_HUMAN"
         else:
             try:
-                branch = self.git_ops.create_child_branch(epic["epic_branch"], child_issue)
+                branch = self.git_ops.create_child_branch(
+                    epic["epic_branch"],
+                    child_issue,
+                    base_branch=self._previous_child_base(epic),
+                )
             except GitOpsError as exc:
                 child = self.state_store.init_child(epic_n, child_issue, branch="")
                 child["needs_human_reason"] = f"create_child_branch failed: {exc}"
@@ -274,6 +282,18 @@ class Runner:
     def _log(self, epic_issue: int, event: dict[str, object]) -> None:
         self.state_store.append_log(epic_issue, event)
 
+    def _previous_child_base(self, epic: EpicState) -> str | None:
+        """Stacked-branch design: branch the next child off the previous done
+        child's branch so each child sees prior work without waiting for human
+        PR merges. Falls back to the epic branch when the previous child's
+        branch no longer exists locally (already merged + deleted).
+        """
+        done = epic["children_done"]
+        if not done:
+            return None
+        prev_branch = child_branch_name(epic["epic_branch"], done[-1])
+        return prev_branch if self.git_ops.branch_exists(prev_branch) else None
+
     # --------------------------------------------------------- signals
 
     @contextmanager
@@ -376,10 +396,16 @@ def _handle_triage(runner: Runner, epic: EpicState, child: ChildState) -> None:
         return
     if readiness == "ready":
         runner.transition(epic, child, "PACKETIZE")
+    elif readiness == "needs-confirmation":
+        runner._log(
+            epic["epic_issue_number"],
+            {"child": child["issue_number"], "event": "triage_caution_accepted"},
+        )
+        runner.transition(epic, child, "PACKETIZE")
     elif readiness == "do-not-run":
         runner.transition(epic, child, "SKIPPED")
     else:
-        child["needs_human_reason"] = "triage readiness=needs-confirmation"
+        child["needs_human_reason"] = f"triage readiness={readiness}"
         runner.transition(epic, child, "NEEDS_HUMAN")
 
 
@@ -500,17 +526,19 @@ def _handle_verify_pr(runner: Runner, epic: EpicState, child: ChildState) -> Non
         runner.state_store.save_child(epic["epic_issue_number"], child)
         return
     child["pr_url"] = url
-    # /pr-creation hard-codes `--base main`; retarget to the epic branch so the
-    # epic accumulates child PRs as designed. Soft-fail: a failed retarget logs
-    # but doesn't escalate (the PR still exists, just on the wrong base).
-    retargeted = runner.git_ops.retarget_pr(url, epic["epic_branch"])
+    # /pr-creation now resolves base to stacked (prev sibling → epic → main).
+    # We still retarget defensively in case the slash fallback hit main: the
+    # right target is "previous done child branch if alive, else epic". This
+    # keeps PRs chained for the stacked review flow. Soft-fail.
+    desired_base = runner._previous_child_base(epic) or epic["epic_branch"]
+    retargeted = runner.git_ops.retarget_pr(url, desired_base)
     runner._log(
         epic["epic_issue_number"],
         {
             "event": "pr_retarget",
             "child": child["issue_number"],
             "pr_url": url,
-            "new_base": epic["epic_branch"],
+            "new_base": desired_base,
             "ok": retargeted,
         },
     )

--- a/manager/runner.py
+++ b/manager/runner.py
@@ -429,7 +429,12 @@ def _handle_plan(runner: Runner, epic: EpicState, child: ChildState) -> None:
             reason=f"plan parse failed: {exc}",
         )
         return
-    if rec == "proceed":
+    if rec in ("proceed", "proceed with caution"):
+        if rec == "proceed with caution":
+            runner._log(
+                epic["epic_issue_number"],
+                {"child": child["issue_number"], "event": "plan_caution_accepted"},
+            )
         runner.transition(epic, child, "IMPLEMENT")
     else:
         child["needs_human_reason"] = f"plan recommendation={rec}"

--- a/manager/runner.py
+++ b/manager/runner.py
@@ -211,7 +211,12 @@ class Runner:
         cost = cost_check(epic["cost_usd"])
         if cost.tripped:
             raise _StopEpic(cost.reason)
-        diff = diff_check(self.git_ops.diff_lines(epic["epic_branch"]))
+        # Stacked design: measure THIS child's diff against its immediate base
+        # (previous done child's branch if alive, else epic). Measuring against
+        # epic accumulates prior siblings' commits and trips the cap on day 1
+        # for every child after the first.
+        diff_base = self._previous_child_base(epic) or epic["epic_branch"]
+        diff = diff_check(self.git_ops.diff_lines(diff_base))
         if diff.tripped:
             child["needs_human_reason"] = diff.reason
             self.transition(epic, child, "NEEDS_HUMAN")

--- a/manager/runner.py
+++ b/manager/runner.py
@@ -460,12 +460,24 @@ def _handle_plan(runner: Runner, epic: EpicState, child: ChildState) -> None:
             reason=f"plan parse failed: {exc}",
         )
         return
-    if rec in ("proceed", "proceed with caution"):
-        if rec == "proceed with caution":
-            runner._log(
-                epic["epic_issue_number"],
-                {"child": child["issue_number"], "event": "plan_caution_accepted"},
-            )
+    if rec == "proceed":
+        runner.transition(epic, child, "IMPLEMENT")
+    elif rec == "proceed with caution":
+        runner._log(
+            epic["epic_issue_number"],
+            {"child": child["issue_number"], "event": "plan_caution_accepted"},
+        )
+        runner.transition(epic, child, "IMPLEMENT")
+    elif rec == "confirm first":
+        # `/spec-architect` の最強 halt 信号だが、PR review が最終 safety net で
+        # あり、agent が round を重ねるごとに新たな question を生成する pattern
+        # (#139 で 3 round / $2+ 消費) を構造的に解決するため IMPLEMENT に流す。
+        # fix before merge は引き続き retry 経路を持つので大規模仕様ずれは
+        # IMPLEMENT 段階で吸収される。
+        runner._log(
+            epic["epic_issue_number"],
+            {"child": child["issue_number"], "event": "plan_confirm_first_accepted"},
+        )
         runner.transition(epic, child, "IMPLEMENT")
     else:
         child["needs_human_reason"] = f"plan recommendation={rec}"

--- a/manager/runner.py
+++ b/manager/runner.py
@@ -531,11 +531,12 @@ def _handle_verify_pr(runner: Runner, epic: EpicState, child: ChildState) -> Non
         runner.state_store.save_child(epic["epic_issue_number"], child)
         return
     child["pr_url"] = url
-    # /pr-creation now resolves base to stacked (prev sibling → epic → main).
-    # We still retarget defensively in case the slash fallback hit main: the
-    # right target is "previous done child branch if alive, else epic". This
-    # keeps PRs chained for the stacked review flow. Soft-fail.
-    desired_base = runner._previous_child_base(epic) or epic["epic_branch"]
+    # Flat-PR design: PR base is always the epic branch (never a sibling
+    # child). Branches remain stacked (each child branches off the previous
+    # one) so each child can see prior work, but the PR merge target is flat
+    # for GitHub-native review ergonomics. Retarget defensively in case the
+    # slash fallback hit main. Soft-fail.
+    desired_base = epic["epic_branch"]
     retargeted = runner.git_ops.retarget_pr(url, desired_base)
     runner._log(
         epic["epic_issue_number"],

--- a/migrations/008_voices.sql
+++ b/migrations/008_voices.sql
@@ -1,0 +1,60 @@
+-- ================================================================
+-- voices table (Issue #136, child of epic #134 — idea mining)
+--
+-- 製品レビューやユーザーの声 (UGC) を idea-mining 用に蓄積する
+-- private テーブル。newspaper pipeline (`articles` / `is_sent` /
+-- ranking / embedding) からは独立しており、daily newsletter / web
+-- archive にも露出しない。
+--
+-- 初期 fetcher は Apple iTunes RSS (`idea_mining/fetchers/apple_rss.py`)
+-- で、★1-4 のレビューのみを source='apple_rss' として insert する。
+-- ★5 は INSERT 前にコード側で除外する (rating は meta JSONB に保持)。
+--
+-- ## カラム
+--
+--   * id          — UUID PK
+--   * source      — fetcher 名 (e.g. 'apple_rss')。将来 Reddit / HN を
+--                   追加するときは別 source 値で並列に積む。
+--   * source_id   — fetcher 内で一意な ID (Apple RSS の review id)。
+--   * posted_at   — レビュー投稿日時 (Apple feed の `updated`)。
+--   * title       — レビュータイトル (Apple feed の `title`)。
+--   * body        — レビュー本文 (Apple feed の `content`)。
+--   * meta        — JSONB: { version, author, country, lang, rating, ... }。
+--                   スキーマは fetcher ごとに緩く、追加フィールドは将来
+--                   ALTER 無しで足せる。
+--   * created_at  — 取り込み時刻。
+--
+-- ## 制約
+--
+--   * UNIQUE (source, source_id) — 再実行で同一レビューが重複しない
+--     ように。INSERT 側は ON CONFLICT (source, source_id) DO NOTHING で
+--     冪等にする。
+--   * idx_voices_source_posted — 「最近のレビュー」クエリ用。
+--
+-- ## 非対応
+--
+--   * daily newsletter / archive への露出 (private のまま)
+--   * embedding / pgvector 適用 (Issue #136 では out-of-scope)
+--   * 評価 UI / 削除 UI
+--   * `clicks.user_id` 連携 (1 人運用前提)
+--
+-- 2 回流しても壊れないよう全部 idempotent (IF NOT EXISTS)。
+-- 手動 apply: Neon SQL Editor で実行する。
+-- ================================================================
+
+CREATE TABLE IF NOT EXISTS voices (
+    id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    source      text        NOT NULL,
+    source_id   text        NOT NULL,
+    posted_at   timestamptz NOT NULL,
+    title       text,
+    body        text,
+    meta        jsonb       NOT NULL DEFAULT '{}'::jsonb,
+    created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS voices_source_source_id_uidx
+    ON voices (source, source_id);
+
+CREATE INDEX IF NOT EXISTS idx_voices_source_posted
+    ON voices (source, posted_at DESC);

--- a/migrations/009_patterns.sql
+++ b/migrations/009_patterns.sql
@@ -1,0 +1,72 @@
+-- ================================================================
+-- patterns table (Issue #134 child — idea mining extractor)
+--
+-- 直近 7 日の `voices` (Apple iTunes ★1-4 customer reviews 等) を
+-- Haiku でクラスタリングし、頻度 3+ の構造的ペインを週次で蓄積する
+-- private テーブル。`extractor` (`idea_mining/extractor.py`) が
+-- 火 / 木 / 土 03:00 UTC の cron で書き込む。
+--
+-- newspaper pipeline (`articles` / ranking / embedding / mailer /
+-- archive) からは独立しており、daily newsletter / web archive にも
+-- 露出しない (private のまま)。
+--
+-- ## カラム
+--
+--   * id                    — UUID PK
+--   * week_iso              — `YYYY-Www` 形式の ISO week (e.g. '2026-W21')。
+--                             extractor 実行時 UTC の
+--                             `datetime.now(timezone.utc).isocalendar()` から生成。
+--   * pain                  — pain の短文ラベル (Haiku が抽出)。
+--   * categories            — pain の topical タグ群 (TEXT[])。
+--   * frequency             — 同種 voice の出現回数 (Haiku がクラスタ集計)。
+--                             frequency < 3 の pain は INSERT 前に extractor 側で
+--                             捨てるため、ここに 1-2 の行は来ない。
+--   * source_diversity      — distinct `voices.source` 数。
+--                             < 2 のとき confidence が <= 0.5 に clamp される。
+--   * representative_voices — UUID[]、pain を代表する `voices.id` の参照。
+--                             FK 制約は張らない (voices は append-only で
+--                             削除しない前提)。
+--   * confidence            — REAL 0..1。source_diversity < 2 で <= 0.5 clamp。
+--   * meta                  — JSONB: { model, raw_response_snippet, ... }。
+--                             extractor が将来追加メタを足せるよう緩く。
+--   * created_at            — 最初に INSERT された時刻。
+--   * updated_at            — ON CONFLICT DO UPDATE で refresh される時刻。
+--
+-- ## 制約
+--
+--   * UNIQUE (week_iso, pain) — 同 (週, pain) で複数 row が出ないように。
+--     extractor 側は `ON CONFLICT (week_iso, pain) DO UPDATE` で
+--     frequency / source_diversity / representative_voices / confidence /
+--     categories / meta / updated_at を refresh する。
+--   * idx_patterns_week — 「特定週の全 pain」クエリ用。
+--
+-- ## 非対応 (out-of-scope)
+--
+--   * 古い week_iso の archive / truncate (歴史記録として残す)
+--   * daily newsletter / archive への露出
+--   * pgvector / embedding
+--   * 評価 UI / multi-tenant 化
+--
+-- 2 回流しても壊れないよう全部 idempotent (IF NOT EXISTS)。
+-- 手動 apply: Neon SQL Editor で実行する。
+-- ================================================================
+
+CREATE TABLE IF NOT EXISTS patterns (
+    id                    uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    week_iso              text        NOT NULL,
+    pain                  text        NOT NULL,
+    categories            text[]      NOT NULL DEFAULT ARRAY[]::text[],
+    frequency             integer     NOT NULL,
+    source_diversity      integer     NOT NULL,
+    representative_voices uuid[]      NOT NULL DEFAULT ARRAY[]::uuid[],
+    confidence            real        NOT NULL,
+    meta                  jsonb       NOT NULL DEFAULT '{}'::jsonb,
+    created_at            timestamptz NOT NULL DEFAULT now(),
+    updated_at            timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS patterns_week_iso_pain_uidx
+    ON patterns (week_iso, pain);
+
+CREATE INDEX IF NOT EXISTS idx_patterns_week
+    ON patterns (week_iso);

--- a/migrations/010_create_candidates.sql
+++ b/migrations/010_create_candidates.sql
@@ -1,0 +1,90 @@
+-- ================================================================
+-- candidates table (Issue #138 — B-Mode Ideator output)
+--
+-- `idea_mining/ideator.py` が patterns 1 件あたり 5-10 件のアイデア
+-- 候補を Anthropic Opus (`claude-opus-4-7`) で生成し、本テーブルへ
+-- INSERT する。profile/user-constraints + profile/negative-examples
+-- を system prompt の先頭に注入する前提で、結果はバリデーション
+-- (monetization enum / llm_moat_conditions enum / negative-example
+-- キーワードフィルタ) を通過したものだけが本テーブルに入る。
+--
+-- newspaper pipeline (`articles` / ranking / embedding / mailer /
+-- archive) には露出しない private テーブル。
+--
+-- ## カラム
+--
+--   * id                  — BIGSERIAL PK
+--   * spot_id             — Phase 0 では nullable で null 固定。
+--                           将来 `spots` テーブル導入時に FK 化する余地のみ残す。
+--   * pattern_id          — patterns.id (uuid) への FK。NOT NULL。
+--                           Issue 提示 DDL は BIGINT だったが、現行
+--                           patterns.id は uuid のため uuid に揃える。
+--   * name                — 候補プロダクト名。NOT NULL。
+--   * one_liner           — 価値提案 1 行。
+--   * target_user         — 具体ペルソナ。
+--   * monetization        — subscription / one-time / affiliate / freemium / b2b
+--                           CHECK 制約で値域固定。
+--   * llm_moat_conditions — workflow / data / distribution / trust / network
+--                           / physical / regulatory の text[] (≥1)。
+--                           値域は Python 側でも再検証する (DB レベルでは
+--                           array 要素 CHECK が組みづらいため設計上は
+--                           Python が真の gate)。
+--   * why_different       — negative-examples との差分説明。
+--   * estimated_mvp_hours — MVP 工数 (integer, nullable)。
+--   * killer_use_case     — 想定キラーユースケース。
+--   * generated_at        — Ideator が候補を出した時刻 (DEFAULT now())。
+--   * critic_verdict      — Issue #139 (Critic Agent) が後段で書き込む
+--                           GO / PENDING / KILL。本 Issue では NULL のまま。
+--   * critic_meta         — Critic の 5F / PESTLE / KILL flags の JSONB。
+--                           本 Issue では NULL のまま。
+--
+-- ## 非対応 (out-of-scope; 本 Issue 範囲外)
+--
+--   * spot_id への FK 制約 (spots テーブル未導入のため bigint NULL のみ)
+--   * critic_verdict / critic_meta への書き込み (Issue #139)
+--   * candidates の dedupe / UNIQUE 制約
+--   * pgvector / embedding
+--   * UI / dashboard 露出
+--
+-- 2 回流しても壊れないよう全部 idempotent (IF NOT EXISTS / DROP
+-- CONSTRAINT IF EXISTS)。手動 apply: Neon SQL Editor で実行する。
+-- ================================================================
+
+CREATE TABLE IF NOT EXISTS candidates (
+    id                    bigserial   PRIMARY KEY,
+    spot_id               bigint,
+    pattern_id            uuid        NOT NULL REFERENCES patterns(id),
+    name                  text        NOT NULL,
+    one_liner             text,
+    target_user           text,
+    monetization          text,
+    llm_moat_conditions   text[]      NOT NULL DEFAULT ARRAY[]::text[],
+    why_different         text,
+    estimated_mvp_hours   integer,
+    killer_use_case       text,
+    generated_at          timestamptz NOT NULL DEFAULT now(),
+    critic_verdict        text,
+    critic_meta           jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_candidates_pattern_id
+    ON candidates (pattern_id);
+
+CREATE INDEX IF NOT EXISTS idx_candidates_generated_at
+    ON candidates (generated_at DESC);
+
+ALTER TABLE candidates
+    DROP CONSTRAINT IF EXISTS candidates_monetization_chk;
+ALTER TABLE candidates
+    ADD CONSTRAINT candidates_monetization_chk
+    CHECK (monetization IS NULL OR monetization IN (
+        'subscription', 'one-time', 'affiliate', 'freemium', 'b2b'
+    ));
+
+ALTER TABLE candidates
+    DROP CONSTRAINT IF EXISTS candidates_critic_verdict_chk;
+ALTER TABLE candidates
+    ADD CONSTRAINT candidates_critic_verdict_chk
+    CHECK (critic_verdict IS NULL OR critic_verdict IN (
+        'GO', 'PENDING', 'KILL'
+    ));

--- a/sources.yaml
+++ b/sources.yaml
@@ -239,3 +239,34 @@ sources:
     feed_url: https://hnrss.org/frontpage
     why: テック業界のリアルタイム話題集約。
     url: https://news.ycombinator.com
+
+# ============================================================
+# apple_apps — Apple iTunes RSS (★1-4 customer reviews → voices)
+#
+# idea-mining 用の private シグナル源。`daily_news.py` / newsletter /
+# web archive とは無関係で、`voices` テーブルにのみ書き込む。
+#
+# Issue #136 では country MVP として jp のみ運用。us/gb の追加は
+# 別 issue で判断 (out-of-scope)。
+#
+# fetcher: idea_mining/fetchers/apple_rss.py
+# workflow: .github/workflows/idea-mining-weekly.yml (毎週月 14:00 UTC)
+# ============================================================
+apple_apps:
+  - name: Notion
+    app_id: "1232780281"
+    country: [jp]
+    enabled: true
+    why: 個人の生産性ツール市場での pain point 観測 (knowledge mgmt + AI 機能)。
+
+  - name: Obsidian
+    app_id: "1557175442"
+    country: [jp]
+    enabled: true
+    why: ローカル / Markdown / plugin 系の note-taking pain point 観測。
+
+  - name: MoneyForward
+    app_id: "459683577"
+    country: [jp]
+    enabled: true
+    why: 日本市場の家計簿 / マネー系 SaaS の継続課金 / UI pain 観測。

--- a/tests/idea_mining/_digest_fakes.py
+++ b/tests/idea_mining/_digest_fakes.py
@@ -1,0 +1,139 @@
+"""Shared in-memory psycopg-shaped fakes for idea_mining digest tests.
+
+`tests/idea_mining/test_critic.py` のスタイルを踏襲し、Neon の代わりに
+``patterns`` / ``candidates`` テーブルを 2 つの list で表す軽量 fake を
+公開する。pytest-postgres は導入しない (test-agent.md: 既存 fixture に
+合わせる)。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class PatternRow:
+    id: str
+    week_iso: str
+    pain: str
+    categories: list[str]
+    frequency: int
+    source_diversity: int
+    confidence: float
+
+
+@dataclass
+class CandidateRow:
+    id: int
+    pattern_id: str
+    name: str
+    critic_verdict: str | None
+    one_liner: str | None = None
+    target_user: str | None = None
+    monetization: str | None = None
+    why_different: str | None = None
+    killer_use_case: str | None = None
+    critic_meta: dict[str, object] | None = None
+    generated_at_rank: int = 0  # 大きいほど新しい (ORDER BY 用)
+
+
+@dataclass
+class _FakeStore:
+    patterns: list[PatternRow] = field(default_factory=list)
+    candidates: list[CandidateRow] = field(default_factory=list)
+
+
+class _FakeCursor:
+    def __init__(self, store: _FakeStore) -> None:
+        self._store = store
+        self._result: list[tuple[object, ...]] = []
+        self.rowcount: int = 0
+
+    def execute(self, sql: str, params: tuple[object, ...] | None = None) -> None:
+        normalized = " ".join(sql.split()).lower()
+        if "from patterns where week_iso" in normalized:
+            assert params is not None and len(params) == 2
+            week_iso, limit = params
+            assert isinstance(week_iso, str)
+            assert isinstance(limit, int)
+            matched = [p for p in self._store.patterns if p.week_iso == week_iso]
+            # ORDER BY frequency DESC, pain ASC
+            matched.sort(key=lambda p: (-p.frequency, p.pain))
+            trimmed = matched[:limit]
+            self._result = [
+                (
+                    p.id,
+                    p.pain,
+                    list(p.categories),
+                    p.frequency,
+                    p.source_diversity,
+                    p.confidence,
+                )
+                for p in trimmed
+            ]
+            self.rowcount = len(self._result)
+            return
+
+        if (
+            "from candidates where pattern_id" in normalized
+            and "critic_verdict is not null" in normalized
+        ):
+            assert params is not None and len(params) == 1
+            (pattern_id,) = params
+            matched = [
+                c
+                for c in self._store.candidates
+                if c.pattern_id == pattern_id and c.critic_verdict is not None
+            ]
+            # ORDER BY generated_at DESC, id DESC
+            matched.sort(key=lambda c: (-c.generated_at_rank, -c.id))
+            self._result = [
+                (
+                    c.id,
+                    c.name,
+                    c.one_liner,
+                    c.target_user,
+                    c.monetization,
+                    c.why_different,
+                    c.killer_use_case,
+                    c.critic_verdict,
+                    c.critic_meta,
+                )
+                for c in matched
+            ]
+            self.rowcount = len(self._result)
+            return
+
+        raise AssertionError(f"unexpected SQL in fake cursor: {sql!r}")
+
+    def fetchall(self) -> list[tuple[object, ...]]:
+        return list(self._result)
+
+    def fetchone(self) -> tuple[object, ...] | None:
+        return self._result[0] if self._result else None
+
+    def __enter__(self) -> "_FakeCursor":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+class FakeConn:
+    """Minimal psycopg.Connection stand-in for digest unit tests."""
+
+    def __init__(
+        self,
+        *,
+        patterns: list[PatternRow] | None = None,
+        candidates: list[CandidateRow] | None = None,
+    ) -> None:
+        self._store = _FakeStore(
+            patterns=list(patterns or []),
+            candidates=list(candidates or []),
+        )
+
+    def cursor(self) -> _FakeCursor:
+        return _FakeCursor(self._store)
+
+    def commit(self) -> None:
+        return None

--- a/tests/idea_mining/fetchers/test_apple_rss.py
+++ b/tests/idea_mining/fetchers/test_apple_rss.py
@@ -1,0 +1,443 @@
+"""Tests for `idea_mining.fetchers.apple_rss`.
+
+Apple iTunes RSS fetcher の挙動 (★5 除外 / meta JSONB / ON CONFLICT NoOp /
+retry & Sentry alert / sources.yaml パース / migration 008) を最小限の
+スコープで検証する。
+
+外部 HTTP / DB / Sentry は dependency-inject や monkeypatch で全部モック
+する。実 Neon / 実 Apple API は叩かない。
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from idea_mining.fetchers import apple_rss
+from idea_mining.fetchers.apple_rss import (
+    APPLE_RSS_URL_FMT,
+    INSERT_SQL,
+    LANG_BY_COUNTRY,
+    RETRY_DELAYS_SECONDS,
+    SOURCE_NAME,
+    AppleApp,
+    fetch_one,
+    insert_voices,
+    load_apple_apps,
+    parse_review_entries,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+# ----------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------
+
+
+def _entry(rating: str, review_id: str, **overrides: Any) -> dict:
+    base = {
+        "id": {"label": review_id},
+        "title": {"label": f"title-{review_id}"},
+        "content": {"label": f"body-{review_id}"},
+        "im:rating": {"label": rating},
+        "im:version": {"label": "1.2.3"},
+        "author": {"name": {"label": f"user-{review_id}"}},
+        "updated": {"label": "2026-05-19T12:34:56-07:00"},
+    }
+    base.update(overrides)
+    return base
+
+
+def _payload(*entries: dict) -> dict:
+    return {"feed": {"entry": list(entries)}}
+
+
+# ----------------------------------------------------------------------
+# Parser tests
+# ----------------------------------------------------------------------
+
+
+def test_parse_drops_rating_5_and_keeps_1_through_4() -> None:
+    payload = _payload(
+        _entry("1", "r1"),
+        _entry("2", "r2"),
+        _entry("3", "r3"),
+        _entry("4", "r4"),
+        _entry("5", "r5"),  # excluded
+    )
+
+    rows = parse_review_entries(payload, country="jp", app_id="1232780281")
+
+    ratings = sorted(r["meta"]["rating"] for r in rows)
+    assert ratings == [1, 2, 3, 4]
+    assert all(r["source"] == SOURCE_NAME for r in rows)
+    assert "r5" not in {r["source_id"] for r in rows}
+
+
+def test_parse_meta_has_required_fields() -> None:
+    payload = _payload(_entry("2", "r1"))
+
+    [row] = parse_review_entries(payload, country="jp", app_id="1232780281")
+
+    meta = row["meta"]
+    for key in ("version", "author", "country", "lang", "rating"):
+        assert key in meta, f"meta missing required key: {key}"
+    assert meta["version"] == "1.2.3"
+    assert meta["author"] == "user-r1"
+    assert meta["country"] == "jp"
+    assert meta["lang"] == "ja"
+    assert meta["rating"] == 2
+
+
+def test_parse_country_jp_yields_meta_lang_ja() -> None:
+    payload = _payload(_entry("3", "r1"))
+
+    [row] = parse_review_entries(payload, country="jp", app_id="1")
+
+    assert row["meta"]["country"] == "jp"
+    assert row["meta"]["lang"] == "ja"
+
+
+def test_parse_country_us_yields_meta_lang_en() -> None:
+    # `LANG_BY_COUNTRY` で us → en にマップされていることの sanity check.
+    # 運用上は jp のみだが、lookup ロジックの境界として確認。
+    payload = _payload(_entry("3", "r1"))
+
+    [row] = parse_review_entries(payload, country="us", app_id="1")
+
+    assert row["meta"]["lang"] == "en"
+
+
+def test_parse_handles_single_entry_dict() -> None:
+    # Apple feed は entries が 1 件のとき list ではなく dict になるケースがある。
+    payload = {"feed": {"entry": _entry("2", "r1")}}
+
+    rows = parse_review_entries(payload, country="jp", app_id="1")
+
+    assert len(rows) == 1
+    assert rows[0]["source_id"] == "r1"
+
+
+def test_parse_handles_missing_entry_field() -> None:
+    # feed.entry が無い場合 (= レビューゼロ) は空リスト。
+    assert parse_review_entries({"feed": {}}, country="jp", app_id="1") == []
+
+
+def test_parse_skips_entry_without_rating() -> None:
+    # `im:rating` を欠くエントリは app metadata 等として skip する。
+    payload = _payload({"id": {"label": "metadata"}}, _entry("4", "r1"))
+
+    rows = parse_review_entries(payload, country="jp", app_id="1")
+
+    assert len(rows) == 1
+    assert rows[0]["source_id"] == "r1"
+
+
+def test_parse_review_body_and_title_preserved() -> None:
+    payload = _payload(_entry("1", "r99"))
+
+    [row] = parse_review_entries(payload, country="jp", app_id="1")
+
+    assert row["title"] == "title-r99"
+    assert row["body"] == "body-r99"
+    assert row["posted_at"] == "2026-05-19T12:34:56-07:00"
+
+
+# ----------------------------------------------------------------------
+# Retry / backoff / Sentry alert
+# ----------------------------------------------------------------------
+
+
+def test_fetch_one_succeeds_on_first_try() -> None:
+    payload = _payload(_entry("2", "r1"))
+    calls: list[str] = []
+
+    def http_get(url: str) -> dict:
+        calls.append(url)
+        return payload
+
+    sleeps: list[float] = []
+
+    result = fetch_one(
+        "jp", "1", http_get=http_get, sleep_fn=lambda s: sleeps.append(s)
+    )
+
+    assert result is payload
+    assert len(calls) == 1
+    assert sleeps == []
+    assert calls[0] == APPLE_RSS_URL_FMT.format(country="jp", app_id="1")
+
+
+def test_fetch_one_retries_with_exp_backoff_then_sentry_on_exhaustion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """初期1 + 5 retries が全部失敗したら Sentry alert を発火し None を返す。"""
+    calls: list[str] = []
+
+    def always_fail(url: str) -> dict:
+        calls.append(url)
+        raise TimeoutError("simulated")
+
+    sleeps: list[float] = []
+    sentry_calls: list[tuple[str, dict]] = []
+
+    def fake_capture_message(msg: str, **kwargs: Any) -> None:
+        sentry_calls.append((msg, kwargs))
+
+    monkeypatch.setattr(
+        apple_rss.sentry_sdk, "capture_message", fake_capture_message
+    )
+
+    result = fetch_one(
+        "jp",
+        "999",
+        http_get=always_fail,
+        sleep_fn=lambda s: sleeps.append(s),
+    )
+
+    assert result is None
+    # 1 initial + 5 retries
+    assert len(calls) == 1 + len(RETRY_DELAYS_SECONDS)
+    # Sleeps happen between each retry — 5 total, matching the constant.
+    assert sleeps == list(RETRY_DELAYS_SECONDS)
+    # Exactly one Sentry alert with level=error and app coords in the body.
+    assert len(sentry_calls) == 1
+    msg, kwargs = sentry_calls[0]
+    assert "jp/999" in msg
+    assert kwargs.get("level") == "error"
+
+
+def test_fetch_one_recovers_mid_retry() -> None:
+    """途中で復旧したら Sentry alert は発火せず正常 payload を返す。"""
+    payload = _payload(_entry("3", "r1"))
+    attempt_counter = {"n": 0}
+
+    def flaky(url: str) -> dict:
+        attempt_counter["n"] += 1
+        if attempt_counter["n"] < 3:
+            raise TimeoutError("flaky")
+        return payload
+
+    sleeps: list[float] = []
+
+    result = fetch_one(
+        "jp", "1", http_get=flaky, sleep_fn=lambda s: sleeps.append(s)
+    )
+
+    assert result is payload
+    # 1 initial + 2 retries = succeed on 3rd attempt
+    assert attempt_counter["n"] == 3
+    # Sleeps happened only between failed attempts.
+    assert sleeps == [1, 2]
+
+
+# ----------------------------------------------------------------------
+# INSERT SQL contract — ON CONFLICT DO NOTHING
+# ----------------------------------------------------------------------
+
+
+def test_insert_sql_uses_on_conflict_source_source_id_do_nothing() -> None:
+    """同一 (source, source_id) の再 insert が NoOp になることを SQL レベルで保証。"""
+    normalized = re.sub(r"\s+", " ", INSERT_SQL).strip().lower()
+    assert "insert into voices" in normalized
+    assert "on conflict (source, source_id) do nothing" in normalized
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, dict]] = []
+        self.rowcount = 1
+
+    def execute(self, sql: str, params: dict) -> None:
+        self.executed.append((sql, params))
+
+    def __enter__(self) -> "_FakeCursor":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        self.cur = _FakeCursor()
+        self.commits = 0
+
+    def cursor(self) -> _FakeCursor:
+        return self.cur
+
+    def commit(self) -> None:
+        self.commits += 1
+
+
+def test_insert_voices_passes_meta_as_jsonb_and_uses_conflict_sql() -> None:
+    conn = _FakeConn()
+    rows = [
+        {
+            "source": SOURCE_NAME,
+            "source_id": "r1",
+            "posted_at": "2026-05-19T12:34:56-07:00",
+            "title": "t",
+            "body": "b",
+            "meta": {
+                "version": "1.0",
+                "author": "u",
+                "country": "jp",
+                "lang": "ja",
+                "rating": 3,
+            },
+        },
+    ]
+
+    inserted = insert_voices(conn, rows)  # type: ignore[arg-type]
+
+    assert inserted == 1
+    assert conn.commits == 1
+    assert len(conn.cur.executed) == 1
+    sql, params = conn.cur.executed[0]
+    normalized = re.sub(r"\s+", " ", sql).strip().lower()
+    assert "on conflict (source, source_id) do nothing" in normalized
+    # meta must be wrapped for psycopg JSONB serialization.
+    from psycopg.types.json import Jsonb
+
+    assert isinstance(params["meta"], Jsonb)
+
+
+def test_insert_voices_treats_rowcount_zero_as_noop() -> None:
+    """ON CONFLICT skip 時は cur.rowcount=0 → inserted カウントを増やさない."""
+    conn = _FakeConn()
+    conn.cur.rowcount = 0
+    rows = [
+        {
+            "source": SOURCE_NAME,
+            "source_id": "dup",
+            "posted_at": "2026-05-19T12:34:56-07:00",
+            "title": None,
+            "body": None,
+            "meta": {"rating": 1, "country": "jp", "lang": "ja"},
+        }
+    ]
+
+    inserted = insert_voices(conn, rows)  # type: ignore[arg-type]
+
+    assert inserted == 0
+
+
+# ----------------------------------------------------------------------
+# sources.yaml apple_apps parsing
+# ----------------------------------------------------------------------
+
+
+def test_load_apple_apps_reads_real_sources_yaml() -> None:
+    apps = load_apple_apps(REPO_ROOT / "sources.yaml")
+
+    by_name = {a.name: a for a in apps}
+    for required in ("Notion", "Obsidian", "MoneyForward"):
+        assert required in by_name, f"sources.yaml missing apple_apps entry: {required}"
+        assert by_name[required].countries == ("jp",)
+        assert by_name[required].enabled is True
+        # app_id is a string ID (Apple uses numeric strings).
+        assert by_name[required].app_id.isdigit()
+
+
+def test_load_apple_apps_skips_disabled(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "sources.yaml"
+    yaml_path.write_text(
+        yaml.safe_dump(
+            {
+                "sources": [],
+                "apple_apps": [
+                    {
+                        "name": "Notion",
+                        "app_id": "1",
+                        "country": ["jp"],
+                        "enabled": True,
+                    },
+                    {
+                        "name": "Disabled",
+                        "app_id": "2",
+                        "country": ["jp"],
+                        "enabled": False,
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    apps = load_apple_apps(yaml_path)
+
+    assert [a.name for a in apps] == ["Notion"]
+
+
+def test_load_apple_apps_does_not_require_apple_apps_key(tmp_path: Path) -> None:
+    # 既存 sources.yaml (apple_apps セクション無し) でも壊れない。
+    yaml_path = tmp_path / "sources.yaml"
+    yaml_path.write_text(yaml.safe_dump({"sources": []}), encoding="utf-8")
+
+    assert load_apple_apps(yaml_path) == []
+
+
+def test_load_apple_apps_skips_entries_with_empty_country(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "sources.yaml"
+    yaml_path.write_text(
+        yaml.safe_dump(
+            {
+                "apple_apps": [
+                    {"name": "NoCountry", "app_id": "1", "country": [], "enabled": True},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert load_apple_apps(yaml_path) == []
+
+
+# ----------------------------------------------------------------------
+# Migration 008 schema check (text-level)
+# ----------------------------------------------------------------------
+
+
+def test_migration_008_defines_voices_table_with_unique_and_index() -> None:
+    sql_path = REPO_ROOT / "migrations" / "008_voices.sql"
+    sql = sql_path.read_text(encoding="utf-8").lower()
+
+    # Table itself.
+    assert "create table if not exists voices" in sql
+    # Required columns referenced in the fetcher's INSERT.
+    for col in ("source", "source_id", "posted_at", "meta"):
+        assert col in sql
+
+    # UNIQUE (source, source_id) — required for ON CONFLICT idempotency.
+    assert re.search(
+        r"create unique index.*?voices.*?\(\s*source\s*,\s*source_id\s*\)",
+        sql,
+        flags=re.DOTALL,
+    ), "voices_source_source_id_uidx not found"
+
+    # idx_voices_source_posted — explicitly named in the acceptance criteria.
+    assert "idx_voices_source_posted" in sql
+
+
+# ----------------------------------------------------------------------
+# Module-level constants sanity
+# ----------------------------------------------------------------------
+
+
+def test_retry_delays_constant_matches_spec() -> None:
+    assert RETRY_DELAYS_SECONDS == (1, 2, 4, 8, 16)
+
+
+def test_lang_lookup_jp_is_ja() -> None:
+    assert LANG_BY_COUNTRY["jp"] == "ja"
+
+
+def test_apple_app_dataclass_is_frozen() -> None:
+    app = AppleApp(name="x", app_id="1", countries=("jp",))
+    with pytest.raises(Exception):
+        app.app_id = "2"  # type: ignore[misc]

--- a/tests/idea_mining/test_critic.py
+++ b/tests/idea_mining/test_critic.py
@@ -1,0 +1,754 @@
+"""Tests for `idea_mining.critic` E2E adversarial review path.
+
+Anthropic / Neon は in-memory fake で代用。Issue #139 acceptance:
+
+* `candidates.critic_verdict IS NULL` を snapshot 取得し 1 row ずつ Sonnet で
+  評価する
+* verdict は GO / PENDING / KILL のいずれか、critic_meta は JSONB
+* 1 row 1 commit (row-level transaction)
+* malformed JSON は sentry capture + warning ログで skip、raise / retry しない
+* 'LLM thin wrapper + target self-resolves' 相当 fixture が KILL になる
+* prompt 末尾 RUBRIC テキストが Decisions §4 の verbatim と一致する
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from idea_mining.critic import (
+    REQUIRED_META_KEYS,
+    SELECT_CANDIDATE_IDS_SQL,
+    SELECT_CANDIDATE_SQL,
+    SONNET_MODEL,
+    UPDATE_CRITIC_SQL,
+    build_system_prompt,
+    build_user_message,
+    extract_verdict_and_meta,
+    fetch_candidate,
+    fetch_candidate_ids,
+    parse_sonnet_response,
+    run_for_candidate,
+    update_critic_verdict,
+)
+from idea_mining.prompts.critic import SYSTEM_PROMPT_TEMPLATE
+
+PROFILE_FIXTURE = """\
+# User Constraints
+- 個人プロジェクト前提
+- LLM thin wrapper は避ける
+
+# Negative Examples
+## Aesthetic OS
+- 理由: コンセプト先行 / LLM thin wrapper
+"""
+
+# Decisions §4 の RUBRIC テキスト (verbatim contract — このリテラルが prompt
+# 末尾と一致しなければ Critic prompt の意味的同一性が崩れる)。
+RUBRIC_VERBATIM = (
+    "RUBRIC:\n"
+    "- 5 Forces: 業界構造 (新規参入 / 代替品 / 供給者 / 買い手 / 競合) を評価\n"
+    "- PESTLE: 政治 / 経済 / 社会 / 技術 / 法 / 環境\n"
+    "- Pre-Build KILL: 既存 SaaS で 30 分以内に置換できるなら KILL\n"
+    "- LLM-Moat 7-cond: (1) 専有データ (2) ワークフロー深さ (3) ネットワーク効果 "
+    "(4) 統合密度 (5) コンプライアンス (6) 製造/物流 (7) ブランド/コミュニティ "
+    "— 2 つ以上満たさないなら PENDING、いずれも満たさないなら KILL\n"
+    "- Killer Scenarios: 3 ヶ月以内に競合大手がこの機能を出した場合の生存率"
+)
+
+
+# ----------------------------------------------------------------------
+# Fake psycopg-shaped connection
+# ----------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self, fake_conn: "_FakeConn") -> None:
+        self._fake_conn = fake_conn
+        self._select_result: list[tuple[Any, ...]] = []
+        self.rowcount: int = 0
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self._fake_conn.executed.append((sql, params))
+        normalized = " ".join(sql.split()).lower()
+
+        if "select id from candidates where critic_verdict is null" in normalized:
+            rows = [
+                (cid,)
+                for cid, row in sorted(self._fake_conn.rows_by_id.items())
+                if row.get("critic_verdict") is None
+            ]
+            self._select_result = rows
+            self.rowcount = len(rows)
+            return
+
+        if "from candidates where id =" in normalized and "select" in normalized:
+            assert isinstance(params, tuple)
+            cid = int(params[0])
+            row = self._fake_conn.rows_by_id.get(cid)
+            if row is None:
+                self._select_result = []
+                self.rowcount = 0
+                return
+            self._select_result = [
+                (
+                    row["id"],
+                    row["name"],
+                    row.get("one_liner"),
+                    row.get("target_user"),
+                    row.get("monetization"),
+                    row.get("llm_moat_conditions"),
+                    row.get("why_different"),
+                    row.get("estimated_mvp_hours"),
+                    row.get("killer_use_case"),
+                )
+            ]
+            self.rowcount = 1
+            return
+
+        if "update candidates" in normalized:
+            assert isinstance(params, tuple) and len(params) == 3
+            verdict, meta_json, cid = params
+            assert isinstance(verdict, str)
+            assert isinstance(meta_json, str)
+            target = self._fake_conn.rows_by_id.get(int(cid))
+            if target is None or target.get("critic_verdict") is not None:
+                self.rowcount = 0
+                return
+            target["critic_verdict"] = verdict
+            target["critic_meta"] = json.loads(meta_json)
+            self._fake_conn.updates_applied.append(
+                {
+                    "id": int(cid),
+                    "verdict": verdict,
+                    "meta": target["critic_meta"],
+                }
+            )
+            self.rowcount = 1
+            return
+
+        self.rowcount = 0
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return self._select_result[0] if self._select_result else None
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        return list(self._select_result)
+
+    def __enter__(self) -> "_FakeCursor":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+class _FakeConn:
+    def __init__(self, rows: list[dict[str, Any]] | None = None) -> None:
+        self.rows_by_id: dict[int, dict[str, Any]] = {}
+        for row in rows or []:
+            self.rows_by_id[int(row["id"])] = dict(row)
+        self.executed: list[tuple[str, Any]] = []
+        self.updates_applied: list[dict[str, Any]] = []
+        self.commits: int = 0
+
+    def cursor(self) -> _FakeCursor:
+        return _FakeCursor(self)
+
+    def commit(self) -> None:
+        self.commits += 1
+
+
+# ----------------------------------------------------------------------
+# Fake Anthropic
+# ----------------------------------------------------------------------
+
+
+class _FakeMessages:
+    def __init__(
+        self,
+        recorder: list[dict[str, Any]],
+        text_strategy: Any,
+    ) -> None:
+        self._recorder = recorder
+        self._text_strategy = text_strategy
+
+    def create(self, **kwargs: Any) -> Any:
+        self._recorder.append(kwargs)
+        strategy = self._text_strategy
+        if callable(strategy):
+            text = strategy(kwargs, len(self._recorder) - 1)
+        else:
+            text = strategy
+
+        class _Block:
+            def __init__(self, t: str) -> None:
+                self.text = t
+
+        class _Resp:
+            def __init__(self, blocks: list[_Block]) -> None:
+                self.content = blocks
+
+        return _Resp([_Block(text)])
+
+
+class _FakeAnthropic:
+    def __init__(self, text_strategy: Any) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.messages = _FakeMessages(self.calls, text_strategy)
+
+
+# ----------------------------------------------------------------------
+# Builders
+# ----------------------------------------------------------------------
+
+
+def _candidate_row(
+    cid: int,
+    *,
+    name: str = "Some Candidate",
+    critic_verdict: str | None = None,
+    critic_meta: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": cid,
+        "name": name,
+        "one_liner": f"{name} の 1 行説明",
+        "target_user": "個人開発者",
+        "monetization": "subscription",
+        "llm_moat_conditions": ["workflow", "data"],
+        "why_different": "...",
+        "estimated_mvp_hours": 40,
+        "killer_use_case": "...",
+        "critic_verdict": critic_verdict,
+        "critic_meta": critic_meta,
+    }
+
+
+def _critic_payload(
+    verdict: str,
+    *,
+    overrides: dict[str, Any] | None = None,
+) -> str:
+    payload: dict[str, Any] = {
+        "verdict": verdict,
+        "five_forces": {
+            "rivalry": "H",
+            "new_entrants": "H",
+            "substitutes": "H",
+            "buyers": "M",
+            "suppliers": "L",
+        },
+        "pestle": {
+            "political": "neutral",
+            "economic": "headwind",
+            "social": "neutral",
+            "technological": "tailwind",
+            "legal": "neutral",
+            "environmental": "neutral",
+        },
+        "kill_flags": [],
+        "llm_moat_conditions": ["workflow"],
+        "killer_scenarios": ["Foundation Model update absorbs the feature."],
+        "cited_competitors": [],
+        "kill_reasons": [],
+    }
+    if overrides:
+        payload.update(overrides)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+# ----------------------------------------------------------------------
+# SQL contracts
+# ----------------------------------------------------------------------
+
+
+def test_select_candidate_ids_sql_filters_null_verdict_only() -> None:
+    normalized = " ".join(SELECT_CANDIDATE_IDS_SQL.split()).lower()
+    assert normalized.startswith("select id from candidates where critic_verdict is null")
+
+
+def test_select_candidate_sql_lists_required_columns() -> None:
+    normalized = " ".join(SELECT_CANDIDATE_SQL.split()).lower()
+    for col in (
+        "name",
+        "one_liner",
+        "target_user",
+        "monetization",
+        "llm_moat_conditions",
+        "why_different",
+        "estimated_mvp_hours",
+        "killer_use_case",
+    ):
+        assert col in normalized, f"SELECT missing column: {col}"
+
+
+def test_update_critic_sql_uses_jsonb_cast_and_null_guard() -> None:
+    normalized = " ".join(UPDATE_CRITIC_SQL.split()).lower()
+    assert "update candidates" in normalized
+    assert "set critic_verdict = %s" in normalized
+    assert "critic_meta = %s::jsonb" in normalized
+    assert "where id = %s" in normalized
+    assert "and critic_verdict is null" in normalized
+
+
+def test_update_critic_sql_does_not_insert() -> None:
+    """Critic must never INSERT — only UPDATE existing candidates."""
+    normalized = " ".join(UPDATE_CRITIC_SQL.split()).lower()
+    assert "insert" not in normalized
+
+
+# ----------------------------------------------------------------------
+# Prompt contracts
+# ----------------------------------------------------------------------
+
+
+def test_system_prompt_template_has_single_profile_block_placeholder() -> None:
+    # Only `{profile_block}` should be a substitution; all other literal
+    # braces (in the OUTPUT JSON example) must already be escaped as
+    # `{{` / `}}` so that `.format()` does not blow up.
+    formatted = SYSTEM_PROMPT_TEMPLATE.format(profile_block="X")
+    # Brace-equal-count means escaping was consistent.
+    assert formatted.count("{") == formatted.count("}")
+    # The replacement landed exactly once.
+    assert formatted.count("X") == 1
+
+
+def test_system_prompt_template_contains_rubric_verbatim() -> None:
+    formatted = SYSTEM_PROMPT_TEMPLATE.format(profile_block=PROFILE_FIXTURE)
+    assert RUBRIC_VERBATIM in formatted
+    # The RUBRIC block sits at (or near) the tail — assert it occurs after
+    # the profile block.
+    assert formatted.index(RUBRIC_VERBATIM) > formatted.index(PROFILE_FIXTURE)
+
+
+def test_build_system_prompt_injects_profile_block() -> None:
+    prompt = build_system_prompt(PROFILE_FIXTURE)
+    assert "個人プロジェクト前提" in prompt
+    assert "Aesthetic OS" in prompt
+    # And the formatted output equals SYSTEM_PROMPT_TEMPLATE.format(...).
+    assert prompt == SYSTEM_PROMPT_TEMPLATE.format(profile_block=PROFILE_FIXTURE)
+
+
+def test_build_system_prompt_rejects_empty_profile() -> None:
+    with pytest.raises(ValueError):
+        build_system_prompt("")
+    with pytest.raises(ValueError):
+        build_system_prompt("   \n  ")
+
+
+def test_build_user_message_contains_candidate_name() -> None:
+    cand = _candidate_row(7, name="Some Candidate")
+    msg = build_user_message(cand)
+    assert "Some Candidate" in msg
+
+
+# ----------------------------------------------------------------------
+# Response parsing
+# ----------------------------------------------------------------------
+
+
+def test_parse_sonnet_response_pulls_json_object() -> None:
+    raw = 'preamble \n{"verdict": "KILL"}\n trailing'
+    out = parse_sonnet_response(raw)
+    assert out == {"verdict": "KILL"}
+
+
+def test_parse_sonnet_response_raises_on_malformed_json() -> None:
+    with pytest.raises(ValueError):
+        parse_sonnet_response("not JSON at all")
+
+
+def test_extract_verdict_and_meta_pulls_required_keys() -> None:
+    parsed = json.loads(_critic_payload("GO"))
+    verdict, meta = extract_verdict_and_meta(parsed)
+    assert verdict == "GO"
+    for key in REQUIRED_META_KEYS:
+        assert key in meta
+
+
+def test_extract_verdict_and_meta_uppercases_verdict() -> None:
+    parsed = {"verdict": "kill"}
+    verdict, _ = extract_verdict_and_meta(parsed)
+    assert verdict == "KILL"
+
+
+def test_extract_verdict_and_meta_rejects_unknown_verdict() -> None:
+    with pytest.raises(ValueError):
+        extract_verdict_and_meta({"verdict": "DUNNO"})
+
+
+def test_extract_verdict_and_meta_rejects_missing_verdict() -> None:
+    with pytest.raises(ValueError):
+        extract_verdict_and_meta({"other_field": "x"})
+
+
+# ----------------------------------------------------------------------
+# DB helpers
+# ----------------------------------------------------------------------
+
+
+def test_fetch_candidate_ids_returns_only_null_verdict_rows() -> None:
+    conn = _FakeConn(
+        rows=[
+            _candidate_row(1),
+            _candidate_row(2, critic_verdict="GO"),
+            _candidate_row(3),
+        ]
+    )
+
+    ids = fetch_candidate_ids(conn)  # type: ignore[arg-type]
+
+    assert ids == [1, 3]
+
+
+def test_fetch_candidate_returns_none_for_missing() -> None:
+    conn = _FakeConn()
+
+    out = fetch_candidate(conn, 999)  # type: ignore[arg-type]
+
+    assert out is None
+
+
+def test_update_critic_verdict_commits_per_row() -> None:
+    conn = _FakeConn(rows=[_candidate_row(1)])
+
+    rowcount = update_critic_verdict(
+        conn,  # type: ignore[arg-type]
+        candidate_id=1,
+        verdict="GO",
+        meta={"five_forces": {"rivalry": "L"}, "kill_reasons": []},
+    )
+
+    assert rowcount == 1
+    assert conn.commits == 1
+    assert conn.rows_by_id[1]["critic_verdict"] == "GO"
+    assert conn.rows_by_id[1]["critic_meta"] == {
+        "five_forces": {"rivalry": "L"},
+        "kill_reasons": [],
+    }
+
+
+def test_update_critic_verdict_noops_when_already_verdicted() -> None:
+    """Defense-in-depth: UPDATE WHERE critic_verdict IS NULL must skip rows
+    already marked. (Snapshot iteration guarantees no double-UPDATE within
+    the same batch, but this row-level guard catches concurrency too.)"""
+    conn = _FakeConn(rows=[_candidate_row(1, critic_verdict="KILL")])
+
+    rowcount = update_critic_verdict(
+        conn,  # type: ignore[arg-type]
+        candidate_id=1,
+        verdict="GO",
+        meta={},
+    )
+
+    assert rowcount == 0
+    assert conn.rows_by_id[1]["critic_verdict"] == "KILL"
+
+
+# ----------------------------------------------------------------------
+# run_for_candidate — full path
+# ----------------------------------------------------------------------
+
+
+def test_run_for_candidate_updates_and_commits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _FakeConn(rows=[_candidate_row(1, name="Good Idea")])
+    client = _FakeAnthropic(_critic_payload("GO"))
+
+    ok = run_for_candidate(
+        conn,  # type: ignore[arg-type]
+        client,  # type: ignore[arg-type]
+        candidate_id=1,
+        profile=PROFILE_FIXTURE,
+    )
+
+    assert ok is True
+    assert len(client.calls) == 1
+    assert client.calls[0]["model"] == SONNET_MODEL
+    assert conn.commits == 1
+    assert conn.rows_by_id[1]["critic_verdict"] == "GO"
+    meta = conn.rows_by_id[1]["critic_meta"]
+    assert isinstance(meta, dict)
+    for key in REQUIRED_META_KEYS:
+        assert key in meta
+
+
+def test_run_for_candidate_skips_when_candidate_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _FakeConn()
+    client = _FakeAnthropic("(should not be called)")
+
+    captured: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_capture(msg: str, **kwargs: Any) -> None:
+        captured.append((msg, kwargs))
+
+    from idea_mining import critic as critic_mod
+
+    monkeypatch.setattr(
+        critic_mod.sentry_sdk, "capture_message", fake_capture
+    )
+
+    ok = run_for_candidate(
+        conn,  # type: ignore[arg-type]
+        client,  # type: ignore[arg-type]
+        candidate_id=99,
+        profile=PROFILE_FIXTURE,
+    )
+
+    assert ok is False
+    assert client.calls == []
+    assert conn.commits == 0
+    assert len(captured) == 1
+    assert "not found" in captured[0][0]
+
+
+def test_run_for_candidate_skips_on_malformed_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _FakeConn(rows=[_candidate_row(1)])
+    client = _FakeAnthropic("not JSON at all")
+
+    captured: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_capture(msg: str, **kwargs: Any) -> None:
+        captured.append((msg, kwargs))
+
+    from idea_mining import critic as critic_mod
+
+    monkeypatch.setattr(
+        critic_mod.sentry_sdk, "capture_message", fake_capture
+    )
+
+    ok = run_for_candidate(
+        conn,  # type: ignore[arg-type]
+        client,  # type: ignore[arg-type]
+        candidate_id=1,
+        profile=PROFILE_FIXTURE,
+    )
+
+    assert ok is False
+    assert conn.commits == 0
+    assert conn.rows_by_id[1]["critic_verdict"] is None
+    assert len(captured) == 1
+    assert "malformed" in captured[0][0].lower()
+
+
+def test_run_for_candidate_skips_on_invalid_verdict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _FakeConn(rows=[_candidate_row(1)])
+    client = _FakeAnthropic('{"verdict": "DUNNO"}')
+
+    captured: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_capture(msg: str, **kwargs: Any) -> None:
+        captured.append((msg, kwargs))
+
+    from idea_mining import critic as critic_mod
+
+    monkeypatch.setattr(
+        critic_mod.sentry_sdk, "capture_message", fake_capture
+    )
+
+    ok = run_for_candidate(
+        conn,  # type: ignore[arg-type]
+        client,  # type: ignore[arg-type]
+        candidate_id=1,
+        profile=PROFILE_FIXTURE,
+    )
+
+    assert ok is False
+    assert conn.rows_by_id[1]["critic_verdict"] is None
+    assert len(captured) == 1
+
+
+# ----------------------------------------------------------------------
+# Row-level commit — one bad row should not roll back others
+# ----------------------------------------------------------------------
+
+
+def test_batch_row_level_commit_isolates_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Run 3 candidates; the middle one returns malformed JSON. The first
+    and third UPDATEs must remain committed even though the middle skipped.
+    """
+    conn = _FakeConn(
+        rows=[
+            _candidate_row(1, name="A"),
+            _candidate_row(2, name="B"),
+            _candidate_row(3, name="C"),
+        ]
+    )
+
+    # Per-call mapping by candidate name embedded in the user message
+    # ("name: 'A'" / "name: 'B'" / "name: 'C'").
+    def text_strategy(kwargs: dict[str, Any], _i: int) -> str:
+        user_content = kwargs["messages"][0]["content"]
+        if "'A'" in user_content:
+            return _critic_payload("GO")
+        if "'B'" in user_content:
+            return "not JSON at all"
+        if "'C'" in user_content:
+            return _critic_payload("KILL")
+        raise AssertionError(f"unexpected user content: {user_content!r}")
+
+    client = _FakeAnthropic(text_strategy)
+
+    captured: list[str] = []
+
+    def fake_capture(msg: str, **_kwargs: Any) -> None:
+        captured.append(msg)
+
+    from idea_mining import critic as critic_mod
+
+    monkeypatch.setattr(
+        critic_mod.sentry_sdk, "capture_message", fake_capture
+    )
+
+    ids = fetch_candidate_ids(conn)  # type: ignore[arg-type]
+    assert ids == [1, 2, 3]
+
+    results: list[bool] = []
+    for cid in ids:
+        results.append(
+            run_for_candidate(
+                conn,  # type: ignore[arg-type]
+                client,  # type: ignore[arg-type]
+                candidate_id=cid,
+                profile=PROFILE_FIXTURE,
+            )
+        )
+
+    assert results == [True, False, True]
+    # 2 successful UPDATEs → 2 commits. The skipped row never reached the
+    # UPDATE/commit step.
+    assert conn.commits == 2
+    assert conn.rows_by_id[1]["critic_verdict"] == "GO"
+    assert conn.rows_by_id[2]["critic_verdict"] is None  # untouched
+    assert conn.rows_by_id[3]["critic_verdict"] == "KILL"
+    assert len(captured) == 1
+    assert "malformed" in captured[0].lower()
+
+
+def test_batch_only_processes_null_verdict_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """rows with verdict already set are excluded from the snapshot, so
+    Sonnet is never invoked for them and they are not re-UPDATEd."""
+    conn = _FakeConn(
+        rows=[
+            _candidate_row(1, name="Pending Row"),
+            _candidate_row(2, name="Already Verdicted", critic_verdict="GO"),
+            _candidate_row(3, name="Another Pending"),
+        ]
+    )
+    client = _FakeAnthropic(_critic_payload("PENDING"))
+
+    ids = fetch_candidate_ids(conn)  # type: ignore[arg-type]
+    assert ids == [1, 3]
+    for cid in ids:
+        run_for_candidate(
+            conn,  # type: ignore[arg-type]
+            client,  # type: ignore[arg-type]
+            candidate_id=cid,
+            profile=PROFILE_FIXTURE,
+        )
+
+    # Sonnet was called exactly twice (once per pending row).
+    assert len(client.calls) == 2
+    # The already-verdicted row was not touched.
+    assert conn.rows_by_id[2]["critic_verdict"] == "GO"
+    # Both pending rows are now verdicted.
+    assert conn.rows_by_id[1]["critic_verdict"] == "PENDING"
+    assert conn.rows_by_id[3]["critic_verdict"] == "PENDING"
+
+
+# ----------------------------------------------------------------------
+# Aesthetic-OS-style KILL fixture
+# ----------------------------------------------------------------------
+
+
+def test_llm_thin_wrapper_target_self_resolves_is_killed() -> None:
+    """The Critic must KILL ideas that are LLM thin wrappers whose target
+    user can self-resolve the pain with the raw LLM. The verdict and the
+    cited reasons must land in critic_meta.
+
+    The test fixture forces Sonnet's response to KILL with explicit
+    competitors + kill_reasons; we only verify that the Critic stores
+    them in critic_meta exactly as returned (Decisions §B output schema).
+    """
+    conn = _FakeConn(
+        rows=[
+            _candidate_row(
+                42,
+                name="GPT-Backed Note Renamer",
+            )
+        ]
+    )
+    kill_payload = _critic_payload(
+        "KILL",
+        overrides={
+            "verdict": "KILL",
+            "kill_flags": ["llm_thin_wrapper", "target_self_resolves"],
+            "llm_moat_conditions": [],
+            "cited_competitors": ["ChatGPT", "Claude.ai", "Notion AI"],
+            "kill_reasons": [
+                "LLM thin wrapper — target user can paste the same prompt into ChatGPT.",
+                "Target user already self-resolves with vanilla ChatGPT free tier.",
+            ],
+            "killer_scenarios": [
+                "Foundation Model update absorbs note renaming as a built-in."
+            ],
+        },
+    )
+    client = _FakeAnthropic(kill_payload)
+
+    ok = run_for_candidate(
+        conn,  # type: ignore[arg-type]
+        client,  # type: ignore[arg-type]
+        candidate_id=42,
+        profile=PROFILE_FIXTURE,
+    )
+
+    assert ok is True
+    row = conn.rows_by_id[42]
+    assert row["critic_verdict"] == "KILL"
+    meta = row["critic_meta"]
+    assert isinstance(meta, dict)
+    assert meta["cited_competitors"] == ["ChatGPT", "Claude.ai", "Notion AI"]
+    assert any(
+        "thin wrapper" in r.lower() for r in meta["kill_reasons"]
+    ), meta["kill_reasons"]
+    assert any(
+        "self-resolve" in r.lower() for r in meta["kill_reasons"]
+    ), meta["kill_reasons"]
+    assert "llm_thin_wrapper" in meta["kill_flags"]
+    assert "target_self_resolves" in meta["kill_flags"]
+
+
+# ----------------------------------------------------------------------
+# Anthropic call args — profile + RUBRIC must land in system prompt
+# ----------------------------------------------------------------------
+
+
+def test_sonnet_call_carries_profile_block_and_rubric() -> None:
+    conn = _FakeConn(rows=[_candidate_row(1)])
+    client = _FakeAnthropic(_critic_payload("PENDING"))
+
+    run_for_candidate(
+        conn,  # type: ignore[arg-type]
+        client,  # type: ignore[arg-type]
+        candidate_id=1,
+        profile=PROFILE_FIXTURE,
+    )
+
+    call = client.calls[0]
+    assert "個人プロジェクト前提" in call["system"]
+    assert "Aesthetic OS" in call["system"]
+    assert RUBRIC_VERBATIM in call["system"]
+    assert call["model"] == SONNET_MODEL

--- a/tests/idea_mining/test_digest_query.py
+++ b/tests/idea_mining/test_digest_query.py
@@ -1,0 +1,224 @@
+"""Tests for digest DB query layer (Issue #140).
+
+* `fetch_top_patterns` は ``week_iso`` で絞り、``frequency`` 降順で最大 3 件
+  返す
+* `fetch_verdict_candidates` は ``critic_verdict IS NOT NULL`` の行のみ返す
+* `_trim_for_display` が GO 2 件 + KILL 1 件にトリムする
+"""
+from __future__ import annotations
+
+import pytest
+
+from idea_mining.digest import (
+    MAX_GO_PER_PATTERN,
+    MAX_KILL_PER_PATTERN,
+    TOP_PATTERNS,
+    Candidate,
+    _trim_for_display,
+    build_digest,
+    fetch_top_patterns,
+    fetch_verdict_candidates,
+)
+
+from tests.idea_mining._digest_fakes import CandidateRow, FakeConn, PatternRow
+
+WEEK = "2026-W21"
+OTHER_WEEK = "2026-W20"
+
+
+@pytest.fixture
+def populated_conn() -> FakeConn:
+    return FakeConn(
+        patterns=[
+            PatternRow(
+                id="00000000-0000-0000-0000-00000000000a",
+                week_iso=WEEK,
+                pain="低 frequency pattern",
+                categories=["cat1"],
+                frequency=4,
+                source_diversity=2,
+                confidence=0.6,
+            ),
+            PatternRow(
+                id="00000000-0000-0000-0000-00000000000b",
+                week_iso=WEEK,
+                pain="高 frequency pattern",
+                categories=["cat2"],
+                frequency=12,
+                source_diversity=4,
+                confidence=0.9,
+            ),
+            PatternRow(
+                id="00000000-0000-0000-0000-00000000000c",
+                week_iso=WEEK,
+                pain="中 frequency pattern",
+                categories=["cat3"],
+                frequency=8,
+                source_diversity=3,
+                confidence=0.7,
+            ),
+            PatternRow(
+                id="00000000-0000-0000-0000-00000000000d",
+                week_iso=WEEK,
+                pain="4 番目 pattern (top 3 で切られる)",
+                categories=[],
+                frequency=3,
+                source_diversity=2,
+                confidence=0.5,
+            ),
+            # 別週の pattern は混入してはいけない。
+            PatternRow(
+                id="00000000-0000-0000-0000-00000000000e",
+                week_iso=OTHER_WEEK,
+                pain="別週",
+                categories=[],
+                frequency=100,
+                source_diversity=10,
+                confidence=1.0,
+            ),
+        ],
+        candidates=[
+            # 高 frequency (b) — GO 3 件 + KILL 2 件 + PENDING 1 件 + 未 verdict 1 件
+            CandidateRow(
+                id=1,
+                pattern_id="00000000-0000-0000-0000-00000000000b",
+                name="GO-old",
+                critic_verdict="GO",
+                generated_at_rank=1,
+            ),
+            CandidateRow(
+                id=2,
+                pattern_id="00000000-0000-0000-0000-00000000000b",
+                name="GO-mid",
+                critic_verdict="GO",
+                generated_at_rank=2,
+            ),
+            CandidateRow(
+                id=3,
+                pattern_id="00000000-0000-0000-0000-00000000000b",
+                name="GO-new",
+                critic_verdict="GO",
+                generated_at_rank=3,
+            ),
+            CandidateRow(
+                id=4,
+                pattern_id="00000000-0000-0000-0000-00000000000b",
+                name="KILL-old",
+                critic_verdict="KILL",
+                generated_at_rank=1,
+                critic_meta={"kill_reasons": ["old reason"]},
+            ),
+            CandidateRow(
+                id=5,
+                pattern_id="00000000-0000-0000-0000-00000000000b",
+                name="KILL-new",
+                critic_verdict="KILL",
+                generated_at_rank=3,
+                critic_meta={"kill_reasons": ["new reason"]},
+            ),
+            CandidateRow(
+                id=6,
+                pattern_id="00000000-0000-0000-0000-00000000000b",
+                name="PENDING",
+                critic_verdict="PENDING",
+                generated_at_rank=3,
+            ),
+            CandidateRow(
+                id=7,
+                pattern_id="00000000-0000-0000-0000-00000000000b",
+                name="未 verdict",
+                critic_verdict=None,
+                generated_at_rank=3,
+            ),
+        ],
+    )
+
+
+def test_fetch_top_patterns_filters_week_and_orders_by_frequency_desc(
+    populated_conn: FakeConn,
+) -> None:
+    patterns = fetch_top_patterns(populated_conn, WEEK)
+    assert len(patterns) == TOP_PATTERNS == 3
+    # 別週は除外。
+    pains = [p.pain for p in patterns]
+    assert "別週" not in pains
+    # frequency DESC
+    freqs = [p.frequency for p in patterns]
+    assert freqs == sorted(freqs, reverse=True)
+    assert freqs == [12, 8, 4]
+
+
+def test_fetch_verdict_candidates_filters_null_verdict(
+    populated_conn: FakeConn,
+) -> None:
+    candidates = fetch_verdict_candidates(
+        populated_conn, "00000000-0000-0000-0000-00000000000b"
+    )
+    names = [c.name for c in candidates]
+    assert "未 verdict" not in names
+    # PENDING は除外しない (NOT NULL のみが条件)。
+    assert "PENDING" in names
+    # 全候補 verdict が GO / PENDING / KILL のいずれか。
+    assert all(c.critic_verdict in {"GO", "PENDING", "KILL"} for c in candidates)
+
+
+def test_fetch_verdict_candidates_orders_newest_first(
+    populated_conn: FakeConn,
+) -> None:
+    candidates = fetch_verdict_candidates(
+        populated_conn, "00000000-0000-0000-0000-00000000000b"
+    )
+    go_names = [c.name for c in candidates if c.critic_verdict == "GO"]
+    # 新しい順 (generated_at DESC, id DESC) で並んでいる。
+    assert go_names == ["GO-new", "GO-mid", "GO-old"]
+    kill_names = [c.name for c in candidates if c.critic_verdict == "KILL"]
+    assert kill_names == ["KILL-new", "KILL-old"]
+
+
+def _mk_candidate(name: str, verdict: str) -> Candidate:
+    return Candidate(
+        id=hash(name) & 0xFFFFFFF,
+        name=name,
+        one_liner=None,
+        target_user=None,
+        monetization=None,
+        why_different=None,
+        killer_use_case=None,
+        critic_verdict=verdict,
+        kill_reasons=[],
+    )
+
+
+def test_trim_for_display_caps_go_at_two_and_kill_at_one() -> None:
+    candidates = [
+        _mk_candidate("g1", "GO"),
+        _mk_candidate("g2", "GO"),
+        _mk_candidate("g3", "GO"),
+        _mk_candidate("k1", "KILL"),
+        _mk_candidate("k2", "KILL"),
+        _mk_candidate("p1", "PENDING"),
+    ]
+    go, kill = _trim_for_display(candidates)
+    assert len(go) == MAX_GO_PER_PATTERN == 2
+    assert [c.name for c in go] == ["g1", "g2"]
+    assert len(kill) == MAX_KILL_PER_PATTERN == 1
+    assert [c.name for c in kill] == ["k1"]
+
+
+def test_build_digest_links_candidates_to_each_pattern(
+    populated_conn: FakeConn,
+) -> None:
+    digest = build_digest(populated_conn, WEEK)
+    # 3 patterns 全部含まれる (verdict 候補がゼロでも sections に積む)。
+    assert len(digest.sections) == 3
+    # 高 frequency pattern の section に candidates が乗っている。
+    top = digest.sections[0]
+    assert top.pattern.pain == "高 frequency pattern"
+    assert [c.name for c in top.go_candidates] == ["GO-new", "GO-mid"]
+    assert [c.name for c in top.kill_candidates] == ["KILL-new"]
+    # KILL の理由は critic_meta から取れている。
+    assert top.kill_candidates[0].kill_reasons == ["new reason"]
+    # candidate-less pattern も section に乗っている (本文では「verdict 候補
+    # なし」表示)。
+    others = digest.sections[1:]
+    assert all(s.go_candidates == [] and s.kill_candidates == [] for s in others)

--- a/tests/idea_mining/test_digest_skip.py
+++ b/tests/idea_mining/test_digest_skip.py
@@ -1,0 +1,169 @@
+"""Tests for `idea_mining.digest.run` skip semantics (Issue #140).
+
+acceptance criteria:
+
+    対象週の patterns または verdict 付き candidates がゼロのときは
+    送信スキップしログのみ残す (workflow は exit 0)
+"""
+from __future__ import annotations
+
+import idea_mining.digest as digest_module
+from idea_mining.digest import run
+
+from tests.idea_mining._digest_fakes import CandidateRow, FakeConn, PatternRow
+
+WEEK = "2026-W21"
+
+
+def _no_send(monkeypatch) -> list[dict[str, object]]:
+    """Replace `email_sender.send_email` with a spy so a skip never sends."""
+    calls: list[dict[str, object]] = []
+
+    def fake_send(**kwargs: object) -> None:
+        calls.append(dict(kwargs))
+
+    monkeypatch.setattr(digest_module.email_sender, "send_email", fake_send)
+    return calls
+
+
+def test_run_skips_when_no_patterns_for_week(monkeypatch) -> None:
+    """対象週に pattern が 1 件もない → skip."""
+    sends = _no_send(monkeypatch)
+    conn = FakeConn(
+        patterns=[
+            # 別週の pattern のみ → 対象週から見ると 0 件。
+            PatternRow(
+                id="p-other",
+                week_iso="2026-W20",
+                pain="別週 pain",
+                categories=[],
+                frequency=10,
+                source_diversity=3,
+                confidence=0.9,
+            ),
+        ],
+        candidates=[],
+    )
+    outcome = run(
+        conn,
+        week_iso=WEEK,
+        recipient="kazuki@example.com",
+        dry_run=False,
+    )
+    assert outcome == "skipped"
+    assert sends == []
+
+
+def test_run_skips_when_no_verdict_candidates(monkeypatch) -> None:
+    """patterns はあるが verdict 付き candidate が 0 → skip."""
+    sends = _no_send(monkeypatch)
+    conn = FakeConn(
+        patterns=[
+            PatternRow(
+                id="p-1",
+                week_iso=WEEK,
+                pain="pain-X",
+                categories=[],
+                frequency=10,
+                source_diversity=3,
+                confidence=0.8,
+            ),
+        ],
+        candidates=[
+            CandidateRow(
+                id=1,
+                pattern_id="p-1",
+                name="まだ verdict 出てない",
+                critic_verdict=None,
+            ),
+        ],
+    )
+    outcome = run(
+        conn,
+        week_iso=WEEK,
+        recipient="kazuki@example.com",
+        dry_run=False,
+    )
+    assert outcome == "skipped"
+    assert sends == []
+
+
+def test_run_sends_when_at_least_one_verdict_candidate(monkeypatch) -> None:
+    """skip 条件の counter-test: 1 件でも verdict があれば送信する。"""
+    sends = _no_send(monkeypatch)
+    conn = FakeConn(
+        patterns=[
+            PatternRow(
+                id="p-1",
+                week_iso=WEEK,
+                pain="pain-X",
+                categories=[],
+                frequency=10,
+                source_diversity=3,
+                confidence=0.8,
+            ),
+        ],
+        candidates=[
+            CandidateRow(
+                id=1,
+                pattern_id="p-1",
+                name="採用候補",
+                critic_verdict="GO",
+                one_liner="GO の 1 行",
+                generated_at_rank=1,
+            ),
+        ],
+    )
+    outcome = run(
+        conn,
+        week_iso=WEEK,
+        recipient="kazuki@example.com",
+        dry_run=False,
+    )
+    assert outcome == "sent"
+    assert len(sends) == 1
+    payload = sends[0]
+    assert payload["to"] == "kazuki@example.com"
+    assert payload["subject"] == "[Hibi] 今週のアイデア候補 1 件 (2026-W21)"
+    # multipart で plain + html 両方が乗っている。
+    assert payload["text_body"] is not None
+    assert payload["html_body"] is not None
+
+
+def test_run_dry_run_prints_and_does_not_send(monkeypatch, capsys) -> None:
+    """DRY_RUN: stdout に出力し、Gmail は呼ばない (skip 条件には該当しない)。"""
+    sends = _no_send(monkeypatch)
+    conn = FakeConn(
+        patterns=[
+            PatternRow(
+                id="p-1",
+                week_iso=WEEK,
+                pain="pain-Y",
+                categories=[],
+                frequency=8,
+                source_diversity=2,
+                confidence=0.7,
+            ),
+        ],
+        candidates=[
+            CandidateRow(
+                id=2,
+                pattern_id="p-1",
+                name="dry-run GO",
+                critic_verdict="GO",
+                one_liner="dry-run 用",
+                generated_at_rank=1,
+            ),
+        ],
+    )
+    outcome = run(
+        conn,
+        week_iso=WEEK,
+        recipient="kazuki@example.com",
+        dry_run=True,
+    )
+    assert outcome == "dry_run"
+    assert sends == []
+    captured = capsys.readouterr().out
+    assert "[Hibi] 今週のアイデア候補 1 件 (2026-W21)" in captured
+    assert "dry-run GO" in captured

--- a/tests/idea_mining/test_digest_template.py
+++ b/tests/idea_mining/test_digest_template.py
@@ -1,0 +1,202 @@
+"""Tests for digest HTML / plain text renderers (Issue #140).
+
+3 ケースを検証する:
+
+* GO+KILL 混在 (正常系) — HTML / text 両方に GO 名 / KILL 名 + 理由が出る
+* 空週 — レンダリングは可能だが ``should_skip`` が True で配信スキップになる
+* verdict 未付与のみ — 同上 (KILL 理由なし表示は呼び出されない)
+"""
+from __future__ import annotations
+
+from idea_mining.digest import (
+    Candidate,
+    Digest,
+    DigestSection,
+    Pattern,
+    build_digest,
+    format_subject,
+    render_html,
+    render_plain_text,
+)
+
+from tests.idea_mining._digest_fakes import CandidateRow, FakeConn, PatternRow
+
+WEEK = "2026-W21"
+
+
+def _pattern(
+    id_: str, *, pain: str = "テスト pain", frequency: int = 10
+) -> Pattern:
+    return Pattern(
+        id=id_,
+        pain=pain,
+        categories=["dev"],
+        frequency=frequency,
+        source_diversity=3,
+        confidence=0.8,
+    )
+
+
+def _go(name: str, one_liner: str = "GO 候補の説明") -> Candidate:
+    return Candidate(
+        id=hash(name) & 0xFFFFFFF,
+        name=name,
+        one_liner=one_liner,
+        target_user="個人開発者",
+        monetization="subscription",
+        why_different=None,
+        killer_use_case=None,
+        critic_verdict="GO",
+        kill_reasons=[],
+    )
+
+
+def _kill(name: str, reasons: list[str]) -> Candidate:
+    return Candidate(
+        id=hash(name) & 0xFFFFFFF,
+        name=name,
+        one_liner="KILL 候補の説明",
+        target_user=None,
+        monetization=None,
+        why_different=None,
+        killer_use_case=None,
+        critic_verdict="KILL",
+        kill_reasons=reasons,
+    )
+
+
+# ----------------------------------------------------------------------
+# Case 1: GO + KILL 混在
+# ----------------------------------------------------------------------
+
+
+def test_render_html_and_text_contain_go_and_kill_with_reason() -> None:
+    digest = Digest(
+        week_iso=WEEK,
+        sections=[
+            DigestSection(
+                pattern=_pattern("p-1", pain="字幕取得が不安定", frequency=12),
+                obsidian_url=(
+                    "obsidian://open?vault=Obsidan-workspace"
+                    "&file=10_projects/hibi/idea-mining/patterns/"
+                    "2026-W21/x.md"
+                ),
+                go_candidates=[
+                    _go("GO-α", one_liner="α の 1 行価値"),
+                    _go("GO-β"),
+                ],
+                kill_candidates=[
+                    _kill("KILL-γ", reasons=["既存 SaaS で 30 分以内に置換可能"])
+                ],
+            )
+        ],
+    )
+    assert digest.total_candidates == 3
+
+    subject = format_subject(digest)
+    assert subject == "[Hibi] 今週のアイデア候補 3 件 (2026-W21)"
+
+    html_body = render_html(digest)
+    text_body = render_plain_text(digest)
+
+    # 件名と pattern pain が両 part に出る。
+    assert "字幕取得が不安定" in html_body
+    assert "字幕取得が不安定" in text_body
+
+    # GO / KILL ラベル + 候補名が両 part に出る。
+    for fragment in ("GO", "KILL", "GO-α", "GO-β", "KILL-γ"):
+        assert fragment in html_body
+        assert fragment in text_body
+
+    # KILL 理由は両 part で表示。
+    assert "既存 SaaS で 30 分以内に置換可能" in html_body
+    assert "既存 SaaS で 30 分以内に置換可能" in text_body
+
+    # Vault 直リンクが両 part に含まれる。
+    assert "obsidian://open?vault=Obsidan-workspace" in text_body
+    # HTML 側は href 内に乗る (& は &amp; に escape されている)。
+    assert "obsidian://open?vault=Obsidan-workspace" in html_body
+    assert "&amp;file=" in html_body
+
+    # 装飾レイヤ: saturated color / 絵文字を避ける (design-system 準拠)。
+    assert "rgb(255" not in html_body  # 鮮色 RGB を直書きしていない
+    assert "🟢" not in html_body and "🔴" not in html_body
+    assert "🟢" not in text_body and "🔴" not in text_body
+
+
+# ----------------------------------------------------------------------
+# Case 2: 空週 (patterns 0)
+# ----------------------------------------------------------------------
+
+
+def test_empty_week_digest_should_skip_and_renders_safely() -> None:
+    digest = Digest(week_iso=WEEK, sections=[])
+    assert digest.total_candidates == 0
+    assert digest.should_skip is True
+
+    # 念のため、render 関数自体は (呼ばれても) 例外で落ちない。
+    text_body = render_plain_text(digest)
+    assert WEEK in text_body
+    html_body = render_html(digest)
+    assert WEEK in html_body
+
+
+# ----------------------------------------------------------------------
+# Case 3: verdict 未付与のみ
+# ----------------------------------------------------------------------
+
+
+def test_only_unverdicted_candidates_skip_but_pattern_rendered_empty() -> None:
+    """3 patterns あっても verdict 候補ゼロなら skip 判定。
+
+    ただし render 自体は落ちず、各 section に「verdict 付き候補なし」相当
+    の文言が出ていることを確認する。
+    """
+    conn = FakeConn(
+        patterns=[
+            PatternRow(
+                id="p-1",
+                week_iso=WEEK,
+                pain="pain-A",
+                categories=[],
+                frequency=10,
+                source_diversity=2,
+                confidence=0.8,
+            ),
+            PatternRow(
+                id="p-2",
+                week_iso=WEEK,
+                pain="pain-B",
+                categories=[],
+                frequency=5,
+                source_diversity=2,
+                confidence=0.6,
+            ),
+        ],
+        candidates=[
+            # critic_verdict=None → fetch_verdict_candidates でフィルタされる
+            CandidateRow(
+                id=10,
+                pattern_id="p-1",
+                name="未 verdict 候補",
+                critic_verdict=None,
+            ),
+        ],
+    )
+    digest = build_digest(conn, WEEK)
+    # patterns は 2 件、candidates は ゼロ。
+    assert len(digest.sections) == 2
+    assert digest.total_candidates == 0
+    assert digest.should_skip is True
+
+    text_body = render_plain_text(digest)
+    html_body = render_html(digest)
+
+    # 各 section に「verdict 付き候補なし」表記が出る (本文に登場すること)。
+    assert text_body.count("verdict 付き候補なし") == 2
+    assert html_body.count("verdict 付き候補なし") == 2
+
+    # pattern pain は両 part に。
+    for fragment in ("pain-A", "pain-B"):
+        assert fragment in text_body
+        assert fragment in html_body

--- a/tests/idea_mining/test_extractor.py
+++ b/tests/idea_mining/test_extractor.py
@@ -1,0 +1,653 @@
+"""Tests for `idea_mining.extractor` (voices → patterns via Haiku).
+
+External services (Anthropic / Neon / Sentry) は全部モック。実 Haiku は
+叩かない。DB は in-memory fake で代用し、SQL contract (ON CONFLICT
+(week_iso, pain) DO UPDATE) は SQL 文字列レベルで確認する。
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from idea_mining import extractor as extractor_mod
+from idea_mining.extractor import (
+    CLAUDE_MODEL,
+    LOW_DIVERSITY_CONFIDENCE_CAP,
+    MIN_FREQUENCY,
+    UPSERT_PATTERN_SQL,
+    current_week_iso,
+    filter_and_clamp,
+    parse_haiku_response,
+    run_once,
+    upsert_patterns,
+)
+from idea_mining.prompts.extractor import SYSTEM_PROMPT
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+VOICE_ID_1 = "11111111-1111-1111-1111-111111111111"
+VOICE_ID_2 = "22222222-2222-2222-2222-222222222222"
+VOICE_ID_3 = "33333333-3333-3333-3333-333333333333"
+ALL_VOICE_IDS = {VOICE_ID_1, VOICE_ID_2, VOICE_ID_3}
+
+
+# ----------------------------------------------------------------------
+# Fake DB infra (in-memory psycopg-shaped conn)
+# ----------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self, fake_conn: "_FakeConn") -> None:
+        self._fake_conn = fake_conn
+        self.executed: list[tuple[str, dict[str, Any] | tuple[Any, ...] | None]] = []
+        self.rowcount: int = 0
+        self._select_result: list[tuple[Any, ...]] = []
+
+    def execute(
+        self, sql: str, params: dict[str, Any] | tuple[Any, ...] | None = None
+    ) -> None:
+        self.executed.append((sql, params))
+        normalized = " ".join(sql.split()).lower()
+        if normalized.startswith("select"):
+            self._select_result = list(self._fake_conn.voices_rows)
+            self.rowcount = len(self._select_result)
+            return
+        if "insert into patterns" in normalized:
+            assert isinstance(params, dict)
+            key = (params["week_iso"], params["pain"])
+            row = {
+                "week_iso": params["week_iso"],
+                "pain": params["pain"],
+                "categories": list(params["categories"]),
+                "frequency": params["frequency"],
+                "source_diversity": params["source_diversity"],
+                "representative_voices": list(params["representative_voices"]),
+                "confidence": params["confidence"],
+                "meta": params["meta"],
+            }
+            if key in self._fake_conn.patterns_by_key:
+                self._fake_conn.patterns_by_key[key].update(row)
+                self._fake_conn.update_count += 1
+            else:
+                self._fake_conn.patterns_by_key[key] = row
+                self._fake_conn.insert_count += 1
+            self.rowcount = 1
+            return
+        self.rowcount = 0
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        return list(self._select_result)
+
+    def __enter__(self) -> "_FakeCursor":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+class _FakeConn:
+    def __init__(self, voices_rows: list[tuple[Any, ...]] | None = None) -> None:
+        self.voices_rows: list[tuple[Any, ...]] = list(voices_rows or [])
+        self.patterns_by_key: dict[tuple[str, str], dict[str, Any]] = {}
+        self.insert_count = 0
+        self.update_count = 0
+        self.commits = 0
+        self._last_cursor: _FakeCursor | None = None
+
+    def cursor(self) -> _FakeCursor:
+        cur = _FakeCursor(self)
+        self._last_cursor = cur
+        return cur
+
+    def commit(self) -> None:
+        self.commits += 1
+
+
+# ----------------------------------------------------------------------
+# Haiku response builders
+# ----------------------------------------------------------------------
+
+
+def _pattern(
+    *,
+    pain: str,
+    frequency: int = 3,
+    source_diversity: int = 2,
+    representative_voices: list[str] | None = None,
+    confidence: float = 0.8,
+    categories: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "pain": pain,
+        "categories": categories if categories is not None else ["productivity"],
+        "frequency": frequency,
+        "source_diversity": source_diversity,
+        "representative_voices": (
+            representative_voices
+            if representative_voices is not None
+            else [VOICE_ID_1, VOICE_ID_2, VOICE_ID_3]
+        ),
+        "confidence": confidence,
+    }
+
+
+def _haiku_payload(patterns: list[dict[str, Any]]) -> str:
+    return json.dumps({"patterns": patterns}, ensure_ascii=False)
+
+
+class _FakeMessages:
+    def __init__(self, text: str, recorder: list[dict[str, Any]]) -> None:
+        self._text = text
+        self._recorder = recorder
+
+    def create(self, **kwargs: Any) -> Any:
+        self._recorder.append(kwargs)
+
+        class _Block:
+            def __init__(self, text: str) -> None:
+                self.text = text
+
+        class _Resp:
+            def __init__(self, blocks: list[_Block]) -> None:
+                self.content = blocks
+
+        return _Resp([_Block(self._text)])
+
+
+class _FakeAnthropic:
+    def __init__(self, text: str) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.messages = _FakeMessages(text, self.calls)
+
+
+# ----------------------------------------------------------------------
+# Migration 009 schema check
+# ----------------------------------------------------------------------
+
+
+def test_migration_009_defines_patterns_table_with_unique_and_indexes() -> None:
+    sql_path = REPO_ROOT / "migrations" / "009_patterns.sql"
+    sql = sql_path.read_text(encoding="utf-8").lower()
+
+    assert "create table if not exists patterns" in sql
+    # Required columns called out in the acceptance criteria.
+    for col in (
+        "week_iso",
+        "pain",
+        "categories",
+        "frequency",
+        "source_diversity",
+        "representative_voices",
+        "confidence",
+    ):
+        assert col in sql, f"migration 009 missing column: {col}"
+    # representative_voices must be a UUID array.
+    assert re.search(r"representative_voices\s+uuid\[\]", sql), (
+        "representative_voices must be declared as uuid[]"
+    )
+    # categories must be a TEXT array.
+    assert re.search(r"categories\s+text\[\]", sql), (
+        "categories must be declared as text[]"
+    )
+    # UNIQUE (week_iso, pain) — the upsert hinge.
+    assert re.search(
+        r"create unique index.*?patterns.*?\(\s*week_iso\s*,\s*pain\s*\)",
+        sql,
+        flags=re.DOTALL,
+    ), "patterns UNIQUE (week_iso, pain) index not found"
+    # Required helper index.
+    assert "idx_patterns_week" in sql
+
+
+# ----------------------------------------------------------------------
+# week_iso generator
+# ----------------------------------------------------------------------
+
+
+def test_current_week_iso_uses_iso_calendar_yyyy_www_format() -> None:
+    from datetime import datetime, timezone
+
+    # Mid-week (Wednesday) so week boundaries don't trip us up.
+    fixed = datetime(2026, 5, 20, 12, 0, 0, tzinfo=timezone.utc)
+    iso = fixed.isocalendar()
+    assert current_week_iso(fixed) == f"{iso.year:04d}-W{iso.week:02d}"
+
+
+def test_current_week_iso_zero_pads_single_digit_week() -> None:
+    from datetime import datetime, timezone
+
+    fixed = datetime(2026, 1, 7, 12, 0, 0, tzinfo=timezone.utc)
+    out = current_week_iso(fixed)
+    assert re.fullmatch(r"\d{4}-W\d{2}", out), out
+
+
+def test_current_week_iso_defaults_to_now_utc(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from datetime import datetime, timezone
+
+    fixed = datetime(2026, 5, 20, 12, 0, 0, tzinfo=timezone.utc)
+
+    class _FakeDT:
+        @classmethod
+        def now(cls, tz: Any = None) -> datetime:
+            assert tz is timezone.utc
+            return fixed
+
+    monkeypatch.setattr(extractor_mod, "datetime", _FakeDT)
+    iso = fixed.isocalendar()
+    assert current_week_iso() == f"{iso.year:04d}-W{iso.week:02d}"
+
+
+# ----------------------------------------------------------------------
+# parse_haiku_response
+# ----------------------------------------------------------------------
+
+
+def test_parse_haiku_response_accepts_clean_json() -> None:
+    raw = _haiku_payload([_pattern(pain="ペイン A")])
+
+    out = parse_haiku_response(raw, voice_ids=ALL_VOICE_IDS)
+
+    assert len(out) == 1
+    assert out[0]["pain"] == "ペイン A"
+    assert out[0]["frequency"] == 3
+    assert out[0]["source_diversity"] == 2
+    assert out[0]["confidence"] == 0.8
+
+
+def test_parse_haiku_response_strips_code_fence_wrapping() -> None:
+    raw = "```json\n" + _haiku_payload([_pattern(pain="x")]) + "\n```"
+
+    out = parse_haiku_response(raw, voice_ids=ALL_VOICE_IDS)
+
+    assert len(out) == 1
+
+
+def test_parse_haiku_response_drops_unknown_voice_uuids() -> None:
+    unknown_uuid = "99999999-9999-9999-9999-999999999999"
+    raw = _haiku_payload(
+        [_pattern(pain="x", representative_voices=[VOICE_ID_1, unknown_uuid])]
+    )
+
+    out = parse_haiku_response(raw, voice_ids=ALL_VOICE_IDS)
+
+    assert out[0]["representative_voices"] == [VOICE_ID_1]
+
+
+def test_parse_haiku_response_raises_on_non_json_text() -> None:
+    with pytest.raises(ValueError):
+        parse_haiku_response("not json at all", voice_ids=ALL_VOICE_IDS)
+
+
+def test_parse_haiku_response_raises_on_missing_patterns_key() -> None:
+    with pytest.raises(ValueError):
+        parse_haiku_response('{"foo": []}', voice_ids=ALL_VOICE_IDS)
+
+
+def test_parse_haiku_response_raises_on_invalid_uuid() -> None:
+    raw = _haiku_payload(
+        [_pattern(pain="x", representative_voices=["not-a-uuid"])]
+    )
+
+    with pytest.raises(ValueError):
+        parse_haiku_response(raw, voice_ids=ALL_VOICE_IDS)
+
+
+def test_parse_haiku_response_raises_on_confidence_out_of_range() -> None:
+    raw = _haiku_payload([_pattern(pain="x", confidence=1.5)])
+
+    with pytest.raises(ValueError):
+        parse_haiku_response(raw, voice_ids=ALL_VOICE_IDS)
+
+
+def test_parse_haiku_response_accepts_empty_patterns_list() -> None:
+    assert parse_haiku_response('{"patterns": []}', voice_ids=ALL_VOICE_IDS) == []
+
+
+# ----------------------------------------------------------------------
+# filter_and_clamp
+# ----------------------------------------------------------------------
+
+
+def test_filter_drops_frequency_below_three() -> None:
+    raw = [
+        _pattern(pain="below", frequency=2),
+        _pattern(pain="ok", frequency=MIN_FREQUENCY),
+    ]
+    parsed = parse_haiku_response(_haiku_payload(raw), voice_ids=ALL_VOICE_IDS)
+
+    out = filter_and_clamp(parsed)
+
+    assert {p["pain"] for p in out} == {"ok"}
+
+
+def test_filter_keeps_frequency_at_threshold() -> None:
+    parsed = parse_haiku_response(
+        _haiku_payload([_pattern(pain="threshold", frequency=MIN_FREQUENCY)]),
+        voice_ids=ALL_VOICE_IDS,
+    )
+
+    out = filter_and_clamp(parsed)
+
+    assert len(out) == 1
+
+
+def test_clamp_confidence_when_source_diversity_below_two() -> None:
+    parsed = parse_haiku_response(
+        _haiku_payload(
+            [_pattern(pain="single-source", source_diversity=1, confidence=0.9)]
+        ),
+        voice_ids=ALL_VOICE_IDS,
+    )
+
+    out = filter_and_clamp(parsed)
+
+    assert out[0]["confidence"] == LOW_DIVERSITY_CONFIDENCE_CAP
+
+
+def test_clamp_does_not_raise_already_low_confidence() -> None:
+    parsed = parse_haiku_response(
+        _haiku_payload(
+            [_pattern(pain="single-source", source_diversity=1, confidence=0.2)]
+        ),
+        voice_ids=ALL_VOICE_IDS,
+    )
+
+    out = filter_and_clamp(parsed)
+
+    assert out[0]["confidence"] == pytest.approx(0.2)
+
+
+def test_clamp_skipped_when_source_diversity_two_or_more() -> None:
+    parsed = parse_haiku_response(
+        _haiku_payload(
+            [_pattern(pain="diverse", source_diversity=2, confidence=0.95)]
+        ),
+        voice_ids=ALL_VOICE_IDS,
+    )
+
+    out = filter_and_clamp(parsed)
+
+    assert out[0]["confidence"] == pytest.approx(0.95)
+
+
+# ----------------------------------------------------------------------
+# Upsert SQL contract
+# ----------------------------------------------------------------------
+
+
+def test_upsert_sql_uses_on_conflict_week_iso_pain_do_update() -> None:
+    normalized = " ".join(UPSERT_PATTERN_SQL.split()).lower()
+    assert "insert into patterns" in normalized
+    assert "on conflict (week_iso, pain) do update" in normalized
+    # The columns that must be refreshed on conflict.
+    for col in (
+        "categories",
+        "frequency",
+        "source_diversity",
+        "representative_voices",
+        "confidence",
+        "updated_at",
+    ):
+        assert col in normalized, f"upsert refresh missing column: {col}"
+
+
+def test_upsert_inserts_once_then_updates_on_second_run() -> None:
+    conn = _FakeConn()
+    patterns = [
+        {
+            "pain": "重複の SaaS 課金がしんどい",
+            "categories": ["finance"],
+            "frequency": 4,
+            "source_diversity": 2,
+            "representative_voices": [VOICE_ID_1, VOICE_ID_2],
+            "confidence": 0.7,
+        }
+    ]
+
+    first = upsert_patterns(
+        conn,  # type: ignore[arg-type]
+        patterns,
+        week_iso="2026-W21",
+        raw_response_snippet="raw1",
+    )
+    # Second call: same key, refreshed numbers.
+    refreshed = [
+        {
+            "pain": "重複の SaaS 課金がしんどい",
+            "categories": ["finance", "subscription"],
+            "frequency": 7,
+            "source_diversity": 3,
+            "representative_voices": [VOICE_ID_1, VOICE_ID_2, VOICE_ID_3],
+            "confidence": 0.85,
+        }
+    ]
+    second = upsert_patterns(
+        conn,  # type: ignore[arg-type]
+        refreshed,
+        week_iso="2026-W21",
+        raw_response_snippet="raw2",
+    )
+
+    assert first == 1
+    assert second == 1
+    # Only one row total — fake DB enforces UNIQUE (week_iso, pain).
+    assert len(conn.patterns_by_key) == 1
+    final = conn.patterns_by_key[("2026-W21", "重複の SaaS 課金がしんどい")]
+    assert final["frequency"] == 7
+    assert final["source_diversity"] == 3
+    assert final["confidence"] == 0.85
+    assert final["categories"] == ["finance", "subscription"]
+    assert conn.insert_count == 1
+    assert conn.update_count == 1
+
+
+# ----------------------------------------------------------------------
+# run_once — soft-fail paths
+# ----------------------------------------------------------------------
+
+
+def test_run_once_returns_zero_when_voices_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _FakeConn(voices_rows=[])
+    client = _FakeAnthropic(text="(should not be called)")
+
+    upserted = run_once(conn, client, week_iso="2026-W21")  # type: ignore[arg-type]
+
+    assert upserted == 0
+    # Haiku must not be called when there are no voices.
+    assert client.calls == []
+    assert conn.patterns_by_key == {}
+
+
+def _voice_row(
+    voice_id: str = VOICE_ID_1,
+    *,
+    source: str = "apple_rss",
+    rating: int = 2,
+) -> tuple[Any, ...]:
+    from datetime import datetime, timezone
+
+    posted_at = datetime(2026, 5, 19, 12, 0, 0, tzinfo=timezone.utc)
+    return (
+        voice_id,
+        source,
+        posted_at,
+        f"title-{voice_id[:4]}",
+        f"body-{voice_id[:4]}",
+        {"rating": rating, "country": "jp", "lang": "ja"},
+    )
+
+
+def test_run_once_exits_zero_on_malformed_haiku_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _FakeConn(voices_rows=[_voice_row()])
+    client = _FakeAnthropic(text="this is not JSON at all")
+
+    sentry_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_capture_message(msg: str, **kwargs: Any) -> None:
+        sentry_calls.append((msg, kwargs))
+
+    monkeypatch.setattr(
+        extractor_mod.sentry_sdk, "capture_message", fake_capture_message
+    )
+
+    upserted = run_once(conn, client, week_iso="2026-W21")  # type: ignore[arg-type]
+
+    assert upserted == 0
+    assert conn.patterns_by_key == {}
+    assert len(sentry_calls) == 1
+    msg, kwargs = sentry_calls[0]
+    assert "malformed" in msg.lower()
+    assert kwargs.get("level") == "warning"
+
+
+def test_run_once_exits_zero_when_only_apple_source_present() -> None:
+    """Apple のみ (source_diversity=1) でも raise せず exit 0。"""
+    conn = _FakeConn(
+        voices_rows=[
+            _voice_row(VOICE_ID_1, source="apple_rss"),
+            _voice_row(VOICE_ID_2, source="apple_rss"),
+            _voice_row(VOICE_ID_3, source="apple_rss"),
+        ]
+    )
+    # Haiku returns a single pattern with source_diversity=1.
+    payload = _haiku_payload(
+        [_pattern(pain="apple-only", source_diversity=1, confidence=0.9)]
+    )
+    client = _FakeAnthropic(text=payload)
+
+    upserted = run_once(conn, client, week_iso="2026-W21")  # type: ignore[arg-type]
+
+    # Pattern survived frequency >= 3 filter, confidence was clamped.
+    assert upserted == 1
+    row = conn.patterns_by_key[("2026-W21", "apple-only")]
+    assert row["confidence"] == LOW_DIVERSITY_CONFIDENCE_CAP
+
+
+def test_run_once_drops_low_frequency_patterns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _FakeConn(
+        voices_rows=[
+            _voice_row(VOICE_ID_1),
+            _voice_row(VOICE_ID_2),
+            _voice_row(VOICE_ID_3),
+        ]
+    )
+    payload = _haiku_payload(
+        [
+            _pattern(pain="below", frequency=2),
+            _pattern(pain="ok", frequency=3),
+        ]
+    )
+    client = _FakeAnthropic(text=payload)
+
+    upserted = run_once(conn, client, week_iso="2026-W21")  # type: ignore[arg-type]
+
+    assert upserted == 1
+    assert set(conn.patterns_by_key.keys()) == {("2026-W21", "ok")}
+
+
+def test_run_once_passes_system_prompt_to_haiku() -> None:
+    conn = _FakeConn(voices_rows=[_voice_row()])
+    payload = _haiku_payload([_pattern(pain="x")])
+    client = _FakeAnthropic(text=payload)
+
+    run_once(conn, client, week_iso="2026-W21")  # type: ignore[arg-type]
+
+    assert len(client.calls) == 1
+    call = client.calls[0]
+    assert call["model"] == CLAUDE_MODEL
+    assert call["system"] == SYSTEM_PROMPT
+
+
+# ----------------------------------------------------------------------
+# Workflow YAML cron schedule
+# ----------------------------------------------------------------------
+
+
+def test_workflow_cron_runs_tue_thu_sat_at_03_utc() -> None:
+    import yaml as _yaml
+
+    wf_path = REPO_ROOT / ".github" / "workflows" / "idea-mining-extractor.yml"
+    # PyYAML treats bare `on` as Python True — feed via safe_load and accept either key.
+    parsed = _yaml.safe_load(wf_path.read_text(encoding="utf-8"))
+    triggers = parsed.get("on") if "on" in parsed else parsed.get(True)
+    assert isinstance(triggers, dict), f"workflow 'on' block missing: {parsed!r}"
+    schedules = triggers["schedule"]
+    crons = [item["cron"] for item in schedules]
+    assert "0 3 * * 2,4,6" in crons
+    assert "workflow_dispatch" in triggers
+
+
+def test_workflow_passes_anthropic_api_key_env() -> None:
+    wf_path = REPO_ROOT / ".github" / "workflows" / "idea-mining-extractor.yml"
+    text = wf_path.read_text(encoding="utf-8")
+    assert "ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}" in text
+
+
+# ----------------------------------------------------------------------
+# SYSTEM_PROMPT snapshot
+# ----------------------------------------------------------------------
+
+
+SYSTEM_PROMPT_SNAPSHOT: str = """あなたは Hibi のアイデアマイニング担当のアナリストです。
+
+与えられる入力は、過去 7 日に集めた個人開発者向けプロダクトに対する ★1-4 のユーザーレビュー (`voices`) のリストです。
+各 voice には id (UUID)、source (e.g. 'apple_rss')、posted_at、title、body、rating が含まれます。
+
+あなたのタスクは、これらの voice を「構造的なペイン (pain)」単位でクラスタリングし、JSON のみで返すことです。
+
+クラスタリングの方針:
+- pain は「あるプロダクト名固有の不満」ではなく、「個人開発者が複数のプロダクトで繰り返し直面しうる構造」として抽出する。
+- 同じ構造のペインは違うプロダクト・違う表現でも 1 つの pain にまとめる。
+- 表面的なバグ報告 (e.g. 「クラッシュした」「起動しない」) は構造的ペインではないため除外する。
+- 機能要望そのもの (e.g. 「ダークモードが欲しい」) は構造的ペインではないため除外する。
+
+出力スキーマ (JSON のみ。前後に余計な文字・コードブロックを入れない):
+{
+  "patterns": [
+    {
+      "pain": "短く具体的な日本語ラベル。プロダクト名は入れない。",
+      "categories": ["topical-tag-1", "topical-tag-2"],
+      "frequency": 5,
+      "source_diversity": 2,
+      "representative_voices": ["<voice-uuid-1>", "<voice-uuid-2>", "<voice-uuid-3>"],
+      "confidence": 0.8
+    }
+  ]
+}
+
+各フィールドの意味:
+- pain: その構造的ペインの短文ラベル (日本語)。固有名詞を入れない。
+- categories: pain を分類する topical タグの配列。0 件可。
+- frequency: その pain にまとめた voice の総数 (整数)。
+- source_diversity: その pain にまとめた voice の distinct な source 数 (整数)。
+- representative_voices: その pain を代表する voice の id (UUID) の配列。最大 5 件まで。入力に存在する id のみ使う。
+- confidence: 0.0-1.0 の浮動小数。クラスタの確からしさ。
+
+ルール:
+- frequency が 3 未満になる pain は patterns に含めない (出力から除外する)。
+- source_diversity が 2 未満 (= 1 source のみ) の pain は confidence を 0.5 以下に抑える。
+- 入力 voice が 0 件、あるいは抽出に値する構造的ペインが無い場合は {"patterns": []} を返す。
+- representative_voices の UUID は入力に実在するものから選ぶ。新たに生成しない。
+- JSON 以外の文字 (前置き、後置き、コードフェンス) を絶対に出力しない。
+"""
+
+
+def test_system_prompt_snapshot() -> None:
+    """SYSTEM_PROMPT contract is intentionally locked verbatim.
+
+    Update SYSTEM_PROMPT_SNAPSHOT only when the team has decided to
+    change the Haiku contract for the extractor.
+    """
+    assert SYSTEM_PROMPT == SYSTEM_PROMPT_SNAPSHOT

--- a/tests/idea_mining/test_ideator_db.py
+++ b/tests/idea_mining/test_ideator_db.py
@@ -1,0 +1,408 @@
+"""Tests for `idea_mining.ideator` E2E candidate insertion path.
+
+Anthropic / Neon は in-memory fake で代用。Issue #138 acceptance: 1 pattern
+あたり 5-10 件の候補を candidates テーブルへ insert する。SQL contract は
+INSERT 文字列レベルで確認する。
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from idea_mining.ideator import (
+    CLAUDE_MODEL,
+    INSERT_CANDIDATE_SQL,
+    SELECT_PATTERN_SQL,
+    insert_candidates,
+    run_for_pattern,
+)
+
+
+PATTERN_ID = "11111111-1111-1111-1111-111111111111"
+PATTERN_PAIN = "重複の SaaS 課金がしんどい"
+
+PROFILE_FIXTURE = """\
+# User Constraints
+- 必須項目: 個人プロジェクト前提
+
+# Negative Examples
+## Aesthetic OS
+- 理由: コンセプト先行
+"""
+
+
+# ----------------------------------------------------------------------
+# Fake psycopg-shaped connection
+# ----------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self, fake_conn: "_FakeConn") -> None:
+        self._fake_conn = fake_conn
+        self.executed: list[tuple[str, Any]] = []
+        self._select_result: list[tuple[Any, ...]] = []
+        self.rowcount: int = 0
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+        self._fake_conn.executed.append((sql, params))
+        normalized = " ".join(sql.split()).lower()
+        if "from patterns" in normalized and "select" in normalized:
+            assert isinstance(params, tuple)
+            pid = params[0]
+            if pid in self._fake_conn.patterns_by_id:
+                row = self._fake_conn.patterns_by_id[pid]
+                self._select_result = [row]
+                self.rowcount = 1
+            else:
+                self._select_result = []
+                self.rowcount = 0
+            return
+        if "insert into candidates" in normalized:
+            assert isinstance(params, dict)
+            self._fake_conn.candidates_inserted.append(dict(params))
+            self.rowcount = 1
+            return
+        self.rowcount = 0
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return self._select_result[0] if self._select_result else None
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        return list(self._select_result)
+
+    def __enter__(self) -> "_FakeCursor":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+class _FakeConn:
+    def __init__(
+        self, patterns_by_id: dict[str, tuple[Any, ...]] | None = None
+    ) -> None:
+        self.patterns_by_id: dict[str, tuple[Any, ...]] = dict(
+            patterns_by_id or {}
+        )
+        self.candidates_inserted: list[dict[str, Any]] = []
+        self.executed: list[tuple[str, Any]] = []
+        self.commits = 0
+
+    def cursor(self) -> _FakeCursor:
+        return _FakeCursor(self)
+
+    def commit(self) -> None:
+        self.commits += 1
+
+
+# ----------------------------------------------------------------------
+# Fake Anthropic
+# ----------------------------------------------------------------------
+
+
+class _FakeMessages:
+    def __init__(self, text: str, recorder: list[dict[str, Any]]) -> None:
+        self._text = text
+        self._recorder = recorder
+
+    def create(self, **kwargs: Any) -> Any:
+        self._recorder.append(kwargs)
+
+        class _Block:
+            def __init__(self, text: str) -> None:
+                self.text = text
+
+        class _Resp:
+            def __init__(self, blocks: list[_Block]) -> None:
+                self.content = blocks
+
+        return _Resp([_Block(self._text)])
+
+
+class _FakeAnthropic:
+    def __init__(self, text: str) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.messages = _FakeMessages(text, self.calls)
+
+
+# ----------------------------------------------------------------------
+# Response builders
+# ----------------------------------------------------------------------
+
+
+def _candidate(name: str, **overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "name": name,
+        "one_liner": f"{name} の 1 行説明",
+        "target_user": "個人開発者",
+        "monetization": "subscription",
+        "llm_moat_conditions": ["workflow", "data"],
+        "why_different": "コンセプト先行ではなく実運用ログから始まる",
+        "estimated_mvp_hours": 40,
+        "killer_use_case": "実運用での反復ログ",
+    }
+    base.update(overrides)
+    return base
+
+
+def _opus_payload(candidates: list[dict[str, Any]]) -> str:
+    return json.dumps({"candidates": candidates}, ensure_ascii=False)
+
+
+def _make_pattern_row(pattern_id: str = PATTERN_ID) -> tuple[Any, ...]:
+    return (pattern_id, PATTERN_PAIN)
+
+
+# ----------------------------------------------------------------------
+# SQL contracts
+# ----------------------------------------------------------------------
+
+
+def test_select_pattern_sql_is_a_safe_param_query() -> None:
+    normalized = " ".join(SELECT_PATTERN_SQL.split()).lower()
+    assert normalized.startswith("select id, pain from patterns where id = %s")
+
+
+def test_insert_candidate_sql_lists_all_required_columns() -> None:
+    normalized = " ".join(INSERT_CANDIDATE_SQL.split()).lower()
+    assert "insert into candidates" in normalized
+    for col in (
+        "spot_id",
+        "pattern_id",
+        "name",
+        "one_liner",
+        "target_user",
+        "monetization",
+        "llm_moat_conditions",
+        "why_different",
+        "estimated_mvp_hours",
+        "killer_use_case",
+    ):
+        assert col in normalized, f"INSERT missing column: {col}"
+
+
+def test_insert_candidate_sql_uses_named_parameters() -> None:
+    for placeholder in (
+        "%(spot_id)s",
+        "%(pattern_id)s",
+        "%(name)s",
+        "%(monetization)s",
+        "%(llm_moat_conditions)s",
+    ):
+        assert placeholder in INSERT_CANDIDATE_SQL
+
+
+# ----------------------------------------------------------------------
+# insert_candidates
+# ----------------------------------------------------------------------
+
+
+def test_insert_candidates_writes_each_row_and_commits_once() -> None:
+    conn = _FakeConn()
+    candidates = [
+        {
+            "name": f"Candidate {i}",
+            "one_liner": "1 行",
+            "target_user": "個人開発者",
+            "monetization": "subscription",
+            "llm_moat_conditions": ["workflow", "data"],
+            "why_different": "...",
+            "estimated_mvp_hours": 40,
+            "killer_use_case": "...",
+        }
+        for i in range(5)
+    ]
+
+    inserted = insert_candidates(conn, candidates, pattern_id=PATTERN_ID)  # type: ignore[arg-type]
+
+    assert inserted == 5
+    assert len(conn.candidates_inserted) == 5
+    assert conn.commits == 1
+    # Every row references the input pattern_id.
+    assert all(row["pattern_id"] == PATTERN_ID for row in conn.candidates_inserted)
+    # spot_id must remain null in Phase 0.
+    assert all(row["spot_id"] is None for row in conn.candidates_inserted)
+
+
+def test_insert_candidates_passes_arrays_as_lists() -> None:
+    conn = _FakeConn()
+    candidates = [
+        {
+            "name": "x",
+            "one_liner": "y",
+            "target_user": "z",
+            "monetization": "subscription",
+            "llm_moat_conditions": ["workflow", "data", "trust"],
+            "why_different": None,
+            "estimated_mvp_hours": None,
+            "killer_use_case": None,
+        }
+    ]
+
+    insert_candidates(conn, candidates, pattern_id=PATTERN_ID)  # type: ignore[arg-type]
+
+    assert conn.candidates_inserted[0]["llm_moat_conditions"] == [
+        "workflow",
+        "data",
+        "trust",
+    ]
+
+
+def test_insert_candidates_returns_zero_when_empty_list() -> None:
+    conn = _FakeConn()
+
+    inserted = insert_candidates(conn, [], pattern_id=PATTERN_ID)  # type: ignore[arg-type]
+
+    assert inserted == 0
+    assert conn.candidates_inserted == []
+    assert conn.commits == 0
+
+
+# ----------------------------------------------------------------------
+# run_for_pattern — full path
+# ----------------------------------------------------------------------
+
+
+def test_run_for_pattern_inserts_5_candidates_min(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _FakeConn(patterns_by_id={PATTERN_ID: _make_pattern_row()})
+    payload = _opus_payload([_candidate(f"Cand-{i}") for i in range(5)])
+    client = _FakeAnthropic(text=payload)
+
+    inserted = run_for_pattern(
+        conn,  # type: ignore[arg-type]
+        client,  # type: ignore[arg-type]
+        pattern_id=PATTERN_ID,
+        profile_block=PROFILE_FIXTURE,
+    )
+
+    assert inserted == 5
+    assert len(conn.candidates_inserted) == 5
+    # Opus was called exactly once, with Opus model id.
+    assert len(client.calls) == 1
+    assert client.calls[0]["model"] == CLAUDE_MODEL
+
+
+def test_run_for_pattern_inserts_up_to_10_candidates() -> None:
+    conn = _FakeConn(patterns_by_id={PATTERN_ID: _make_pattern_row()})
+    payload = _opus_payload([_candidate(f"Cand-{i}") for i in range(10)])
+    client = _FakeAnthropic(text=payload)
+
+    inserted = run_for_pattern(
+        conn,  # type: ignore[arg-type]
+        client,  # type: ignore[arg-type]
+        pattern_id=PATTERN_ID,
+        profile_block=PROFILE_FIXTURE,
+    )
+
+    assert inserted == 10
+
+
+def test_run_for_pattern_calls_opus_with_profile_in_system_prompt() -> None:
+    conn = _FakeConn(patterns_by_id={PATTERN_ID: _make_pattern_row()})
+    payload = _opus_payload([_candidate(f"Cand-{i}") for i in range(5)])
+    client = _FakeAnthropic(text=payload)
+
+    run_for_pattern(
+        conn,  # type: ignore[arg-type]
+        client,  # type: ignore[arg-type]
+        pattern_id=PATTERN_ID,
+        profile_block=PROFILE_FIXTURE,
+    )
+
+    call = client.calls[0]
+    assert "必須項目: 個人プロジェクト前提" in call["system"]
+    assert "Aesthetic OS" in call["system"]
+    # pattern.pain is delivered in the user message.
+    user_content = call["messages"][0]["content"]
+    assert PATTERN_PAIN in user_content
+
+
+def test_run_for_pattern_skips_when_pattern_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _FakeConn(patterns_by_id={})  # no rows
+    client = _FakeAnthropic(text="(should not be called)")
+
+    captured: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_capture(msg: str, **kwargs: Any) -> None:
+        captured.append((msg, kwargs))
+
+    from idea_mining import ideator as ideator_mod
+
+    monkeypatch.setattr(
+        ideator_mod.sentry_sdk, "capture_message", fake_capture
+    )
+
+    inserted = run_for_pattern(
+        conn,  # type: ignore[arg-type]
+        client,  # type: ignore[arg-type]
+        pattern_id=PATTERN_ID,
+        profile_block=PROFILE_FIXTURE,
+    )
+
+    assert inserted == 0
+    assert client.calls == []
+    assert conn.candidates_inserted == []
+    assert len(captured) == 1
+    assert "pattern not found" in captured[0][0]
+
+
+def test_run_for_pattern_returns_zero_on_malformed_opus_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _FakeConn(patterns_by_id={PATTERN_ID: _make_pattern_row()})
+    client = _FakeAnthropic(text="not JSON at all")
+
+    captured: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_capture(msg: str, **kwargs: Any) -> None:
+        captured.append((msg, kwargs))
+
+    from idea_mining import ideator as ideator_mod
+
+    monkeypatch.setattr(
+        ideator_mod.sentry_sdk, "capture_message", fake_capture
+    )
+
+    inserted = run_for_pattern(
+        conn,  # type: ignore[arg-type]
+        client,  # type: ignore[arg-type]
+        pattern_id=PATTERN_ID,
+        profile_block=PROFILE_FIXTURE,
+    )
+
+    assert inserted == 0
+    assert conn.candidates_inserted == []
+    assert len(captured) == 1
+    assert "malformed" in captured[0][0].lower()
+
+
+def test_run_for_pattern_drops_invalid_candidates_but_inserts_valid() -> None:
+    conn = _FakeConn(patterns_by_id={PATTERN_ID: _make_pattern_row()})
+    payload = _opus_payload(
+        [
+            _candidate("Good-1"),
+            _candidate("Bad-empty-moat", llm_moat_conditions=[]),
+            _candidate("Bad-bad-monetization", monetization="ads"),
+            _candidate("Good-2"),
+            _candidate("Good-3"),
+        ]
+    )
+    client = _FakeAnthropic(text=payload)
+
+    inserted = run_for_pattern(
+        conn,  # type: ignore[arg-type]
+        client,  # type: ignore[arg-type]
+        pattern_id=PATTERN_ID,
+        profile_block=PROFILE_FIXTURE,
+    )
+
+    assert inserted == 3
+    names = {row["name"] for row in conn.candidates_inserted}
+    assert names == {"Good-1", "Good-2", "Good-3"}

--- a/tests/idea_mining/test_ideator_negative_examples.py
+++ b/tests/idea_mining/test_ideator_negative_examples.py
@@ -1,0 +1,278 @@
+"""Tests for `idea_mining.ideator` negative-examples enforcement.
+
+Issue #138 acceptance: Aesthetic OS と一致または近似する候補が出ないこと
+(negative-examples テストで保証)。
+
+prompt 側に negative-examples を貼っても Opus が稀にすり抜けるため、Python
+側で `name` / `one_liner` への単純な substring フィルタを最終ゲートとして
+持つ。本テストは、(a) extract_negative_example_names が profile から H2
+見出しを拾うこと、(b) validate_candidate が一致候補を reject すること、
+(c) run_for_pattern が混在 mock 応答を捌くことを検証する。
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from idea_mining.ideator import (
+    extract_negative_example_names,
+    run_for_pattern,
+    validate_candidate,
+)
+
+
+PATTERN_ID = "22222222-2222-2222-2222-222222222222"
+PATTERN_PAIN = "個人開発のアイデアが汎用 AI ニュースリーダー化しがち"
+
+PROFILE_WITH_AESTHETIC_OS = """\
+# User Constraints
+
+- 必須項目: 個人プロジェクト前提で運用できること
+- 学習信号はクリックのみ
+
+# Negative Examples
+
+## Aesthetic OS
+- 理由: コンセプトが先行し、実運用での学習信号が貧弱
+
+## Vibe Reader
+- 理由: 汎用ニュースリーダー化、差別化が薄い
+"""
+
+
+# ----------------------------------------------------------------------
+# Negative-name extraction
+# ----------------------------------------------------------------------
+
+
+def test_extract_returns_h2_under_negative_examples_heading() -> None:
+    names = extract_negative_example_names(PROFILE_WITH_AESTHETIC_OS)
+
+    assert "Aesthetic OS" in names
+    assert "Vibe Reader" in names
+
+
+def test_extract_ignores_h2_under_user_constraints_section() -> None:
+    profile = """\
+# User Constraints
+## 必須項目
+- foo
+
+# Negative Examples
+## Aesthetic OS
+- 理由: bar
+"""
+
+    names = extract_negative_example_names(profile)
+
+    assert "必須項目" not in names
+    assert "Aesthetic OS" in names
+
+
+def test_extract_returns_empty_when_no_negative_examples_section() -> None:
+    profile = "# User Constraints\n- foo\n"
+
+    names = extract_negative_example_names(profile)
+
+    assert names == []
+
+
+# ----------------------------------------------------------------------
+# validate_candidate against negative-examples
+# ----------------------------------------------------------------------
+
+
+def _good_candidate(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "name": "Spotline",
+        "one_liner": "ローカル現場の B2B micro-SaaS",
+        "target_user": "個人運送事業者",
+        "monetization": "subscription",
+        "llm_moat_conditions": ["workflow", "data"],
+        "why_different": "実運用ログから始まる",
+        "estimated_mvp_hours": 40,
+        "killer_use_case": "請求書を半自動で締める",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_rejects_candidate_whose_name_is_a_negative_example() -> None:
+    out, reason = validate_candidate(
+        _good_candidate(name="Aesthetic OS"),
+        negative_names=["Aesthetic OS"],
+    )
+
+    assert out is None
+    assert reason is not None
+    assert "negative-example" in reason
+
+
+def test_rejects_candidate_with_case_insensitive_match() -> None:
+    out, reason = validate_candidate(
+        _good_candidate(name="aesthetic os"),
+        negative_names=["Aesthetic OS"],
+    )
+
+    assert out is None
+    assert reason is not None
+
+
+def test_rejects_candidate_when_one_liner_contains_negative_example_name() -> None:
+    out, reason = validate_candidate(
+        _good_candidate(
+            name="MoodKit",
+            one_liner="An Aesthetic OS-style mood archive for indies",
+        ),
+        negative_names=["Aesthetic OS"],
+    )
+
+    assert out is None
+    assert reason is not None
+    assert "Aesthetic OS" in reason
+
+
+def test_accepts_candidate_when_negative_examples_block_is_empty() -> None:
+    out, reason = validate_candidate(
+        _good_candidate(name="Aesthetic OS"),
+        negative_names=[],
+    )
+
+    # With no guards configured, the substring filter is bypassed.
+    # (The prompt is the primary defense; this only confirms the gate is gated.)
+    assert reason is None
+    assert out is not None
+
+
+def test_accepts_unrelated_candidate_when_guards_active() -> None:
+    out, reason = validate_candidate(
+        _good_candidate(name="Spotline"),
+        negative_names=["Aesthetic OS", "Vibe Reader"],
+    )
+
+    assert reason is None
+    assert out is not None
+
+
+# ----------------------------------------------------------------------
+# run_for_pattern E2E with negative-example mixed into the mock response
+# ----------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self, fake_conn: "_FakeConn") -> None:
+        self._fake_conn = fake_conn
+        self._select_result: list[tuple[Any, ...]] = []
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        normalized = " ".join(sql.split()).lower()
+        if "from patterns" in normalized:
+            assert isinstance(params, tuple)
+            pid = params[0]
+            if pid in self._fake_conn.patterns_by_id:
+                self._select_result = [self._fake_conn.patterns_by_id[pid]]
+            else:
+                self._select_result = []
+            return
+        if "insert into candidates" in normalized:
+            assert isinstance(params, dict)
+            self._fake_conn.candidates_inserted.append(dict(params))
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return self._select_result[0] if self._select_result else None
+
+    def __enter__(self) -> "_FakeCursor":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+class _FakeConn:
+    def __init__(self, patterns_by_id: dict[str, tuple[Any, ...]]) -> None:
+        self.patterns_by_id = patterns_by_id
+        self.candidates_inserted: list[dict[str, Any]] = []
+        self.commits = 0
+
+    def cursor(self) -> _FakeCursor:
+        return _FakeCursor(self)
+
+    def commit(self) -> None:
+        self.commits += 1
+
+
+class _FakeMessages:
+    def __init__(self, text: str, recorder: list[dict[str, Any]]) -> None:
+        self._text = text
+        self._recorder = recorder
+
+    def create(self, **kwargs: Any) -> Any:
+        self._recorder.append(kwargs)
+
+        class _Block:
+            def __init__(self, text: str) -> None:
+                self.text = text
+
+        class _Resp:
+            def __init__(self, blocks: list[_Block]) -> None:
+                self.content = blocks
+
+        return _Resp([_Block(self._text)])
+
+
+class _FakeAnthropic:
+    def __init__(self, text: str) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.messages = _FakeMessages(text, self.calls)
+
+
+def _candidate(name: str, **overrides: Any) -> dict[str, Any]:
+    base = {
+        "name": name,
+        "one_liner": f"{name} 1-liner",
+        "target_user": "個人開発者",
+        "monetization": "subscription",
+        "llm_moat_conditions": ["workflow", "data"],
+        "why_different": "実運用ログ駆動",
+        "estimated_mvp_hours": 40,
+        "killer_use_case": "...",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_run_for_pattern_drops_aesthetic_os_lookalike_from_opus_response() -> None:
+    conn = _FakeConn(patterns_by_id={PATTERN_ID: (PATTERN_ID, PATTERN_PAIN)})
+    payload = json.dumps(
+        {
+            "candidates": [
+                _candidate("Spotline"),
+                _candidate("Aesthetic OS"),  # exact match to negative example
+                _candidate(
+                    "MoodArchive",
+                    one_liner="An Aesthetic OS-shaped archive",
+                ),
+                _candidate("Spotline-PRO"),
+                _candidate("Vibe Reader"),  # second negative example
+                _candidate("Spotline-X"),
+            ]
+        },
+        ensure_ascii=False,
+    )
+    client = _FakeAnthropic(text=payload)
+
+    inserted = run_for_pattern(
+        conn,  # type: ignore[arg-type]
+        client,  # type: ignore[arg-type]
+        pattern_id=PATTERN_ID,
+        profile_block=PROFILE_WITH_AESTHETIC_OS,
+    )
+
+    names = {row["name"] for row in conn.candidates_inserted}
+    assert "Aesthetic OS" not in names
+    assert "Vibe Reader" not in names
+    assert "MoodArchive" not in names  # one_liner-side match
+    assert {"Spotline", "Spotline-PRO", "Spotline-X"} <= names
+    assert inserted == 3

--- a/tests/idea_mining/test_ideator_prompt.py
+++ b/tests/idea_mining/test_ideator_prompt.py
@@ -1,0 +1,133 @@
+"""Tests for `idea_mining.ideator` system-prompt assembly.
+
+Issue #138 acceptance: profile/user-constraints.md と
+profile/negative-examples.md を prompt 先頭に必ず注入する。pattern.pain も
+user message に含める。
+"""
+from __future__ import annotations
+
+import pytest
+
+from idea_mining.ideator import (
+    build_system_prompt,
+    build_user_message,
+)
+from idea_mining.prompts.ideator import SYSTEM_PROMPT_TEMPLATE
+
+
+PROFILE_FIXTURE = """\
+# User Constraints
+
+- 必須項目: 個人プロジェクト前提で運用できること
+- 学習信号はクリックのみ
+
+# Negative Examples
+
+## Aesthetic OS
+- 理由: コンセプトが先行し、実運用での学習信号が貧弱
+"""
+
+
+# ----------------------------------------------------------------------
+# build_system_prompt
+# ----------------------------------------------------------------------
+
+
+def test_build_system_prompt_injects_profile_block_at_head() -> None:
+    prompt = build_system_prompt(PROFILE_FIXTURE)
+
+    # Profile block appears literally in the prompt.
+    assert PROFILE_FIXTURE in prompt
+    # The profile is in the *head* of the prompt — before the rule block.
+    profile_idx = prompt.index(PROFILE_FIXTURE)
+    rules_idx = prompt.index("For the input pattern")
+    assert profile_idx < rules_idx, (
+        "profile_block must precede the rule list in the system prompt"
+    )
+
+
+def test_build_system_prompt_contains_user_constraints_marker() -> None:
+    prompt = build_system_prompt(PROFILE_FIXTURE)
+    assert "必須項目: 個人プロジェクト前提で運用できること" in prompt
+
+
+def test_build_system_prompt_contains_negative_examples_marker() -> None:
+    prompt = build_system_prompt(PROFILE_FIXTURE)
+    assert "Aesthetic OS" in prompt
+
+
+def test_build_system_prompt_lists_allowed_monetization_values() -> None:
+    prompt = build_system_prompt(PROFILE_FIXTURE)
+    for value in ("subscription", "one-time", "affiliate", "freemium", "b2b"):
+        assert value in prompt
+
+
+def test_build_system_prompt_lists_allowed_llm_moat_conditions() -> None:
+    prompt = build_system_prompt(PROFILE_FIXTURE)
+    for value in (
+        "workflow",
+        "data",
+        "distribution",
+        "trust",
+        "network",
+        "physical",
+        "regulatory",
+    ):
+        assert value in prompt
+
+
+def test_build_system_prompt_demands_5_to_10_candidates() -> None:
+    prompt = build_system_prompt(PROFILE_FIXTURE)
+    assert "5-10 candidates" in prompt
+
+
+def test_build_system_prompt_rejects_empty_profile() -> None:
+    with pytest.raises(ValueError, match="profile_block is empty"):
+        build_system_prompt("")
+
+
+def test_build_system_prompt_rejects_whitespace_only_profile() -> None:
+    with pytest.raises(ValueError, match="profile_block is empty"):
+        build_system_prompt("   \n\n\t")
+
+
+# ----------------------------------------------------------------------
+# build_user_message
+# ----------------------------------------------------------------------
+
+
+def test_build_user_message_contains_pain() -> None:
+    pattern = {"id": "11111111-1111-1111-1111-111111111111", "pain": "重複の SaaS 課金がしんどい"}
+
+    msg = build_user_message(pattern)
+
+    assert "重複の SaaS 課金がしんどい" in msg
+
+
+def test_build_user_message_asks_for_json_only() -> None:
+    pattern = {"id": "11111111-1111-1111-1111-111111111111", "pain": "x"}
+
+    msg = build_user_message(pattern)
+
+    assert "JSON" in msg
+    assert "candidates" in msg
+
+
+# ----------------------------------------------------------------------
+# Template contract (snapshot-style — guard against drift)
+# ----------------------------------------------------------------------
+
+
+def test_system_prompt_template_contains_single_profile_block_placeholder() -> None:
+    # `.format()` must substitute exactly one {profile_block}; literal braces
+    # in the JSON schema example must stay doubled.
+    assert SYSTEM_PROMPT_TEMPLATE.count("{profile_block}") == 1
+
+
+def test_system_prompt_template_renders_without_keyerror() -> None:
+    # Cheap snapshot: confirms double-braces in the output JSON example are
+    # preserved (otherwise `.format` would KeyError on the embedded keys).
+    rendered = SYSTEM_PROMPT_TEMPLATE.format(profile_block="STUB")
+    assert "STUB" in rendered
+    assert '"candidates"' in rendered
+    assert '"llm_moat_conditions"' in rendered

--- a/tests/idea_mining/test_ideator_validation.py
+++ b/tests/idea_mining/test_ideator_validation.py
@@ -1,0 +1,249 @@
+"""Tests for `idea_mining.ideator.validate_candidate`.
+
+Issue #138 acceptance:
+- llm_moat_conditions が空 / null の候補は insert をスキップしログに残す。
+- llm_moat_conditions は workflow / data / distribution / trust / network /
+  physical / regulatory のいずれかのみ許可する。
+- monetization は subscription / one-time / affiliate / freemium / b2b の
+  いずれかに制約。
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from idea_mining.ideator import (
+    ALLOWED_LLM_MOAT_CONDITIONS,
+    ALLOWED_MONETIZATION,
+    validate_candidate,
+)
+
+
+def _good_candidate(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "name": "Spotline",
+        "one_liner": "ローカル現場の B2B micro-SaaS bus mover",
+        "target_user": "個人運送事業者",
+        "monetization": "subscription",
+        "llm_moat_conditions": ["workflow", "data"],
+        "why_different": "コンセプト先行ではなく実運用ログから始まる",
+        "estimated_mvp_hours": 40,
+        "killer_use_case": "請求書を半自動で締める運用窓",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_valid_candidate_passes() -> None:
+    out, reason = validate_candidate(_good_candidate(), negative_names=[])
+
+    assert reason is None
+    assert out is not None
+    assert out["name"] == "Spotline"
+    assert out["monetization"] == "subscription"
+    assert out["llm_moat_conditions"] == ["workflow", "data"]
+
+
+# ----------------------------------------------------------------------
+# llm_moat_conditions
+# ----------------------------------------------------------------------
+
+
+def test_rejects_empty_llm_moat_conditions() -> None:
+    out, reason = validate_candidate(
+        _good_candidate(llm_moat_conditions=[]), negative_names=[]
+    )
+
+    assert out is None
+    assert reason is not None
+    assert "llm_moat_conditions" in reason
+
+
+def test_rejects_missing_llm_moat_conditions_key() -> None:
+    raw = _good_candidate()
+    del raw["llm_moat_conditions"]
+
+    out, reason = validate_candidate(raw, negative_names=[])
+
+    assert out is None
+    assert reason is not None
+    assert "llm_moat_conditions" in reason
+
+
+def test_rejects_null_llm_moat_conditions() -> None:
+    out, reason = validate_candidate(
+        _good_candidate(llm_moat_conditions=None), negative_names=[]
+    )
+
+    assert out is None
+    assert reason is not None
+    assert "llm_moat_conditions" in reason
+
+
+def test_rejects_invalid_llm_moat_condition_value() -> None:
+    out, reason = validate_candidate(
+        _good_candidate(llm_moat_conditions=["workflow", "vibes"]),
+        negative_names=[],
+    )
+
+    assert out is None
+    assert reason is not None
+    assert "moat" in reason.lower()
+
+
+def test_accepts_all_allowed_llm_moat_conditions() -> None:
+    out, reason = validate_candidate(
+        _good_candidate(llm_moat_conditions=sorted(ALLOWED_LLM_MOAT_CONDITIONS)),
+        negative_names=[],
+    )
+
+    assert reason is None
+    assert out is not None
+
+
+def test_normalizes_llm_moat_condition_casing_and_whitespace() -> None:
+    out, reason = validate_candidate(
+        _good_candidate(llm_moat_conditions=[" Workflow ", "DATA"]),
+        negative_names=[],
+    )
+
+    assert reason is None
+    assert out is not None
+    assert out["llm_moat_conditions"] == ["workflow", "data"]
+
+
+def test_rejects_non_string_in_llm_moat_conditions() -> None:
+    out, reason = validate_candidate(
+        _good_candidate(llm_moat_conditions=["workflow", 7]),
+        negative_names=[],
+    )
+
+    assert out is None
+    assert reason is not None
+    assert "moat" in reason.lower()
+
+
+# ----------------------------------------------------------------------
+# monetization
+# ----------------------------------------------------------------------
+
+
+def test_rejects_invalid_monetization_value() -> None:
+    out, reason = validate_candidate(
+        _good_candidate(monetization="ads"), negative_names=[]
+    )
+
+    assert out is None
+    assert reason is not None
+    assert "monetization" in reason
+
+
+def test_rejects_missing_monetization() -> None:
+    raw = _good_candidate()
+    del raw["monetization"]
+
+    out, reason = validate_candidate(raw, negative_names=[])
+
+    assert out is None
+    assert reason is not None
+    assert "monetization" in reason
+
+
+def test_rejects_null_monetization() -> None:
+    out, reason = validate_candidate(
+        _good_candidate(monetization=None), negative_names=[]
+    )
+
+    assert out is None
+    assert reason is not None
+    assert "monetization" in reason
+
+
+def test_accepts_all_allowed_monetization_values() -> None:
+    for value in sorted(ALLOWED_MONETIZATION):
+        out, reason = validate_candidate(
+            _good_candidate(monetization=value), negative_names=[]
+        )
+
+        assert reason is None, f"{value!r}: {reason}"
+        assert out is not None
+        assert out["monetization"] == value
+
+
+# ----------------------------------------------------------------------
+# name
+# ----------------------------------------------------------------------
+
+
+def test_rejects_empty_name() -> None:
+    out, reason = validate_candidate(
+        _good_candidate(name=""), negative_names=[]
+    )
+
+    assert out is None
+    assert reason is not None
+    assert "name" in reason
+
+
+def test_rejects_whitespace_only_name() -> None:
+    out, reason = validate_candidate(
+        _good_candidate(name="   "), negative_names=[]
+    )
+
+    assert out is None
+    assert reason is not None
+    assert "name" in reason
+
+
+def test_rejects_non_string_name() -> None:
+    out, reason = validate_candidate(
+        _good_candidate(name=123), negative_names=[]
+    )
+
+    assert out is None
+    assert reason is not None
+    assert "name" in reason
+
+
+# ----------------------------------------------------------------------
+# Optional fields type-check
+# ----------------------------------------------------------------------
+
+
+def test_accepts_null_optional_fields() -> None:
+    out, reason = validate_candidate(
+        _good_candidate(
+            one_liner=None,
+            target_user=None,
+            why_different=None,
+            killer_use_case=None,
+            estimated_mvp_hours=None,
+        ),
+        negative_names=[],
+    )
+
+    assert reason is None
+    assert out is not None
+    assert out["one_liner"] is None
+    assert out["estimated_mvp_hours"] is None
+
+
+def test_rejects_non_int_estimated_mvp_hours() -> None:
+    out, reason = validate_candidate(
+        _good_candidate(estimated_mvp_hours="40"), negative_names=[]
+    )
+
+    assert out is None
+    assert reason is not None
+    assert "estimated_mvp_hours" in reason
+
+
+def test_rejects_non_string_one_liner() -> None:
+    out, reason = validate_candidate(
+        _good_candidate(one_liner=42), negative_names=[]
+    )
+
+    assert out is None
+    assert reason is not None
+    assert "one_liner" in reason

--- a/tests/migrations/test_candidates_schema.py
+++ b/tests/migrations/test_candidates_schema.py
@@ -1,0 +1,138 @@
+"""Migration 010 (`candidates`) schema check — SQL string contract.
+
+本テストは Neon を起動せず、`migrations/010_create_candidates.sql` の
+文字列内容のみを検証する。actual schema 適用は Neon SQL Editor で手動。
+
+Issue #138 acceptance: candidates テーブルが additive で新規作成され、
+patterns(id) (uuid) への FK / monetization CHECK / llm_moat_conditions の
+text[] 制約 / critic_verdict 候補値が migration ファイルに含まれる。
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MIGRATION_PATH = REPO_ROOT / "migrations" / "010_create_candidates.sql"
+
+
+def _sql_lower() -> str:
+    return MIGRATION_PATH.read_text(encoding="utf-8").lower()
+
+
+def test_migration_010_creates_candidates_table_idempotently() -> None:
+    assert MIGRATION_PATH.is_file(), f"missing migration file: {MIGRATION_PATH}"
+    sql = _sql_lower()
+    assert "create table if not exists candidates" in sql
+
+
+def test_migration_010_lists_all_required_columns() -> None:
+    sql = _sql_lower()
+    for col in (
+        "id",
+        "spot_id",
+        "pattern_id",
+        "name",
+        "one_liner",
+        "target_user",
+        "monetization",
+        "llm_moat_conditions",
+        "why_different",
+        "estimated_mvp_hours",
+        "killer_use_case",
+        "generated_at",
+        "critic_verdict",
+        "critic_meta",
+    ):
+        assert col in sql, f"migration 010 missing column: {col}"
+
+
+def test_migration_010_uses_bigserial_pk() -> None:
+    sql = _sql_lower()
+    assert re.search(r"\bid\s+bigserial\s+primary\s+key", sql), sql
+
+
+def test_migration_010_pattern_id_is_uuid_fk_to_patterns() -> None:
+    sql = _sql_lower()
+    # pattern_id must be uuid (NOT BIGINT as the Issue draft DDL had — patterns.id is uuid).
+    assert re.search(
+        r"pattern_id\s+uuid\s+not\s+null\s+references\s+patterns\s*\(\s*id\s*\)",
+        sql,
+    ), sql
+
+
+def test_migration_010_spot_id_is_nullable_bigint() -> None:
+    sql = _sql_lower()
+    # Phase 0: nullable bigint, no FK yet.
+    assert re.search(r"spot_id\s+bigint(?!\s+not\s+null)", sql), sql
+    assert "references spots" not in sql
+
+
+def test_migration_010_name_is_not_null() -> None:
+    sql = _sql_lower()
+    assert re.search(r"\bname\s+text\s+not\s+null", sql), sql
+
+
+def test_migration_010_llm_moat_conditions_is_text_array_not_null() -> None:
+    sql = _sql_lower()
+    assert re.search(
+        r"llm_moat_conditions\s+text\[\]\s+not\s+null", sql
+    ), sql
+
+
+def test_migration_010_generated_at_defaults_to_now() -> None:
+    sql = _sql_lower()
+    assert re.search(
+        r"generated_at\s+timestamptz\s+not\s+null\s+default\s+now\(\)",
+        sql,
+    ), sql
+
+
+def test_migration_010_critic_fields_remain_nullable() -> None:
+    sql = _sql_lower()
+    # critic_verdict / critic_meta have no NOT NULL — Issue #139 will write them.
+    assert re.search(r"critic_verdict\s+text(?!\s+not\s+null)", sql), sql
+    assert re.search(r"critic_meta\s+jsonb(?!\s+not\s+null)", sql), sql
+
+
+def test_migration_010_enforces_monetization_enum() -> None:
+    sql = _sql_lower()
+    assert "candidates_monetization_chk" in sql
+    for value in (
+        "'subscription'",
+        "'one-time'",
+        "'affiliate'",
+        "'freemium'",
+        "'b2b'",
+    ):
+        assert value in sql, f"monetization check missing value: {value}"
+
+
+def test_migration_010_enforces_critic_verdict_enum() -> None:
+    sql = _sql_lower()
+    assert "candidates_critic_verdict_chk" in sql
+    for value in ("'go'", "'pending'", "'kill'"):
+        assert value in sql, f"critic_verdict check missing value: {value}"
+
+
+def test_migration_010_creates_helper_indexes() -> None:
+    sql = _sql_lower()
+    assert re.search(
+        r"create index if not exists idx_candidates_pattern_id",
+        sql,
+    ), sql
+    assert re.search(
+        r"create index if not exists idx_candidates_generated_at",
+        sql,
+    ), sql
+
+
+def test_migration_010_does_not_drop_or_alter_other_tables() -> None:
+    """No destructive changes to existing tables (additive-only constraint)."""
+    sql = _sql_lower()
+    assert "drop table" not in sql
+    # ALTER TABLE candidates ... is fine (own table), but never alter
+    # patterns/articles/voices.
+    assert "alter table patterns" not in sql
+    assert "alter table articles" not in sql
+    assert "alter table voices" not in sql

--- a/tests/test_email_sender.py
+++ b/tests/test_email_sender.py
@@ -1,0 +1,73 @@
+"""Tests for the shared Gmail sender (`email_sender`).
+
+Issue #140 で `daily_news.send_email` の Gmail OAuth 認証経路を `email_sender`
+に抽出した。本テストは ``build_message`` の MIME 構造のみを検証する。
+Gmail API 呼び出し / 認証は副作用なので含めない (mock すべきは boundary)。
+"""
+from __future__ import annotations
+
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+from email_sender import build_message
+
+
+def test_build_message_html_only_is_single_text_html_part() -> None:
+    """``text_body=None`` returns a single text/html part (legacy shape)."""
+    msg = build_message(
+        subject="Hibi test",
+        to="kazuki@example.com",
+        html_body="<p>hello</p>",
+    )
+    assert isinstance(msg, MIMEText)
+    assert msg.get_content_type() == "text/html"
+    assert msg["subject"] == "Hibi test"
+    assert msg["to"] == "kazuki@example.com"
+    # HTML body 自体が payload に乗っているはず。
+    payload = msg.get_payload(decode=True)
+    assert isinstance(payload, bytes)
+    assert b"<p>hello</p>" in payload
+
+
+def test_build_message_multipart_has_plain_then_html() -> None:
+    """``text_body`` を渡すと multipart/alternative になり、plain → html
+    の順で attach される (RFC 2046: 末尾が「より豊かな表現」)。
+    """
+    msg = build_message(
+        subject="Hibi digest",
+        to="kazuki@example.com",
+        html_body="<p>こんにちは</p>",
+        text_body="こんにちは",
+    )
+    assert isinstance(msg, MIMEMultipart)
+    assert msg.get_content_type() == "multipart/alternative"
+    assert msg["subject"] == "Hibi digest"
+    assert msg["to"] == "kazuki@example.com"
+
+    parts = msg.get_payload()
+    assert isinstance(parts, list)
+    assert len(parts) == 2
+    plain_part, html_part = parts
+    assert isinstance(plain_part, MIMEText)
+    assert plain_part.get_content_type() == "text/plain"
+    assert isinstance(html_part, MIMEText)
+    assert html_part.get_content_type() == "text/html"
+    # text/plain が先 (= MUA フォールバック)。
+    assert "こんにちは" in plain_part.get_payload(decode=True).decode("utf-8")
+    assert "<p>こんにちは</p>" in html_part.get_payload(decode=True).decode(
+        "utf-8"
+    )
+
+
+def test_build_message_subject_carries_japanese() -> None:
+    """Subject に日本語が乗っても破綻しない (Issue #140 subject 規約)。"""
+    subject = "[Hibi] 今週のアイデア候補 5 件 (2026-W21)"
+    msg = build_message(
+        subject=subject,
+        to="kazuki@example.com",
+        html_body="<p>x</p>",
+        text_body="x",
+    )
+    # email.header 経由で encode されるが、値の round-trip は subject の中身を
+    # 維持していること (Header object 経由でも __str__ で元文字列が戻る)。
+    assert subject in str(msg["subject"])


### PR DESCRIPTION
## Summary

Epic #134 (Personal Idea Mining Phase 0) の全 6 子 issue 統合 PR。21 commits、38 files、+7208 / -43 lines。

| Child | Title | Sub-PR |
|---|---|---|
| #135 | profile loader (Vault 連携) | #141 |
| #136 | Apple iTunes RSS collector → voices | #143 |
| #137 | Extractor (Haiku) → patterns | #144 |
| #138 | Ideator (Opus) → candidates | #146 (#145 から復活) |
| #139 | Critic (Sonnet, adversarial) | #147 |
| #140 | 週次 idea-digest メール送信 | #148 |

## Added (idea-mining pipeline)

```
idea_mining/
├── profile_loader.py           # Vault profile reader (#135)
├── prompts/
│   ├── _profile_block.py       # 全 AI 共通の system prompt 先頭 (#135)
│   ├── extractor.py            # Haiku prompt verbatim (#137)
│   ├── ideator.py              # Opus prompt verbatim (#138)
│   └── critic.py               # Sonnet rubric prompt verbatim (#139)
├── fetchers/apple_rss.py       # Apple App Store RSS → voices (#136)
├── extractor.py                # Haiku batch → patterns (#137)
├── ideator.py                  # Opus batch → candidates (#138)
├── critic.py                   # Sonnet adversarial → critic_verdict UPDATE (#139)
└── digest.py                   # 週次メール送信 (#140)

migrations/
├── 008_voices.sql              # voices テーブル (#136)
├── 009_create_patterns.sql     # patterns テーブル (#137)
└── 010_create_candidates.sql   # candidates テーブル + critic_* カラム (#138)

.github/workflows/
├── idea-mining-weekly.yml      # 月 14:00 UTC: collector (#136)
├── idea-mining-extractor.yml   # 火/木/土 03:00 UTC: extractor (#137)
├── idea-mining-critic.yml      # critic workflow (#139)
└── idea-mining-digest.yml      # 週次 digest メール (#140)

email_sender.py                 # 共通 mailer (#140)

tests/idea_mining/...           # 各 AI 用 unit tests
tests/migrations/...            # schema tests
```

## Manager infrastructure 改修も同梱 (Epic #134 進行中に蓄積)

- `feat(manager): stacked child branches + TRIAGE caution acceptance` (97cccc5)
- `feat(manager,slash): switch to flat PR design (base = epic always)` (0cb8fa4)
- `feat(manager): accept 'confirm first' plan recommendation, IMPLEMENT 進入` (d105309)
- `feat(manager): accept 'proceed with caution' plans without halting` (6295a31)
- `feat(manager): accept 'confirm before merge' verdict + bold markdown in parser` (277668d)
- `feat(pr-creation): force epic branch as PR base when child branch detected` (2cd76d7、PR #142 由来)
- `fix(manager/parsers): tolerate YAML-significant chars in packet list items` (b05ab3d)
- `fix(manager/parsers): always quote list items in fallback` (bf6baca)
- `fix(manager/parsers): quote top-level string fields with embedded colons` (7f82273)
- `fix(manager): measure child diff against stacked base, not epic` (85b8c01)

## Legal

- `docs/legal-posture.md` §5.5 (idea-mining は newspaper パイプライン外、§5 保留対象外) を追加 (2304ea5)
- Apple iTunes RSS は公式 API / UGC で著作権訴訟射程外、private 保管のみ

## Cost (build-time, Claude Max 経由)

- 6 子合計: **$31.72** (#136 と #138 は parser bug 由来の retry 込み)
- 次 epic では `_STAGE_MODEL` 導入で半額目標 (memory `project_cost_strategy.md`)

## Runtime cost 方針

- Phase 0 (本 PR の運用): Claude Code Schedule + Max で $0/月
- 将来 Mac Mini + Ollama 移行検討
- 詳細: memory `project_cost_strategy.md`

## Test plan

- [ ] CI で pytest pass 確認
- [ ] `migrations/008_voices.sql` / `009_create_patterns.sql` / `010_create_candidates.sql` を Neon SQL Editor で順次 apply (idempotent)
- [ ] `idea-mining-weekly.yml` を `workflow_dispatch` で 1 回起動 → `voices` 行が入ること、★5 が混じらないこと
- [ ] `idea-mining-extractor.yml` を `workflow_dispatch` → patterns に frequency≥3 の pain が入ること
- [ ] `idea-mining-critic.yml` を `workflow_dispatch` → critic_verdict が UPDATE されること
- [ ] `idea-mining-digest.yml` を `workflow_dispatch` → メール 1 通受信
- [ ] 既存 daily 13:17 UTC pipeline / articles / clicks / web archive が変更されていないこと

Closes #134
Refs #135 #136 #137 #138 #139 #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)