### PR TITLE
feat(idea-mining-collector): switch voices source from Apple RSS to AppFollow Free (#150)

### DIFF
--- a/.github/workflows/idea-mining-weekly.yml
+++ b/.github/workflows/idea-mining-weekly.yml
@@ -2,11 +2,16 @@ name: Idea Mining Weekly
 
 # idea-mining 用の private fetcher を週次で走らせる。
 #
-# 現状は Apple iTunes RSS (★1-4 customer reviews → voices) のみ。
+# 2026-05-21: Apple iTunes Customer Reviews RSS が死状態に陥ったため
+# (Issue #150, ADR: 10_projects/idea-mining/decisions/2026-05-21-appfollow-free-personal-use.md)
+# AppFollow Free API (★1-4 customer reviews → voices) に切り替えた。
+# 旧 apple_rss step は実装を残置 (将来 Apple RSS 復活時の参照) するが
+# 本 workflow からは呼ばない。
+#
 # newspaper pipeline (`daily-news.yml`) とは完全に分離していて、
 # 失敗してもニュースレターには影響しない。
 #
-# 関連: Issue #136, idea_mining/fetchers/apple_rss.py, migration 008.
+# 関連: Issue #150, idea_mining/fetchers/appfollow.py, migration 008.
 
 on:
   schedule:
@@ -18,7 +23,7 @@ permissions:
   contents: read
 
 jobs:
-  apple_rss:
+  appfollow:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -32,9 +37,10 @@ jobs:
 
       - run: pip install -r requirements.txt
 
-      - run: python -m idea_mining.fetchers.apple_rss
+      - run: python -m idea_mining.fetchers.appfollow
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          APPFOLLOW_API_TOKEN: ${{ secrets.APPFOLLOW_API_TOKEN }}
           # Optional — if SENTRY_DSN is unset the fetcher still runs;
           # 5-consecutive-failure alerts simply log to stderr.
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/idea_mining/fetchers/appfollow.py
+++ b/idea_mining/fetchers/appfollow.py
@@ -1,0 +1,500 @@
+"""AppFollow API v2 fetcher — ★1-4 customer reviews into `voices`.
+
+各 (country, app_id) について AppFollow Free プランの Reviews endpoint
+(`GET https://api.appfollow.io/api/v2/reviews`) を叩き、★1-4 のレビュー
+だけを `voices` テーブルに insert する。★5 は INSERT 前に除外し、
+元の rating は `meta.rating` (1-5) に保持する。
+
+Apple iTunes Customer Reviews RSS が死状態に陥った 2026-05-21 以降の
+代替経路 (Issue #150, ADR: 10_projects/idea-mining/decisions/
+2026-05-21-appfollow-free-personal-use.md)。AppFollow Free は 2 apps cap /
+直近 50 件 / 7 日履歴 / 500 credits/月 / 10 credits/req。
+
+newspaper pipeline (`daily_news.py` / `articles` / mailer / archive) からは
+独立した経路。失敗してもニュースレターには影響しない。
+
+Idempotency:
+    INSERT は `ON CONFLICT (source, source_id) DO NOTHING` で、同一 (source,
+    review_id) の再 insert は NoOp になる (migration 008 の UNIQUE 制約)。
+
+Retry / Failure:
+    HTTP 失敗時は exp backoff 1s,2s,4s,8s,16s で最大 5 回リトライ
+    (1 初期 + 5 retries = 6 attempts)。5 回連続で retry が失敗したら
+    Sentry alert を発火し、当該アプリ × country を skip して次へ進む。
+
+CLI entry-point:
+    `python -m idea_mining.fetchers.appfollow` を idea-mining-weekly
+    workflow から呼ぶ。`DATABASE_URL` と `APPFOLLOW_API_TOKEN` が必須。
+    `SENTRY_DSN` は任意。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Final
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+import psycopg
+import sentry_sdk
+import yaml
+from psycopg.types.json import Jsonb
+
+log = logging.getLogger(__name__)
+
+SOURCE_NAME: Final[str] = "appfollow"
+
+APPFOLLOW_API_BASE: Final[str] = "https://api.appfollow.io/api/v2/reviews"
+USER_AGENT: Final[str] = (
+    "HibiIdeaMiningBot/1.0 (+https://github.com/kazuki-0418/hibi)"
+)
+HTTP_TIMEOUT_SECONDS: Final[int] = 30
+
+# AppFollow Free は直近 7 日履歴。from/to は API の必須 query。
+FETCH_WINDOW_DAYS: Final[int] = 7
+
+# 1 initial attempt + 5 retries. After all retries exhausted, Sentry alert + skip.
+RETRY_DELAYS_SECONDS: Final[tuple[int, ...]] = (1, 2, 4, 8, 16)
+
+# country → BCP-47 lang lookup. AppFollow response の locale を優先するが、
+# 欠落時は country から推定する。
+LANG_BY_COUNTRY: Final[dict[str, str]] = {
+    "jp": "ja",
+    "us": "en",
+    "gb": "en",
+    "ca": "en",
+    "au": "en",
+}
+
+
+# ----------------------------------------------------------------------
+# Config (sources.yaml)
+# ----------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AppFollowApp:
+    """sources.yaml の appfollow_apps セクション 1 件分。"""
+
+    name: str
+    app_id: str
+    countries: tuple[str, ...]
+    enabled: bool = True
+
+
+def load_appfollow_apps(sources_yaml_path: str | Path) -> list[AppFollowApp]:
+    """`sources.yaml` から有効な appfollow_apps エントリを返す。
+
+    既存 `sources:` / `apple_apps:` / `channels` / `rss` セクションには触れない。
+    """
+    with open(sources_yaml_path, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+
+    raw_apps = data.get("appfollow_apps") or []
+    apps: list[AppFollowApp] = []
+    for entry in raw_apps:
+        if not entry.get("enabled", True):
+            continue
+        countries_raw = entry.get("country") or []
+        if not isinstance(countries_raw, list) or not countries_raw:
+            log.warning(
+                "appfollow: skip %r — country must be a non-empty list",
+                entry.get("name"),
+            )
+            continue
+        apps.append(
+            AppFollowApp(
+                name=str(entry["name"]),
+                app_id=str(entry["app_id"]),
+                countries=tuple(str(c) for c in countries_raw),
+                enabled=True,
+            )
+        )
+    return apps
+
+
+# ----------------------------------------------------------------------
+# HTTP fetch with retry + backoff
+# ----------------------------------------------------------------------
+
+
+HttpGet = Callable[[str, dict[str, str]], dict]
+
+
+def _default_http_get(url: str, headers: dict[str, str]) -> dict:
+    """Default JSON GET. Raises URLError / HTTPError / JSONDecodeError / TimeoutError."""
+    req = Request(url, headers=headers)
+    with urlopen(req, timeout=HTTP_TIMEOUT_SECONDS) as resp:
+        payload = resp.read()
+    return json.loads(payload.decode("utf-8"))
+
+
+_RETRYABLE_EXC: tuple[type[BaseException], ...] = (
+    URLError,
+    HTTPError,
+    TimeoutError,
+    json.JSONDecodeError,
+    ConnectionError,
+)
+
+
+def _build_url(app_id: str, country: str, *, days: int = FETCH_WINDOW_DAYS) -> str:
+    """AppFollow Reviews API の query string を組み立てる。
+
+    必須 query: ext_id / from / to。ext_id はストア側 app id を渡す。
+    from-to は UTC date (YYYY-MM-DD)、AppFollow Free の 7-day history と
+    合わせる。country は任意だが、jp 専用運用なので必ず付ける。
+    """
+    today = datetime.now(timezone.utc).date()
+    since = today - timedelta(days=days)
+    params = {
+        "ext_id": app_id,
+        "country": country,
+        "from": since.isoformat(),
+        "to": today.isoformat(),
+        "page": "1",
+    }
+    return f"{APPFOLLOW_API_BASE}?{urlencode(params)}"
+
+
+def fetch_one(
+    country: str,
+    app_id: str,
+    *,
+    api_token: str,
+    http_get: HttpGet = _default_http_get,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> dict | None:
+    """Fetch 1 (country, app_id) feed with exp-backoff retry.
+
+    Returns the decoded JSON dict on success, or ``None`` if all retries
+    were exhausted. On exhaustion, sends a Sentry alert and returns
+    ``None`` so the caller can skip and move on.
+    """
+    url = _build_url(app_id, country)
+    headers = {
+        "User-Agent": USER_AGENT,
+        "X-AppFollow-API-Token": api_token,
+        "Accept": "application/json",
+    }
+    last_err: BaseException | None = None
+
+    try:
+        return http_get(url, headers)
+    except _RETRYABLE_EXC as e:
+        last_err = e
+        log.warning("appfollow: initial fetch failed for %s/%s: %r", country, app_id, e)
+
+    for retry_n, delay in enumerate(RETRY_DELAYS_SECONDS, start=1):
+        sleep_fn(delay)
+        try:
+            return http_get(url, headers)
+        except _RETRYABLE_EXC as e:
+            last_err = e
+            log.warning(
+                "appfollow: retry %d/%d failed for %s/%s: %r",
+                retry_n,
+                len(RETRY_DELAYS_SECONDS),
+                country,
+                app_id,
+                e,
+            )
+
+    sentry_sdk.capture_message(
+        f"appfollow: 5 consecutive retries exhausted for {country}/{app_id}: {last_err!r}",
+        level="error",
+    )
+    return None
+
+
+# ----------------------------------------------------------------------
+# Parser (AppFollow response → voice rows)
+# ----------------------------------------------------------------------
+
+
+def _extract_review_list(payload: dict) -> list[dict]:
+    """AppFollow response の top-level からレビュー list を defensive に取り出す。
+
+    実 API の正確な構造はドキュメント記載なしのため、複数候補を順に試す。
+    本機 token 取得後に実 response を見て不要な候補は削減する。
+    """
+    if not isinstance(payload, dict):
+        return []
+
+    candidates = (
+        ("reviews", "list"),
+        ("reviews",),
+        ("data", "list"),
+        ("data", "reviews"),
+        ("data",),
+        ("items",),
+        ("results",),
+    )
+    for path in candidates:
+        node: Any = payload
+        for key in path:
+            if not isinstance(node, dict):
+                node = None
+                break
+            node = node.get(key)
+            if node is None:
+                break
+        if isinstance(node, list):
+            return [e for e in node if isinstance(e, dict)]
+    return []
+
+
+def _parse_rating(raw: Any) -> int | None:
+    """rating を int (1-5) に。失敗時 None (= 不正エントリは捨てる)。"""
+    if raw is None:
+        return None
+    try:
+        v = int(raw)
+    except (ValueError, TypeError):
+        return None
+    if v < 1 or v > 5:
+        return None
+    return v
+
+
+def _pick_str(entry: dict, *keys: str) -> str | None:
+    """entry から最初に見つかった非空 string を返す。"""
+    for key in keys:
+        val = entry.get(key)
+        if isinstance(val, str) and val:
+            return val
+    return None
+
+
+def parse_review_entries(
+    payload: dict,
+    *,
+    country: str,
+    app_id: str,
+    app_name: str | None = None,
+) -> list[dict]:
+    """AppFollow response を voice row dict のリストに整形。★5 は除外。
+
+    Returns:
+        list of dicts with keys:
+            source     — fixed 'appfollow'
+            source_id  — ストア側 review_id (str)
+            posted_at  — ISO timestamp (str)
+            title      — review title (str | None)
+            body       — review content (str | None)
+            meta       — {rating, author, country, lang, app_version, app_id,
+                          app_name, appfollow_id}
+    """
+    reviews = _extract_review_list(payload)
+    if not reviews:
+        return []
+
+    default_lang = LANG_BY_COUNTRY.get(country, country)
+    rows: list[dict] = []
+    for entry in reviews:
+        rating = _parse_rating(entry.get("rating"))
+        if rating is None:
+            continue
+        if rating == 5:
+            # ★5 は idea-mining 対象外 (positive bias / spam)。
+            continue
+        # ストア側 review id を安定キーに、AppFollow 内部 id は meta へ。
+        review_id = _pick_str(entry, "review_id")
+        if not review_id:
+            # fallback: AppFollow 内部 id を source_id にする (Apple/Google
+            # 側に同一レビューが届かないより、id 違いで重複しても害は薄い)。
+            review_id = _pick_str(entry, "id")
+        if not review_id:
+            continue
+        posted_at = _pick_str(entry, "dt", "date", "updated", "time", "created")
+        if not posted_at:
+            continue
+        locale = _pick_str(entry, "locale") or default_lang
+        meta: dict[str, Any] = {
+            "rating": rating,
+            "author": _pick_str(entry, "author", "user_name"),
+            "user_id": _pick_str(entry, "user_id"),
+            "country": country,
+            "lang": locale,
+            "app_version": _pick_str(entry, "app_version", "version"),
+            "app_id": app_id,
+            "app_name": app_name,
+            "appfollow_id": _pick_str(entry, "id"),
+            "store": _pick_str(entry, "store"),
+        }
+        # meta は None 値を素直に残す (psycopg は Jsonb で受ける)。
+        rows.append(
+            {
+                "source": SOURCE_NAME,
+                "source_id": review_id,
+                "posted_at": posted_at,
+                "title": _pick_str(entry, "title"),
+                "body": _pick_str(entry, "content", "body", "text"),
+                "meta": meta,
+            }
+        )
+    return rows
+
+
+# ----------------------------------------------------------------------
+# DB insert
+# ----------------------------------------------------------------------
+
+
+INSERT_SQL: Final[str] = """
+    INSERT INTO voices (source, source_id, posted_at, title, body, meta)
+    VALUES (%(source)s, %(source_id)s, %(posted_at)s, %(title)s, %(body)s, %(meta)s)
+    ON CONFLICT (source, source_id) DO NOTHING
+"""
+
+
+def insert_voices(conn: psycopg.Connection, rows: list[dict]) -> int:
+    """Bulk-insert voice rows. Returns the number of rows the DB reports
+    as actually inserted (ON CONFLICT skips do not count).
+    """
+    if not rows:
+        return 0
+    inserted = 0
+    with conn.cursor() as cur:
+        for row in rows:
+            params = {
+                "source": row["source"],
+                "source_id": row["source_id"],
+                "posted_at": row["posted_at"],
+                "title": row.get("title"),
+                "body": row.get("body"),
+                "meta": Jsonb(row.get("meta") or {}),
+            }
+            cur.execute(INSERT_SQL, params)
+            inserted += cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
+    conn.commit()
+    return inserted
+
+
+# ----------------------------------------------------------------------
+# Orchestration
+# ----------------------------------------------------------------------
+
+
+@dataclass
+class RunStats:
+    apps_total: int = 0
+    pairs_total: int = 0
+    pairs_skipped: int = 0
+    rows_parsed: int = 0
+    rows_inserted: int = 0
+    failures: list[str] = field(default_factory=list)
+
+
+def run_once(
+    apps: list[AppFollowApp],
+    *,
+    conn: psycopg.Connection,
+    api_token: str,
+    http_get: HttpGet = _default_http_get,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> RunStats:
+    """Drive (app × country) iteration end-to-end. Single-process, sync."""
+    stats = RunStats(apps_total=len(apps))
+    for app in apps:
+        for country in app.countries:
+            stats.pairs_total += 1
+            payload = fetch_one(
+                country,
+                app.app_id,
+                api_token=api_token,
+                http_get=http_get,
+                sleep_fn=sleep_fn,
+            )
+            if payload is None:
+                stats.pairs_skipped += 1
+                stats.failures.append(f"{country}/{app.app_id}")
+                continue
+            rows = parse_review_entries(
+                payload, country=country, app_id=app.app_id, app_name=app.name
+            )
+            stats.rows_parsed += len(rows)
+            stats.rows_inserted += insert_voices(conn, rows)
+    return stats
+
+
+# ----------------------------------------------------------------------
+# CLI entry-point (invoked by .github/workflows/idea-mining-weekly.yml)
+# ----------------------------------------------------------------------
+
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
+DEFAULT_SOURCES_YAML: Final[Path] = REPO_ROOT / "sources.yaml"
+
+
+def _init_sentry() -> None:
+    """Sentry を `observability.init_sentry_from_env` と同じ env で初期化。"""
+    dsn = os.environ.get("SENTRY_DSN")
+    if not dsn:
+        log.info("appfollow: SENTRY_DSN unset — failure alerts disabled")
+        return
+    sentry_sdk.init(
+        dsn=dsn,
+        release=os.environ.get("HIBI_RELEASE", "dev"),
+        environment=os.environ.get("HIBI_ENV", "production"),
+        traces_sample_rate=0.0,
+        send_default_pii=False,
+    )
+    sentry_sdk.set_tag("pipeline", "idea_mining_appfollow")
+
+
+def _connect() -> psycopg.Connection:
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        print("ERROR: DATABASE_URL is not set", file=sys.stderr)
+        sys.exit(1)
+    return psycopg.connect(url)
+
+
+def _require_token() -> str:
+    token = os.environ.get("APPFOLLOW_API_TOKEN")
+    if not token:
+        print("ERROR: APPFOLLOW_API_TOKEN is not set", file=sys.stderr)
+        sys.exit(1)
+    return token
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    _init_sentry()
+
+    api_token = _require_token()
+    apps = load_appfollow_apps(DEFAULT_SOURCES_YAML)
+    log.info("appfollow: %d enabled apps loaded", len(apps))
+    if not apps:
+        log.info("appfollow: no enabled apps — nothing to do")
+        return 0
+
+    with _connect() as conn:
+        stats = run_once(apps, conn=conn, api_token=api_token)
+
+    log.info(
+        "appfollow: done apps=%d pairs=%d skipped=%d parsed=%d inserted=%d failures=%s",
+        stats.apps_total,
+        stats.pairs_total,
+        stats.pairs_skipped,
+        stats.rows_parsed,
+        stats.rows_inserted,
+        stats.failures,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sources.yaml
+++ b/sources.yaml
@@ -243,27 +243,63 @@ sources:
 # ============================================================
 # apple_apps — Apple iTunes RSS (★1-4 customer reviews → voices)
 #
-# idea-mining 用の private シグナル源。`daily_news.py` / newsletter /
-# web archive とは無関係で、`voices` テーブルにのみ書き込む。
+# DISABLED 2026-05-21: Apple iTunes Customer Reviews RSS endpoint が
+# HTTP 200 だが feed.entry が常に空という死状態に到達したため
+# (Issue #150, ADR: 10_projects/idea-mining/decisions/2026-05-21-appfollow-free-personal-use.md)。
+# Apple 側に公式 deprecation アナウンスはないが復旧見込みも不明。
+# 代替経路として AppFollow Free に切替 (appfollow_apps 参照)。
 #
-# Issue #136 では country MVP として jp のみ運用。us/gb の追加は
-# 別 issue で判断 (out-of-scope)。
-#
-# fetcher: idea_mining/fetchers/apple_rss.py
-# workflow: .github/workflows/idea-mining-weekly.yml (毎週月 14:00 UTC)
+# 既存 fetcher (idea_mining/fetchers/apple_rss.py) は将来 Apple が
+# RSS を復活させた場合の参照実装として残置する。
 # ============================================================
 apple_apps:
   - name: Notion
     app_id: "1232780281"
     country: [jp]
-    enabled: true
-    why: 個人の生産性ツール市場での pain point 観測 (knowledge mgmt + AI 機能)。
+    enabled: false
+    why: (disabled) Apple iTunes RSS 死亡につき AppFollow 経路へ移行。
 
   - name: Obsidian
     app_id: "1557175442"
     country: [jp]
+    enabled: false
+    why: (disabled) 同上。
+
+  - name: MoneyForward
+    app_id: "459683577"
+    country: [jp]
+    enabled: false
+    why: (disabled) 同上。
+
+# ============================================================
+# appfollow_apps — AppFollow Free API (★1-4 customer reviews → voices)
+#
+# idea-mining 用の private シグナル源。`daily_news.py` / newsletter /
+# web archive とは無関係で、`voices` テーブルにのみ書き込む
+# (source='appfollow')。
+#
+# Phase 0 proof として Notion (jp) + MoneyForward (jp) の 2 つで開始。
+# 1-2 週後に Canva / DeepL Pro / pixiv / freee 等の niche app へ
+# 入れ替え予定 (ADR の Open 節)。AppFollow Free は 2 apps cap。
+#
+# - app_id は Apple App Store 側の app id (AppFollow API では ext_id
+#   パラメータに渡す)。同じ id を「AppFollow ダッシュボード上で own
+#   として追加」して tracking 対象にしておく。
+# - country は AppFollow API の country パラメータ (jp / us / gb 等)。
+# - ★5 は fetcher 側で除外する (rating < 5 のみ INSERT)。
+# - APPFOLLOW_API_TOKEN env が必要。GitHub Actions secrets で設定。
+#
+# fetcher: idea_mining/fetchers/appfollow.py
+# workflow: .github/workflows/idea-mining-weekly.yml (毎週月 14:00 UTC)
+# ADR: 10_projects/idea-mining/decisions/2026-05-21-appfollow-free-personal-use.md
+# Issue: #150
+# ============================================================
+appfollow_apps:
+  - name: Notion
+    app_id: "1232780281"
+    country: [jp]
     enabled: true
-    why: ローカル / Markdown / plugin 系の note-taking pain point 観測。
+    why: 個人の生産性ツール市場での pain point 観測 (knowledge mgmt + AI 機能)。
 
   - name: MoneyForward
     app_id: "459683577"

--- a/tests/idea_mining/fetchers/test_appfollow.py
+++ b/tests/idea_mining/fetchers/test_appfollow.py
@@ -1,0 +1,528 @@
+"""Tests for `idea_mining.fetchers.appfollow`.
+
+AppFollow Free fetcher の挙動 (★5 除外 / defensive parsing / dedupe key /
+retry & Sentry alert / sources.yaml パース / URL 組み立て / migration 008
+互換) を最小限のスコープで検証する。
+
+外部 HTTP / DB / Sentry は dependency-inject や monkeypatch で全部モック
+する。実 Neon / 実 AppFollow API は叩かない。
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from idea_mining.fetchers import appfollow
+from idea_mining.fetchers.appfollow import (
+    APPFOLLOW_API_BASE,
+    FETCH_WINDOW_DAYS,
+    INSERT_SQL,
+    LANG_BY_COUNTRY,
+    RETRY_DELAYS_SECONDS,
+    SOURCE_NAME,
+    AppFollowApp,
+    _build_url,
+    fetch_one,
+    insert_voices,
+    load_appfollow_apps,
+    parse_review_entries,
+    run_once,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+# ----------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------
+
+
+def _review(
+    rating: int,
+    review_id: str,
+    *,
+    content: str | None = None,
+    title: str | None = None,
+    dt: str = "2026-05-19T12:34:56+00:00",
+    author: str = "anon",
+    app_version: str = "1.2.3",
+    locale: str = "ja",
+    appfollow_id: str | None = None,
+    **overrides: Any,
+) -> dict:
+    body: dict[str, Any] = {
+        "review_id": review_id,
+        "id": appfollow_id or f"af-{review_id}",
+        "rating": rating,
+        "content": content if content is not None else f"body-{review_id}",
+        "title": title if title is not None else f"title-{review_id}",
+        "author": author,
+        "user_id": f"user-{review_id}",
+        "app_version": app_version,
+        "locale": locale,
+        "dt": dt,
+    }
+    body.update(overrides)
+    return body
+
+
+def _wrap(*reviews: dict, shape: str = "reviews.list") -> dict:
+    """top-level の構造バリエーションを試す helper."""
+    items = list(reviews)
+    if shape == "reviews.list":
+        return {"reviews": {"list": items}}
+    if shape == "reviews":
+        return {"reviews": items}
+    if shape == "data.list":
+        return {"data": {"list": items}}
+    if shape == "data":
+        return {"data": items}
+    if shape == "items":
+        return {"items": items}
+    raise ValueError(f"unknown shape: {shape}")
+
+
+# ----------------------------------------------------------------------
+# Parser tests
+# ----------------------------------------------------------------------
+
+
+def test_parse_drops_rating_5_and_keeps_1_through_4() -> None:
+    payload = _wrap(
+        _review(1, "r1"),
+        _review(2, "r2"),
+        _review(3, "r3"),
+        _review(4, "r4"),
+        _review(5, "r5"),  # excluded
+    )
+
+    rows = parse_review_entries(
+        payload, country="jp", app_id="1232780281", app_name="Notion"
+    )
+
+    ratings = sorted(r["meta"]["rating"] for r in rows)
+    assert ratings == [1, 2, 3, 4]
+    assert all(r["source"] == SOURCE_NAME for r in rows)
+    assert "r5" not in {r["source_id"] for r in rows}
+
+
+def test_parse_skips_invalid_rating() -> None:
+    payload = _wrap(
+        _review(0, "r0"),  # rating out of range
+        _review(6, "r6"),  # rating out of range
+        {"review_id": "no_rating", "content": "x", "dt": "2026-05-19T00:00:00+00:00"},
+        _review(2, "r2"),  # kept
+    )
+
+    rows = parse_review_entries(payload, country="jp", app_id="1", app_name="X")
+
+    assert [r["source_id"] for r in rows] == ["r2"]
+
+
+def test_parse_skips_missing_posted_at() -> None:
+    payload = _wrap(
+        {"review_id": "no_dt", "rating": 2, "content": "x"},
+        _review(3, "ok"),
+    )
+
+    rows = parse_review_entries(payload, country="jp", app_id="1", app_name="X")
+
+    assert [r["source_id"] for r in rows] == ["ok"]
+
+
+def test_parse_falls_back_to_internal_id_when_review_id_missing() -> None:
+    payload = _wrap(
+        {
+            "id": "af-only-1",
+            "rating": 3,
+            "content": "x",
+            "dt": "2026-05-19T00:00:00+00:00",
+        },
+    )
+
+    rows = parse_review_entries(payload, country="jp", app_id="1", app_name="X")
+
+    assert rows[0]["source_id"] == "af-only-1"
+
+
+def test_parse_meta_shape() -> None:
+    payload = _wrap(_review(3, "r1", appfollow_id="af-r1", locale="ja"))
+
+    rows = parse_review_entries(
+        payload, country="jp", app_id="1232780281", app_name="Notion"
+    )
+
+    meta = rows[0]["meta"]
+    assert meta["rating"] == 3
+    assert meta["author"] == "anon"
+    assert meta["country"] == "jp"
+    assert meta["lang"] == "ja"
+    assert meta["app_version"] == "1.2.3"
+    assert meta["app_id"] == "1232780281"
+    assert meta["app_name"] == "Notion"
+    assert meta["appfollow_id"] == "af-r1"
+
+
+def test_parse_locale_falls_back_to_country_lang_when_missing() -> None:
+    payload = _wrap(_review(2, "r1", locale=""))
+
+    rows = parse_review_entries(payload, country="jp", app_id="1", app_name="X")
+
+    assert rows[0]["meta"]["lang"] == LANG_BY_COUNTRY["jp"]
+
+
+@pytest.mark.parametrize(
+    "shape", ["reviews.list", "reviews", "data.list", "data", "items"]
+)
+def test_parse_handles_multiple_top_level_shapes(shape: str) -> None:
+    payload = _wrap(_review(2, "r1"), _review(4, "r2"), shape=shape)
+
+    rows = parse_review_entries(payload, country="jp", app_id="1", app_name="X")
+
+    assert sorted(r["source_id"] for r in rows) == ["r1", "r2"]
+
+
+def test_parse_returns_empty_when_no_reviews() -> None:
+    assert parse_review_entries(
+        {"reviews": {"list": []}}, country="jp", app_id="1", app_name="X"
+    ) == []
+    assert parse_review_entries({}, country="jp", app_id="1", app_name="X") == []
+    assert parse_review_entries(
+        {"reviews": {}}, country="jp", app_id="1", app_name="X"
+    ) == []
+
+
+def test_parse_uses_content_field_for_body() -> None:
+    payload = _wrap(_review(3, "r1", content="hello world"))
+
+    rows = parse_review_entries(payload, country="jp", app_id="1", app_name="X")
+
+    assert rows[0]["body"] == "hello world"
+
+
+# ----------------------------------------------------------------------
+# URL build tests
+# ----------------------------------------------------------------------
+
+
+def test_build_url_includes_required_query_params() -> None:
+    url = _build_url("1232780281", "jp", days=7)
+
+    assert url.startswith(APPFOLLOW_API_BASE)
+    assert "ext_id=1232780281" in url
+    assert "country=jp" in url
+    assert "page=1" in url
+    assert "from=" in url
+    assert "to=" in url
+
+
+def test_build_url_date_window_uses_today_and_seven_days_ago() -> None:
+    url = _build_url("1", "jp", days=FETCH_WINDOW_DAYS)
+    today = datetime.now(timezone.utc).date()
+    since = today - timedelta(days=FETCH_WINDOW_DAYS)
+
+    assert f"to={today.isoformat()}" in url
+    assert f"from={since.isoformat()}" in url
+
+
+# ----------------------------------------------------------------------
+# fetch_one retry tests
+# ----------------------------------------------------------------------
+
+
+def test_fetch_one_returns_payload_on_first_try() -> None:
+    calls: list[str] = []
+
+    def http_get(url: str, headers: dict[str, str]) -> dict:
+        calls.append(url)
+        assert headers["X-AppFollow-API-Token"] == "tok"
+        return {"reviews": {"list": []}}
+
+    out = fetch_one(
+        "jp", "1", api_token="tok", http_get=http_get, sleep_fn=lambda _s: None
+    )
+
+    assert out == {"reviews": {"list": []}}
+    assert len(calls) == 1
+
+
+def test_fetch_one_retries_until_success() -> None:
+    attempts = {"n": 0}
+
+    def http_get(url: str, headers: dict[str, str]) -> dict:
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise TimeoutError("flaky")
+        return {"reviews": {"list": []}}
+
+    out = fetch_one(
+        "jp", "1", api_token="tok", http_get=http_get, sleep_fn=lambda _s: None
+    )
+
+    assert out == {"reviews": {"list": []}}
+    assert attempts["n"] == 3
+
+
+def test_fetch_one_returns_none_after_all_retries_exhausted(monkeypatch: pytest.MonkeyPatch) -> None:
+    sent: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_capture(msg: str, *, level: str = "info") -> None:
+        sent.append((msg, {"level": level}))
+
+    monkeypatch.setattr(appfollow.sentry_sdk, "capture_message", fake_capture)
+
+    def http_get(url: str, headers: dict[str, str]) -> dict:
+        raise TimeoutError("always")
+
+    out = fetch_one(
+        "jp", "1", api_token="tok", http_get=http_get, sleep_fn=lambda _s: None
+    )
+
+    assert out is None
+    # 1 + len(RETRY_DELAYS_SECONDS) attempts = 6
+    assert len(sent) == 1
+    assert sent[0][1]["level"] == "error"
+    assert "5 consecutive retries exhausted" in sent[0][0]
+    # sanity: retry delays = 5 entries
+    assert len(RETRY_DELAYS_SECONDS) == 5
+
+
+# ----------------------------------------------------------------------
+# insert_voices tests
+# ----------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, dict]] = []
+        self.rowcount = 1
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: dict) -> None:
+        self.executed.append((sql, params))
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        self._cur = _FakeCursor()
+        self.commits = 0
+
+    def cursor(self) -> _FakeCursor:
+        return self._cur
+
+    def commit(self) -> None:
+        self.commits += 1
+
+
+def test_insert_voices_returns_zero_for_empty_rows() -> None:
+    conn = _FakeConn()
+
+    assert insert_voices(conn, []) == 0  # type: ignore[arg-type]
+    assert conn.commits == 0
+
+
+def test_insert_voices_uses_expected_sql_and_columns() -> None:
+    conn = _FakeConn()
+    rows = [
+        {
+            "source": SOURCE_NAME,
+            "source_id": "r1",
+            "posted_at": "2026-05-19T00:00:00+00:00",
+            "title": "t",
+            "body": "b",
+            "meta": {"rating": 3},
+        }
+    ]
+
+    inserted = insert_voices(conn, rows)  # type: ignore[arg-type]
+
+    assert inserted == 1
+    assert conn.commits == 1
+    sql, params = conn._cur.executed[0]
+    assert "INSERT INTO voices" in sql
+    assert "ON CONFLICT (source, source_id) DO NOTHING" in sql
+    assert params["source"] == SOURCE_NAME
+    assert params["source_id"] == "r1"
+
+
+# ----------------------------------------------------------------------
+# sources.yaml loader tests
+# ----------------------------------------------------------------------
+
+
+def test_load_appfollow_apps_filters_disabled(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "sources.yaml"
+    yaml_path.write_text(
+        yaml.safe_dump(
+            {
+                "appfollow_apps": [
+                    {
+                        "name": "Notion",
+                        "app_id": "1232780281",
+                        "country": ["jp"],
+                        "enabled": True,
+                    },
+                    {
+                        "name": "Disabled",
+                        "app_id": "999",
+                        "country": ["jp"],
+                        "enabled": False,
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    apps = load_appfollow_apps(yaml_path)
+
+    assert [a.name for a in apps] == ["Notion"]
+    assert apps[0].app_id == "1232780281"
+    assert apps[0].countries == ("jp",)
+
+
+def test_load_appfollow_apps_skips_entries_without_countries(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "sources.yaml"
+    yaml_path.write_text(
+        yaml.safe_dump(
+            {
+                "appfollow_apps": [
+                    {"name": "NoCountry", "app_id": "1", "country": [], "enabled": True},
+                    {
+                        "name": "Notion",
+                        "app_id": "2",
+                        "country": ["jp"],
+                        "enabled": True,
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    apps = load_appfollow_apps(yaml_path)
+
+    assert [a.name for a in apps] == ["Notion"]
+
+
+def test_load_appfollow_apps_ignores_apple_apps_section(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "sources.yaml"
+    yaml_path.write_text(
+        yaml.safe_dump(
+            {
+                "apple_apps": [
+                    {"name": "Old", "app_id": "1", "country": ["jp"], "enabled": True},
+                ],
+                "appfollow_apps": [
+                    {
+                        "name": "New",
+                        "app_id": "2",
+                        "country": ["jp"],
+                        "enabled": True,
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    apps = load_appfollow_apps(yaml_path)
+
+    assert [a.name for a in apps] == ["New"]
+
+
+def test_repo_sources_yaml_has_at_most_two_enabled_appfollow_apps() -> None:
+    """Free プランの 2 apps cap を YAML レベルで保証する。"""
+    repo_yaml = REPO_ROOT / "sources.yaml"
+    apps = load_appfollow_apps(repo_yaml)
+
+    assert len(apps) <= 2, (
+        f"AppFollow Free is capped at 2 apps; got {len(apps)} enabled. "
+        f"Disable some entries in sources.yaml or upgrade the plan."
+    )
+
+
+# ----------------------------------------------------------------------
+# run_once orchestration tests
+# ----------------------------------------------------------------------
+
+
+def test_run_once_aggregates_stats_across_apps() -> None:
+    conn = _FakeConn()
+
+    def http_get(url: str, headers: dict[str, str]) -> dict:
+        # ext_id ごとに違うレビューを返す
+        if "ext_id=1" in url:
+            return _wrap(_review(2, "r1"), _review(5, "r5"))
+        return _wrap(_review(3, "r2"))
+
+    apps = [
+        AppFollowApp(name="A", app_id="1", countries=("jp",)),
+        AppFollowApp(name="B", app_id="2", countries=("jp",)),
+    ]
+
+    stats = run_once(
+        apps,
+        conn=conn,  # type: ignore[arg-type]
+        api_token="tok",
+        http_get=http_get,
+        sleep_fn=lambda _s: None,
+    )
+
+    # A: r1 only (r5 excluded), B: r2 → parsed=2 inserted=2
+    assert stats.apps_total == 2
+    assert stats.pairs_total == 2
+    assert stats.pairs_skipped == 0
+    assert stats.rows_parsed == 2
+    assert stats.rows_inserted == 2
+    assert stats.failures == []
+
+
+def test_run_once_skips_failed_app_and_continues(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(appfollow.sentry_sdk, "capture_message", lambda *a, **k: None)
+    conn = _FakeConn()
+
+    def http_get(url: str, headers: dict[str, str]) -> dict:
+        if "ext_id=fail" in url:
+            raise TimeoutError("always")
+        return _wrap(_review(3, "ok"))
+
+    apps = [
+        AppFollowApp(name="Fail", app_id="fail", countries=("jp",)),
+        AppFollowApp(name="OK", app_id="ok", countries=("jp",)),
+    ]
+
+    stats = run_once(
+        apps,
+        conn=conn,  # type: ignore[arg-type]
+        api_token="tok",
+        http_get=http_get,
+        sleep_fn=lambda _s: None,
+    )
+
+    assert stats.pairs_skipped == 1
+    assert "jp/fail" in stats.failures
+    assert stats.rows_inserted == 1
+
+
+# ----------------------------------------------------------------------
+# Migration 008 sanity (INSERT_SQL targets the voices table contract)
+# ----------------------------------------------------------------------
+
+
+def test_insert_sql_matches_migration_008_contract() -> None:
+    # migration 008 が voices(source, source_id) UNIQUE を前提にしているので、
+    # INSERT 側もそのキーで ON CONFLICT を取っていることをここで pin する。
+    assert "INSERT INTO voices" in INSERT_SQL
+    assert "ON CONFLICT (source, source_id) DO NOTHING" in INSERT_SQL
+    for column in ("source", "source_id", "posted_at", "title", "body", "meta"):
+        assert f"%({column})s" in INSERT_SQL

--- a/tests/idea_mining/fetchers/test_apple_rss.py
+++ b/tests/idea_mining/fetchers/test_apple_rss.py
@@ -333,15 +333,21 @@ def test_insert_voices_treats_rowcount_zero_as_noop() -> None:
 
 
 def test_load_apple_apps_reads_real_sources_yaml() -> None:
+    # 2026-05-21 以降、Apple iTunes Customer Reviews RSS 死亡を受けて
+    # sources.yaml の apple_apps セクションは全 entry を enabled: false に
+    # 変更し、idea-mining-weekly workflow からも切り離した
+    # (Issue #150, ADR: 10_projects/idea-mining/decisions/
+    # 2026-05-21-appfollow-free-personal-use.md)。
+    # load_apple_apps は enabled=true のみ返すため、本番 sources.yaml に
+    # 対しては 0 件で返ることが正しい挙動。fetcher コード自体は将来 Apple
+    # が RSS を復活させたときの参照実装として残置している。
     apps = load_apple_apps(REPO_ROOT / "sources.yaml")
 
-    by_name = {a.name: a for a in apps}
-    for required in ("Notion", "Obsidian", "MoneyForward"):
-        assert required in by_name, f"sources.yaml missing apple_apps entry: {required}"
-        assert by_name[required].countries == ("jp",)
-        assert by_name[required].enabled is True
-        # app_id is a string ID (Apple uses numeric strings).
-        assert by_name[required].app_id.isdigit()
+    assert apps == [], (
+        "apple_apps must be fully disabled in sources.yaml after the "
+        "2026-05-21 pivot to AppFollow. Re-enable only if Apple revives "
+        "the Customer Reviews RSS endpoint and the ADR is reopened."
+    )
 
 
 def test_load_apple_apps_skips_disabled(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #150

## Summary

- Apple iTunes Customer Reviews RSS が silent dead state (HTTP 200 / entry empty) を受け、`voices` 入力源を **AppFollow Free** に切替
- 新 fetcher: `idea_mining/fetchers/appfollow.py` (`GET /api/v2/reviews`、★1-4 のみ INSERT、defensive response parser)
- `sources.yaml`: `apple_apps:` を全 disabled、`appfollow_apps:` に Notion(jp) + MoneyForward(jp) を追加
- `idea-mining-weekly.yml` を `appfollow` step に差し替え、`APPFOLLOW_API_TOKEN` secret 参照
- Apple RSS fetcher のコードと既存テスト構造は残置 (将来 Apple RSS 復活時の参照実装)

## ADR

`10_projects/idea-mining/decisions/2026-05-21-appfollow-free-personal-use.md` (Obsidian Vault)

主要決定:
- AppFollow Free 採用、ToS 4.2 リスクは個人開発・非商用・非公開の範囲で accept
- Reddit OAuth は Phase 1 fallback として保留
- apps は短期入れ替え予定 (Open 節)

## Test plan

- [x] `pytest tests/idea_mining/fetchers/` → 49 件 pass (27 件新規 + 22 件 apple_rss regression)
- [x] `pytest tests/idea_mining/` 全体 → 174 件 pass (regression なし)
- [ ] kazuki が AppFollow sign up + Notion(jp)/MoneyForward(jp) を own として追加
- [ ] kazuki が API token 発行 → `gh secret set APPFOLLOW_API_TOKEN`
- [ ] `gh workflow run idea-mining-weekly.yml` で初回試走
- [ ] `voices` テーブルに source='appfollow' で row が積まれることを Neon Console で確認
- [ ] 必要に応じて `_extract_review_list` の candidate 順序を実 response 構造に合わせて調整

## Risk / Open

- AppFollow ToS 4.2 (ML 利用禁止) のリスクを accept (ADR 参照、月初 self-check で再評価)
- Free プラン制約: 2 apps cap / 直近 50 件 / 7 日履歴 / 500 credits/月 (週次運用なら 80 credits/月で十分)
- AppFollow API response の top-level 構造は docs に非公開、parser は defensive に複数候補対応。初回試走で実構造を確認して必要なら絞り込む

🤖 Generated with [Claude Code](https://claude.com/claude-code)