### PR TITLE
feat(legal): robots.txt + RSS link-only fallback (KAZ-201)

### DIFF
--- a/architecture/skills/hibi-domain.md
+++ b/architecture/skills/hibi-domain.md
@@ -28,7 +28,7 @@ Hibi の現行ドメイン事実を固定するスキル。
 - Stage A は **メタデータのみ** 取得する。transcript / 本文取得を Stage A に混ぜない
 - Stage B のフィルタ条件は `published_at >= now() - 14 days` AND `is_sent = false`
 - Stage B は ranking で上位 N 件を抽出。N の現行値は 5（旧 10 から変更済み）
-- Stage C: RSS は本文 + 要約 + Neon 保存。YouTube はメタデータのみ（リンク行、要約なし）
+- Stage C: RSS は本文 + 要約 + Neon 保存（robots disallow / 本文未取得時は link-only）。YouTube はメタデータのみ（リンク行、要約なし）
 - 各 Stage は前段の出力に対してのみ動作する。Stage C が Stage A の生メタデータを直接読まない
 - workflow timeout は 10 分以内。Stage B の N を増やすときは Stage C のランタイムを試算する
 

--- a/daily_news.py
+++ b/daily_news.py
@@ -48,7 +48,7 @@ MAX_VIDEOS_PER_RUN = 5  # 1回の配信で要約・送信する最大本数（�
 MAX_ATTEMPTS = 30  # 1回の実行で試行する最大候補数（無限試行防止）
 MIN_CONTENT_CHARS = 500  # RSS 記事本文がこれ未満なら要約対象外
 MIN_SUMMARY_CHARS = 10  # Claude が防御プロンプトに従って空を返したケースを弾く閾値
-# YouTube はメタデータのみ: AI 要約せずタイトル + リンクで digest に載せる (KAZ-200)
+# 本文未取得時は AI 要約せずタイトル + リンクのみ (KAZ-200 YouTube / KAZ-201 RSS)
 LINK_ONLY_SUMMARY: str | None = None
 CLAUDE_MODEL = "claude-haiku-4-5-20251001"
 CONTENT_CHAR_LIMIT = 15000  # Claude に渡す本文の上限（コスト制御）
@@ -113,13 +113,18 @@ def _fetch_items(
     return []
 
 
-def _is_link_only_item(item: dict) -> bool:
-    """YouTube uploads appear in the digest as title + link only (no transcript)."""
-    return item.get("source_type") == "youtube"
+def _is_link_only_item(item: dict, content: str | None) -> bool:
+    """Items without a summarizable body ship as title + link only (no AI summary)."""
+    stype = item.get("source_type")
+    if stype == "youtube":
+        return True
+    if stype == "rss":
+        return not content or len(content) < MIN_CONTENT_CHARS
+    return False
 
 
 def _fetch_content(item: dict) -> str | None:
-    if _is_link_only_item(item):
+    if item.get("source_type") == "youtube":
         return None
     if item.get("source_type") == "rss":
         return rss_fetcher.get_content_text(item)
@@ -613,18 +618,20 @@ def main():
             f"{item['title'][:70]}"
         )
 
-        link_only = _is_link_only_item(item)
         content = _fetch_content(item)
+        link_only = _is_link_only_item(item, content)
         if link_only:
             summary = LINK_ONLY_SUMMARY
-            print("  → link-only (YouTube metadata; no transcript / AI summary)")
-        elif not content or len(content) < MIN_CONTENT_CHARS:
-            char_count = len(content) if content else 0
-            print(
-                f"  → skip (content unavailable or too short: {char_count} chars)"
-            )
-            skipped_count += 1
-            continue
+            if item.get("source_type") == "youtube":
+                print(
+                    "  → link-only (YouTube metadata; no transcript / AI summary)"
+                )
+            else:
+                char_count = len(content) if content else 0
+                print(
+                    "  → link-only (RSS body unavailable; AI summary suppressed, "
+                    f"{char_count} chars)"
+                )
         else:
             summary = summarize(claude, item["title"], content)
             if not summary or len(summary) < MIN_SUMMARY_CHARS:
@@ -640,7 +647,9 @@ def main():
 
         # 送信失敗時に再送できるよう、保存は送信前に行う。
         # article_id はクリック追跡 URL (/r/{id}) の生成に使う。
-        embedding = embed_article(openai_client, item["title"], summary)
+        embedding = embed_article(
+            openai_client, item["title"], summary or ""
+        )
         article_id = save_article(
             {
                 "source_type": item["source_type"],

--- a/docs/legal-posture.md
+++ b/docs/legal-posture.md
@@ -4,7 +4,7 @@ Hibi の現在の法的状態と、進行中の Perplexity 訴訟 (2025-08 提�
 
 将来の AI セッション (Manager / `/triage-issue` / 個別 dev エージェント) がこのファイルを読んで「auth・multi-tenant 化・本文取得拡張・新規メディア追加」を提案する前に、ここでの判断を尊重できるよう書いてある。Markdown 1 ファイルが SSoT。
 
-最終更新: 2026-05-14
+最終更新: 2026-06-03
 
 ---
 
@@ -34,14 +34,16 @@ Hibi の現在の法的状態と、進行中の Perplexity 訴訟 (2025-08 提�
 
 | 訴訟の争点 | Hibi での該当箇所 | 影響度 |
 |---|---|---|
-| robots.txt 無視 | `fetchers/rss.py` の `trafilatura.fetch_url()` は robots.txt を **見ていない** (README の「robots.txt 尊重」は誤記、後述) | 🔴 直撃 |
+| robots.txt 無視 | `fetchers/rss.py` は `urllib.robotparser` で disallow を確認してから `trafilatura.fetch_url()`（明示 User-Agent）。robots.txt 取得失敗時は **fetch しない** (fail closed)。KAZ-201 (2026-06) | 🟡 緩和 (単一ユーザー・非商用のまま) |
 | 記事本文のサーバ複製・保存 | `trafilatura.extract()` で本文取得 + `articles.summary` として Neon に保存 | 🔴 直撃 |
 | paywall 突破 | フィードに paywall 記事 URL が混入した場合、追加判定なく fetch する | 🟡 潜在 (現状の sources.yaml では未確認だが、構造上ガードがない) |
 | 媒体名を冠した不正確情報 | `articles.source_name` をメール本文 / archive にそのまま表示、AI の summary は hallucination リスクあり | 🔴 直撃 |
 
-### README の誤記について
+### robots.txt / 要約抑止 (KAZ-201, 2026-06)
 
-`README.md` のフロー説明に「trafilatura（本文抽出 + robots.txt 尊重）」と記載があるが、現行 `fetchers/rss.py` は robots.txt を見ていない。本ドキュメント作成時点では「**判決を待ってから対応**」方針のため README の表現はこの doc とセットで読む。文言修正は商用化判断再開時にまとめて行う(README で「尊重」と書いて実装してない方が問題が大きいので、必要なら短期で README 側を「robots.txt は現状未尊重(#124 関連で保留中)」に直す選択肢もある)。
+- **#125 相当**: `fetchers/rss.py` が robots.txt を尊重。取得不能時は当該 origin の記事本文を fetch しない。
+- **#128 相当**: RSS で本文未取得・不確実時は Claude 要約を呼ばず link-only（`summary = NULL`、メールはタイトル + Source リンク）。YouTube も KAZ-200 以降同様。
+- README の「robots.txt 尊重」表記は上記実装と一致する。
 
 ## 4. 防衛 PR の位置づけ
 
@@ -49,10 +51,10 @@ epic #124 で 5 件の防衛 issue を起こした(2026-05-14、Hibi 着手前)�
 
 | issue | テーマ | 判断 |
 |---|---|---|
-| #125 | `trafilatura` を robots.txt 尊重モードに変更 + User-Agent 明示 | **保留** (Manager triage で `robots.txt 取得失敗時の fallback` が judgment call として未決のまま停止。判決後に再判断) |
+| #125 | `trafilatura` を robots.txt 尊重モードに変更 + User-Agent 明示 | **実装済** (KAZ-201: fail closed on robots fetch failure) |
 | #126 | paywall 記事 URL の自動検出と除外 | **保留** (paywall detection の精度トレードオフが未検証) |
 | #127 | `/copyright` ページ (出典ポリシー + 削除依頼窓口) | **保留** (公開ページ追加は商用化判断と紐づくため) |
-| #128 | 本文未取得 / 不確実時の AI 要約抑止 | **保留** (現状 1 人運用なので影響対象が kazuki 自身のみ) |
+| #128 | 本文未取得 / 不確実時の AI 要約抑止 | **実装済** (KAZ-201: RSS link-only; YouTube は KAZ-200) |
 | #129 | **本ドキュメント** | ← これ |
 
 #124 と #125-#128 は **2026-05-14 に close**。実装着手は本ドキュメントが固まり、商用化判断が再開された時点で **新規 issue として再起票** する。

--- a/fetchers/rss.py
+++ b/fetchers/rss.py
@@ -1,15 +1,19 @@
 """RSS fetcher — feedparser for metadata, trafilatura for article body.
 
 Respects robots.txt per-origin (cached for the duration of the run).
+When robots.txt cannot be fetched, the origin is treated as disallowed (fail closed).
 """
 
+from configparser import ConfigParser
 from datetime import datetime, timezone
 from time import mktime, struct_time
 from urllib.parse import urlparse
+from urllib.request import Request, urlopen
 from urllib.robotparser import RobotFileParser
 
 import feedparser
 import trafilatura
+from trafilatura.settings import use_config
 
 
 USER_AGENT = (
@@ -17,7 +21,24 @@ USER_AGENT = (
     "(+https://github.com/kazuki-0418/Personal-Daily-News)"
 )
 
+ROBOTS_FETCH_TIMEOUT_SEC = 10
+
 _robots_cache: dict[str, RobotFileParser | None] = {}
+_cached_trafilatura_config: ConfigParser | None = None
+
+
+def clear_robots_cache() -> None:
+    """Reset per-run robots cache (for tests)."""
+    _robots_cache.clear()
+
+
+def _trafilatura_config() -> ConfigParser:
+    global _cached_trafilatura_config
+    if _cached_trafilatura_config is None:
+        config = use_config()
+        config.set("DEFAULT", "USER_AGENT", USER_AGENT)
+        _cached_trafilatura_config = config
+    return _cached_trafilatura_config
 
 
 def _iso_from_struct_time(t: struct_time | None) -> str:
@@ -57,27 +78,37 @@ def fetch_recent_items(source: dict, max_results: int) -> list[dict]:
     return items
 
 
+def _load_robots_parser(origin: str) -> RobotFileParser | None:
+    """Fetch and parse robots.txt for ``origin``. ``None`` on any failure."""
+    robots_url = f"{origin}/robots.txt"
+    rp = RobotFileParser()
+    rp.set_url(robots_url)
+    req = Request(robots_url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urlopen(req, timeout=ROBOTS_FETCH_TIMEOUT_SEC) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+        rp.parse(body.splitlines())
+        return rp
+    except Exception:
+        return None
+
+
 def _robots_allows(url: str) -> bool:
-    """Check robots.txt for ``url``. Fails open on fetch errors."""
+    """Return whether ``USER_AGENT`` may fetch ``url`` per robots.txt.
+
+    Disallows when robots.txt fetch/parse fails (fail closed).
+    """
     parsed = urlparse(url)
     if not parsed.scheme or not parsed.netloc:
         return False
     origin = f"{parsed.scheme}://{parsed.netloc}"
 
     if origin not in _robots_cache:
-        rp = RobotFileParser()
-        rp.set_url(f"{origin}/robots.txt")
-        try:
-            rp.read()
-            _robots_cache[origin] = rp
-        except Exception:
-            # robots.txt unreachable — fail open so a single broken robots
-            # endpoint doesn't silently drop every article.
-            _robots_cache[origin] = None
+        _robots_cache[origin] = _load_robots_parser(origin)
 
     rp = _robots_cache[origin]
     if rp is None:
-        return True
+        return False
     return rp.can_fetch(USER_AGENT, url)
 
 
@@ -88,7 +119,7 @@ def get_content_text(item: dict) -> str | None:
         print(f"    [skip] robots.txt disallows: {url}")
         return None
 
-    downloaded = trafilatura.fetch_url(url)
+    downloaded = trafilatura.fetch_url(url, config=_trafilatura_config())
     if not downloaded:
         print(f"    [skip] download failed: {url}")
         return None

--- a/tests/test_rss_fetcher.py
+++ b/tests/test_rss_fetcher.py
@@ -1,0 +1,50 @@
+"""Unit tests for fetchers.rss robots.txt and body fetch (KAZ-201)."""
+
+from unittest.mock import MagicMock, patch
+
+import fetchers.rss as rss
+
+
+def setup_function() -> None:
+    rss.clear_robots_cache()
+
+
+def test_robots_disallows_skips_body_fetch() -> None:
+    item = {"url": "https://example.com/article"}
+    with patch.object(rss, "_robots_allows", return_value=False):
+        with patch.object(rss.trafilatura, "fetch_url") as mock_fetch:
+            assert rss.get_content_text(item) is None
+            mock_fetch.assert_not_called()
+
+
+def test_robots_fetch_failure_fails_closed() -> None:
+    with patch.object(rss, "urlopen", side_effect=OSError("network")):
+        assert rss._robots_allows("https://blocked.example/post") is False
+
+
+def test_robots_disallow_path_blocks_fetch() -> None:
+    robots_body = "User-agent: *\nDisallow: /private/\n"
+    fake_resp = MagicMock()
+    fake_resp.read.return_value = robots_body.encode()
+    fake_resp.__enter__ = MagicMock(return_value=fake_resp)
+    fake_resp.__exit__ = MagicMock(return_value=False)
+
+    with patch.object(rss, "urlopen", return_value=fake_resp):
+        assert rss._robots_allows("https://site.test/private/secret") is False
+        assert rss._robots_allows("https://site.test/public/ok") is True
+
+
+def test_get_content_text_returns_extracted_body() -> None:
+    item = {"url": "https://example.com/story"}
+    with patch.object(rss, "_robots_allows", return_value=True):
+        with patch.object(rss.trafilatura, "fetch_url", return_value="<html/>"):
+            with patch.object(rss.trafilatura, "extract", return_value="x" * 600):
+                text = rss.get_content_text(item)
+    assert text is not None
+    assert len(text) == 600
+
+
+def test_trafilatura_config_sets_user_agent() -> None:
+    rss._cached_trafilatura_config = None
+    config = rss._trafilatura_config()
+    assert config.get("DEFAULT", "USER_AGENT") == rss.USER_AGENT

--- a/tests/test_youtube_link_only.py
+++ b/tests/test_youtube_link_only.py
@@ -1,16 +1,32 @@
-"""Tests for YouTube metadata-only digest rows (KAZ-200)."""
+"""Tests for link-only digest rows (KAZ-200 YouTube, KAZ-201 RSS)."""
 
-from daily_news import LINK_ONLY_SUMMARY, _fetch_content, _is_link_only_item
+from daily_news import (
+    LINK_ONLY_SUMMARY,
+    MIN_CONTENT_CHARS,
+    _fetch_content,
+    _is_link_only_item,
+)
 
 
-def test_youtube_is_link_only() -> None:
+def test_youtube_is_link_only_without_body() -> None:
     item = {"source_type": "youtube", "content_id": "abc", "url": "https://youtu.be/abc"}
-    assert _is_link_only_item(item) is True
+    assert _is_link_only_item(item, None) is True
 
 
-def test_rss_is_not_link_only() -> None:
+def test_rss_with_sufficient_body_is_not_link_only() -> None:
     item = {"source_type": "rss", "url": "https://example.com/x"}
-    assert _is_link_only_item(item) is False
+    body = "a" * MIN_CONTENT_CHARS
+    assert _is_link_only_item(item, body) is False
+
+
+def test_rss_without_body_is_link_only() -> None:
+    item = {"source_type": "rss", "url": "https://example.com/x"}
+    assert _is_link_only_item(item, None) is True
+
+
+def test_rss_short_body_is_link_only() -> None:
+    item = {"source_type": "rss", "url": "https://example.com/x"}
+    assert _is_link_only_item(item, "short") is True
 
 
 def test_fetch_content_returns_none_for_youtube() -> None:


### PR DESCRIPTION
## Summary

- Harden `fetchers/rss.py`: check robots.txt with an explicit User-Agent before `trafilatura.fetch_url`, and **fail closed** when robots.txt cannot be fetched or parsed.
- Extend link-only digest rows to RSS when article body is unavailable or under 500 chars (no Claude summary; title + source link only), matching the existing YouTube behavior from KAZ-200.
- Update `docs/legal-posture.md` and `hibi-domain.md` to record implementation of former defense issues #125 and #128.

## Test plan

- [x] `pytest` (260 passed)
- [x] `tests/test_rss_fetcher.py` — robots disallow, fail-closed, User-Agent config
- [x] `tests/test_youtube_link_only.py` — RSS + YouTube link-only paths

Closes KAZ-201


Made with [Cursor](https://cursor.com)