### PR TITLE
feat(ranking): goal-conditioned digest from Obsidian (KAZ-202)

### DIFF
--- a/.github/workflows/daily-news.yml
+++ b/.github/workflows/daily-news.yml
@@ -48,6 +48,8 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           HIBI_RELEASE: ${{ github.sha }}
           HIBI_ENV: production
+          # Goal-conditioned ranking (KAZ-202): skip vault when unset in CI.
+          HIBI_GOALS_OPTIONAL: "1"
 
       # Dump editions from Neon → JSON files Astro reads at build time.
       # Idempotent overwrite; no-op if no editions changed.

--- a/architecture/skills/hibi-domain.md
+++ b/architecture/skills/hibi-domain.md
@@ -14,7 +14,7 @@ Hibi の現行ドメイン事実を固定するスキル。
 - pipeline は 3-stage + ranking 構成。各 Stage は前段の出力にのみ依存
 - ranking 反映は **次回バッチ実行時**。クリックは即座に centroid を更新しない
 - embedding 対象は `title + summary`。本文ではない
-- cold start: `clicks_in_30d < 5` で純ランダム、30 件で full weight
+- cold start: `clicks_in_30d < 5` では Obsidian active project の **goal centroid** でランキング（KAZ-202）。goal も無いときのみ純ランダム
 - score 式: `sim × 0.7 × weight + rand() × (1 − 0.4 × weight)`、weight = `min(1, clicks_in_30d / 30)`
 - 現行の事実は以下のダイアグラムから確認する:
   - `architecture/diagrams/pipeline-flow.mmd`
@@ -28,7 +28,7 @@ Hibi の現行ドメイン事実を固定するスキル。
 - Stage A は **メタデータのみ** 取得する。transcript / 本文取得を Stage A に混ぜない
 - Stage B のフィルタ条件は `published_at >= now() - 14 days` AND `is_sent = false`
 - Stage B は ranking で上位 N 件を抽出。N の現行値は 5（旧 10 から変更済み）
-- Stage C: RSS は本文 + 要約 + Neon 保存（robots disallow / 本文未取得時は link-only）。YouTube はメタデータのみ（リンク行、要約なし）
+- Stage C: RSS は本文 + 要約 + Neon 保存（robots disallow / 本文未取得時は link-only）。YouTube はメタデータのみ（リンク行、要約なし）。要約は `---要約---`（DB）と `---関連---`（メール `learning` 行）を分離。challenge 枠 1–2 件常設
 - 各 Stage は前段の出力に対してのみ動作する。Stage C が Stage A の生メタデータを直接読まない
 - workflow timeout は 10 分以内。Stage B の N を増やすときは Stage C のランタイムを試算する
 

--- a/daily_news.py
+++ b/daily_news.py
@@ -29,12 +29,23 @@ from db import (
     update_edition_meta,
     update_edition_sources_scanned,
 )
+from daily_news_ranking import (
+    build_digest_plan,
+    resolve_ranking_centroid,
+    score_candidates,
+)
 from fetchers import rss as rss_fetcher
 from fetchers import youtube as youtube_fetcher
+from goals import load_goal_focus
 from mailer import build_html as build_hibi_html
 from observability import init_sentry_from_env
-from ranking import compute_interest_centroid, cosine_similarity, count_recent_clicks
+from ranking import compute_interest_centroid, count_recent_clicks
 from send_mail import format_subject
+from summarize_goal import (
+    SummaryResult,
+    build_summarize_prompt,
+    parse_summarize_response,
+)
 from voice import check_voice_violations
 
 log = logging.getLogger(__name__)
@@ -68,6 +79,9 @@ JITTER_BASE = 0.3
 # cost を抑える（1候補 ≒ 600 tokens になるのが目安）
 RANKING_DESC_CHAR_LIMIT = 500
 RANKING_TOP_LOG = 10
+CHALLENGE_SLOTS_MIN = 1
+CHALLENGE_SLOTS_MAX = 2
+GOAL_CONTEXT_PROMPT_LIMIT = 4000
 
 REQUIRED_ENV_VARS = [
     "YOUTUBE_API_KEY",
@@ -178,11 +192,7 @@ def embed_batch(openai_client, texts: list[str]) -> list[list[float] | None]:
 # ============================================================
 # Claude summarize
 # ============================================================
-def summarize(client: Anthropic, title: str, content: str) -> str:
-    # design-system/README.md "Content fundamentals → Voice" 由来。
-    # 具体的な禁止ワード列挙ではなく原則だけを 5-7 行で示し、
-    # post-processing (`check_voice_violations`) で観測する設計。
-    voice_rule = """あなたは新聞 Hibi の編集者として要約を書きます。文体ルール:
+_VOICE_RULE = """あなたは新聞 Hibi の編集者として要約を書きます。文体ルール:
 - 三人称・観察的・宣言的に書く。新聞は報告するのであって売り込まない。
 - 一人称(「私」「僕」)も二人称呼びかけ(「あなた」「読者の皆様」)も使わない。
 - 賞賛は抑制する。「すごい」「最高」より「興味深い」「注目」。
@@ -190,39 +200,47 @@ def summarize(client: Anthropic, title: str, content: str) -> str:
 - マーケティング的な煽り(「今すぐ」「お見逃しなく」「驚愕」「衝撃」)を避ける。
 - 句点「。」で終える事実の記述を基本とする。"""
 
-    prompt = f"""{voice_rule}
 
-以下の記事/動画を日本語で3行に要約してください。
-技術的な要点、実装のヒント、開発者にとっての示唆を優先してください。
-各行は1文で、「・」で始めてください。
-
-重要: 本文が断片的・不十分・要約困難な場合でも、謝罪文・「情報が不足」等の注釈・推測による補完は絶対に禁止。その場合は何も出力せず空文字列のみ返してください。
-
-タイトル: {title}
-
-本文:
-{content[:CONTENT_CHAR_LIMIT]}
-
-出力形式:
-・(1行目)
-・(2行目)
-・(3行目)"""
+def summarize(
+    client: Anthropic,
+    title: str,
+    content: str,
+    goal_context: str = "",
+) -> SummaryResult:
+    """Return faithful summary + optional goal-relevance note (KAZ-202)."""
+    prompt = build_summarize_prompt(
+        title,
+        content,
+        voice_rule=_VOICE_RULE,
+        content_char_limit=CONTENT_CHAR_LIMIT,
+        goal_context=goal_context[:GOAL_CONTEXT_PROMPT_LIMIT],
+    )
 
     response = client.messages.create(
         model=CLAUDE_MODEL,
-        max_tokens=500,
+        max_tokens=600,
         messages=[{"role": "user", "content": prompt}],
     )
-    summary = response.content[0].text.strip()
+    parsed = parse_summarize_response(response.content[0].text.strip())
 
-    # design-system voice & tone への準拠を観測する。違反があっても配信は
-    # 止めず warning ログのみ。意図は voice.py module docstring を参照。
-    if summary:
-        violations = check_voice_violations(summary)
-        if violations:
-            log.warning("voice violations in summary: %s", violations)
+    for block_name, text in (("summary", parsed.summary), ("goal_note", parsed.goal_note)):
+        if text:
+            violations = check_voice_violations(text)
+            if violations:
+                log.warning("voice violations in %s: %s", block_name, violations)
 
-    return summary
+    return parsed
+
+
+def embed_goal_centroid(
+    openai_client,
+    goal_focus_text: str,
+) -> list[float] | None:
+    """Embed minimal goal focus text for ranking (single OpenAI call)."""
+    if openai_client is None or not goal_focus_text.strip():
+        return None
+    vectors = embed_batch(openai_client, [goal_focus_text])
+    return vectors[0] if vectors else None
 
 
 # ============================================================
@@ -439,9 +457,9 @@ def _sections_to_articles(sections: list[dict]) -> list[dict]:
                 "url": _redirect_url(item.get("article_id"), item["url"]),
                 "summary": item["summary"],
                 "source": source_name,
-                # category / source_type / learning / practical_application:
-                # not surfaced by daily_news pipeline yet; `_story_html`
-                # handles their absence gracefully.
+                "category": item.get("display_category") or item.get("category"),
+                "source_type": item.get("source_type"),
+                "learning": item.get("goal_note") or "",
             })
     return articles
 
@@ -453,56 +471,62 @@ def rank_candidates(
     candidates: list[dict],
     user_id: str,
     openai_client,
+    goal_centroid: list[float] | None = None,
 ) -> list[dict]:
-    """候補を click-history ベースの similarity + jitter で並べ替える。
-
-    - 履歴 < COLD_START_CLICKS or centroid None → 完全ランダム（従来挙動）
-    - 5 ≦ clicks < 30 → centroid を linearly interpolate（clicks/30）
-    - clicks ≥ FULL_WEIGHT_CLICKS → full weight で centroid を使う
-
-    Returns 元の list と同じ件数、score 降順。各候補に 'sim' / 'score' が
-    書き込まれる。side effect で top-N を stdout にログ出力する。
-    """
+    """Rank by goal centroid (KAZ-202) with optional click-history blend + jitter."""
     with get_conn() as conn:
         click_count = count_recent_clicks(conn, user_id, RANKING_WINDOW_DAYS)
-        centroid = (
+        click_centroid = (
             compute_interest_centroid(conn, user_id, RANKING_WINDOW_DAYS)
             if click_count >= COLD_START_CLICKS
             else None
         )
 
+    centroid = resolve_ranking_centroid(
+        click_centroid,
+        goal_centroid,
+        click_count,
+        cold_start_clicks=COLD_START_CLICKS,
+        full_weight_clicks=FULL_WEIGHT_CLICKS,
+    )
+
     if centroid is None:
         print(
-            f"🎲 Cold start ({click_count} recent clicks, threshold={COLD_START_CLICKS}) "
-            "— using random ranking"
+            f"🎲 No ranking centroid (clicks={click_count}, goal={'yes' if goal_centroid else 'no'}) "
+            "— random order"
         )
         random.shuffle(candidates)
         return candidates
 
-    # 候補を1回の OpenAI 呼び出しでまとめて埋め込む
     texts = [
         f"{c.get('title', '')}\n\n{(c.get('description') or '')[:RANKING_DESC_CHAR_LIMIT]}"
         for c in candidates
     ]
     vectors = embed_batch(openai_client, texts)
 
-    weight = min(1.0, click_count / FULL_WEIGHT_CLICKS)
-    for c, vec in zip(candidates, vectors):
-        if vec is None:
-            c["sim"] = 0.0
-        else:
-            c["sim"] = cosine_similarity(vec, centroid)
-        # sim を信じる度合いは weight に比例。weight=1 で 0.7*sim + 0.3*rand、
-        # weight=0 で 1.0*rand に縮退する（= ほぼランダム）
-        c["score"] = c["sim"] * SIM_BASE * weight + random.random() * (
-            1.0 - (SIM_BASE - JITTER_BASE) * weight
-        )
+    if goal_centroid is not None and click_count < COLD_START_CLICKS:
+        ranking_weight = 1.0
+    else:
+        ranking_weight = min(1.0, click_count / FULL_WEIGHT_CLICKS)
 
+    score_candidates(
+        candidates,
+        vectors,
+        centroid,
+        ranking_weight=ranking_weight,
+        sim_base=SIM_BASE,
+        jitter_base=JITTER_BASE,
+    )
     candidates.sort(key=lambda x: x["score"], reverse=True)
 
+    signal = "goal"
+    if goal_centroid is not None and click_centroid is not None:
+        signal = "goal+click"
+    elif click_centroid is not None:
+        signal = "click"
     print(
         f"\n📊 Ranked {len(candidates)} candidates "
-        f"(click_count={click_count}, weight={weight:.2f})"
+        f"(signal={signal}, clicks={click_count}, weight={ranking_weight:.2f})"
     )
     for i, c in enumerate(candidates[:RANKING_TOP_LOG], 1):
         title = (c.get("title") or "")[:60]
@@ -513,7 +537,10 @@ def rank_candidates(
             f"{c.get('source_name', '?')} / {title}"
         )
     if len(candidates) > RANKING_TOP_LOG:
-        print(f"  [skipped pool] {len(candidates) - RANKING_TOP_LOG} candidates below rank {RANKING_TOP_LOG}")
+        print(
+            f"  [skipped pool] {len(candidates) - RANKING_TOP_LOG} "
+            f"candidates below rank {RANKING_TOP_LOG}"
+        )
 
     return candidates
 
@@ -593,10 +620,31 @@ def main():
 
     print(f"\n📊 Total unsent candidates: {len(candidates)}")
 
-    # Stage B: personalization ranking + attempt_pool 抽出（#28）。
-    # rank_candidates は cold start 時に random.shuffle にフォールバックする。
-    ranked = rank_candidates(candidates, DEFAULT_USER_ID, openai_client)
-    attempt_pool = ranked[:MAX_ATTEMPTS]
+    goal_focus = load_goal_focus()
+    if goal_focus.text:
+        print(
+            f"🎯 Goal context: {len(goal_focus.text)} chars "
+            f"from projects {', '.join(goal_focus.project_slugs) or '(none)'}"
+        )
+    else:
+        print("🎯 Goal context: (empty — optional vault or no active projects)")
+
+    goal_centroid = embed_goal_centroid(openai_client, goal_focus.text)
+
+    # Stage B: goal + click centroid ranking, then digest plan with challenge slots.
+    ranked = rank_candidates(
+        candidates, DEFAULT_USER_ID, openai_client, goal_centroid=goal_centroid
+    )
+    digest_plan = build_digest_plan(
+        ranked[:MAX_ATTEMPTS],
+        MAX_VIDEOS_PER_RUN,
+        challenge_min=CHALLENGE_SLOTS_MIN,
+        challenge_max=CHALLENGE_SLOTS_MAX,
+    )
+    plan_ids = {c["content_id"] for c in digest_plan}
+    attempt_pool = digest_plan + [
+        c for c in ranked[:MAX_ATTEMPTS] if c["content_id"] not in plan_ids
+    ]
     print(
         f"🎲 Attempt pool: {len(attempt_pool)} items "
         f"(target: {MAX_VIDEOS_PER_RUN} summaries, cap: {MAX_ATTEMPTS} attempts)"
@@ -620,6 +668,7 @@ def main():
 
         content = _fetch_content(item)
         link_only = _is_link_only_item(item, content)
+        goal_note = ""
         if link_only:
             summary = LINK_ONLY_SUMMARY
             if item.get("source_type") == "youtube":
@@ -633,7 +682,14 @@ def main():
                     f"{char_count} chars)"
                 )
         else:
-            summary = summarize(claude, item["title"], content)
+            parsed = summarize(
+                claude,
+                item["title"],
+                content or "",
+                goal_context=goal_focus.text,
+            )
+            summary = parsed.summary
+            goal_note = parsed.goal_note
             if not summary or len(summary) < MIN_SUMMARY_CHARS:
                 print(
                     "  → skip (summary empty: Claude defended against insufficient content)"
@@ -642,11 +698,19 @@ def main():
                 continue
 
         summarized_count += 1
-        label = "link-only" if link_only else "summarized"
+        slot = item.get("digest_slot", "goal")
+        if link_only:
+            label = "link-only"
+        elif slot == "challenge":
+            label = "challenge"
+        else:
+            label = "summarized"
         print(f"  ✅ {label} ({summarized_count}/{MAX_VIDEOS_PER_RUN})")
 
-        # 送信失敗時に再送できるよう、保存は送信前に行う。
-        # article_id はクリック追跡 URL (/r/{id}) の生成に使う。
+        display_category = item.get("category")
+        if slot == "challenge":
+            display_category = "Challenge"
+
         embedding = embed_article(
             openai_client, item["title"], summary or ""
         )
@@ -669,8 +733,11 @@ def main():
             {
                 "title": item["title"],
                 "summary": summary,
+                "goal_note": goal_note,
                 "url": item["url"],
                 "article_id": article_id,
+                "display_category": display_category,
+                "source_type": item.get("source_type"),
             }
         )
 

--- a/daily_news_ranking.py
+++ b/daily_news_ranking.py
@@ -1,0 +1,82 @@
+"""Goal-conditioned ranking and digest slot planning (KAZ-202)."""
+
+from __future__ import annotations
+
+import random
+from typing import Any, Sequence
+
+from ranking import blend_centroids, cosine_similarity
+
+
+def resolve_ranking_centroid(
+    click_centroid: Any,
+    goal_centroid: Sequence[float] | None,
+    click_count: int,
+    *,
+    cold_start_clicks: int,
+    full_weight_clicks: int,
+) -> Any:
+    """Pick centroid for ranking: goal when clicks are sparse, blend when both exist."""
+    if goal_centroid is None and click_centroid is None:
+        return None
+    if goal_centroid is None:
+        return click_centroid
+    if click_centroid is None or click_count < cold_start_clicks:
+        return goal_centroid
+    click_weight = min(1.0, click_count / full_weight_clicks)
+    return blend_centroids(goal_centroid, click_centroid, click_weight)
+
+
+def score_candidates(
+    candidates: list[dict],
+    vectors: list[list[float] | None],
+    centroid: Sequence[float],
+    *,
+    ranking_weight: float,
+    sim_base: float,
+    jitter_base: float,
+) -> None:
+    """Write ``sim`` and ``score`` on each candidate (in place)."""
+    weight = max(0.0, min(1.0, ranking_weight))
+    for candidate, vec in zip(candidates, vectors, strict=False):
+        if vec is None:
+            candidate["sim"] = 0.0
+        else:
+            candidate["sim"] = cosine_similarity(vec, centroid)
+        candidate["score"] = candidate["sim"] * sim_base * weight + random.random() * (
+            1.0 - (sim_base - jitter_base) * weight
+        )
+
+
+def build_digest_plan(
+    ranked: list[dict],
+    max_stories: int,
+    *,
+    challenge_min: int = 1,
+    challenge_max: int = 2,
+) -> list[dict]:
+    """Build up to ``max_stories`` items with ``digest_slot`` goal or challenge."""
+    if not ranked or max_stories <= 0:
+        return []
+
+    n = min(max_stories, len(ranked))
+    n_challenge = 0
+    if n >= 2 and challenge_min > 0:
+        n_challenge = min(challenge_max, challenge_min, n - 1)
+
+    by_sim_asc = sorted(ranked, key=lambda c: float(c.get("sim", 0.0)))
+    challenge_picks = by_sim_asc[:n_challenge]
+    challenge_ids = {c["content_id"] for c in challenge_picks}
+    n_goal = n - len(challenge_picks)
+
+    plan: list[dict] = []
+    for candidate in ranked:
+        if candidate["content_id"] in challenge_ids:
+            continue
+        if len(plan) >= n_goal:
+            break
+        plan.append({**candidate, "digest_slot": "goal"})
+
+    for pick in challenge_picks:
+        plan.append({**pick, "digest_slot": "challenge"})
+    return plan

--- a/goals/__init__.py
+++ b/goals/__init__.py
@@ -1,0 +1,5 @@
+"""Obsidian active-project goal context for Hibi ranking and summarization."""
+
+from goals.loader import GoalFocus, load_goal_focus
+
+__all__ = ["GoalFocus", "load_goal_focus"]

--- a/goals/loader.py
+++ b/goals/loader.py
@@ -1,0 +1,156 @@
+"""Load minimal goal focus text from Obsidian ``10_projects/`` active notes.
+
+Active-project convention (KAZ-202):
+- Vault root: ``OBSIDIAN_VAULT_ROOT`` (same as idea-mining).
+- Scan ``10_projects/<project>/`` — one directory depth under ``10_projects/``.
+- A project is **active** when any ``*.md`` in that folder has YAML frontmatter
+  with ``hibi-active: true`` or ``status: active`` (case-insensitive).
+- Abandoned paths are skipped: ``archive``, ``done``, ``abandoned``, ``.trash``.
+- Only these sections are extracted (heading match, case-insensitive):
+  Goal / ゴール / Focus / 焦点 / 進捗 / 決定 / Progress / Decision.
+- Concatenated focus text is capped at ``GOAL_FOCUS_CHAR_LIMIT`` for API privacy.
+
+Tests may set ``HIBI_GOALS_OPTIONAL=1`` (empty focus, no error) or
+``HIBI_GOAL_CONTEXT_OVERRIDE`` (synthetic profile for demos).
+"""
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+VAULT_ROOT_ENV: Final[str] = "OBSIDIAN_VAULT_ROOT"
+OPTIONAL_ENV: Final[str] = "HIBI_GOALS_OPTIONAL"
+OVERRIDE_ENV: Final[str] = "HIBI_GOAL_CONTEXT_OVERRIDE"
+PROJECTS_SUBPATH: Final[str] = "10_projects"
+GOAL_FOCUS_CHAR_LIMIT: Final[int] = 6000
+_EXCLUDED_PATH_PARTS: Final[frozenset[str]] = frozenset(
+    {"archive", "done", "abandoned", ".trash", "_templates"}
+)
+_ACTIVE_FM_KEYS: Final[tuple[str, ...]] = ("hibi-active", "status")
+_ACTIVE_FM_VALUES: Final[frozenset[str]] = frozenset({"active", "true", "yes"})
+_SECTION_NAMES: Final[frozenset[str]] = frozenset(
+    {
+        "goal",
+        "ゴール",
+        "focus",
+        "焦点",
+        "進捗",
+        "決定",
+        "progress",
+        "decision",
+    }
+)
+_FRONTMATTER_RE = re.compile(r"\A---\s*\r?\n(.*?)\r?\n---\s*\r?\n", re.DOTALL)
+_HEADING_RE = re.compile(r"^#{1,3}\s+(.+?)\s*$", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class GoalFocus:
+    """Minimal text bundle passed to embedding / summarization prompts."""
+
+    text: str
+    project_slugs: tuple[str, ...]
+
+
+def _optional_enabled() -> bool:
+    return os.environ.get(OPTIONAL_ENV) == "1"
+
+
+def _frontmatter_active(fm: str) -> bool:
+    for line in fm.splitlines():
+        if ":" not in line:
+            continue
+        key, _, raw = line.partition(":")
+        key = key.strip().lower()
+        if key not in _ACTIVE_FM_KEYS:
+            continue
+        value = raw.strip().strip("\"'").lower()
+        if value in _ACTIVE_FM_VALUES:
+            return True
+    return False
+
+
+def _extract_focus_sections(body: str) -> str:
+    """Keep only goal-relevant ## sections; drop the rest of the note."""
+    matches = list(_HEADING_RE.finditer(body))
+    if not matches:
+        return body.strip()[:2000]
+
+    parts: list[str] = []
+    for idx, match in enumerate(matches):
+        title = match.group(1).strip().lower()
+        if title not in _SECTION_NAMES:
+            continue
+        start = match.end()
+        end = matches[idx + 1].start() if idx + 1 < len(matches) else len(body)
+        chunk = body[start:end].strip()
+        if chunk:
+            parts.append(f"## {match.group(1).strip()}\n{chunk}")
+    return "\n\n".join(parts)
+
+
+def _note_focus(path: Path) -> str:
+    raw = path.read_text(encoding="utf-8")
+    body = raw
+    fm_match = _FRONTMATTER_RE.match(raw)
+    if fm_match:
+        if not _frontmatter_active(fm_match.group(1)):
+            return ""
+        body = raw[fm_match.end() :]
+    elif not _optional_enabled():
+        # Without frontmatter, non-optional runs ignore the file (not marked active).
+        return ""
+
+    return _extract_focus_sections(body)
+
+
+def _path_excluded(path: Path) -> bool:
+    return any(part in _EXCLUDED_PATH_PARTS for part in path.parts)
+
+
+def load_goal_focus() -> GoalFocus:
+    """Load capped goal focus text from active project notes under ``10_projects/``."""
+    override = os.environ.get(OVERRIDE_ENV, "").strip()
+    if override:
+        return GoalFocus(text=override[:GOAL_FOCUS_CHAR_LIMIT], project_slugs=("override",))
+
+    optional = _optional_enabled()
+    vault_root = os.environ.get(VAULT_ROOT_ENV)
+    if not vault_root:
+        if optional:
+            return GoalFocus(text="", project_slugs=())
+        raise RuntimeError(
+            f"{VAULT_ROOT_ENV} is not set; cannot load goal context. "
+            f"Set {OPTIONAL_ENV}=1 to bypass (tests/CI only)."
+        )
+
+    projects_root = Path(vault_root) / PROJECTS_SUBPATH
+    if not projects_root.is_dir():
+        if optional:
+            return GoalFocus(text="", project_slugs=())
+        raise RuntimeError(f"Projects directory missing: {projects_root}")
+
+    chunks: list[str] = []
+    slugs: list[str] = []
+    for project_dir in sorted(projects_root.iterdir()):
+        if not project_dir.is_dir() or project_dir.name.startswith("."):
+            continue
+        slug = project_dir.name
+        project_parts: list[str] = []
+        for md_path in sorted(project_dir.rglob("*.md")):
+            if _path_excluded(md_path):
+                continue
+            focus = _note_focus(md_path)
+            if focus:
+                project_parts.append(focus)
+        if not project_parts:
+            continue
+        slugs.append(slug)
+        combined = "\n\n".join(project_parts)
+        chunks.append(f"# Project: {slug}\n{combined}")
+
+    text = "\n\n".join(chunks)[:GOAL_FOCUS_CHAR_LIMIT]
+    return GoalFocus(text=text, project_slugs=tuple(slugs))

--- a/ranking.py
+++ b/ranking.py
@@ -1,18 +1,9 @@
-"""Click-history-driven similarity ranking for daily_news.py.
-
-Stays deliberately simple: a centroid of recently-clicked article embeddings
-is the "interest profile", and candidates are ranked by cosine similarity to
-that centroid plus a jitter term. Jitter keeps the recommendation from
-collapsing into an echo chamber when the centroid stabilises.
-
-Cold-start + interpolation logic lives in daily_news.rank_candidates; the
-helpers here are pure enough to reason about in isolation.
-"""
+"""Ranking helpers: click centroid, goal centroid blend, cosine similarity."""
 
 from __future__ import annotations
 
 import math
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 
 def compute_interest_centroid(conn, user_id: str, days: int = 30) -> Optional[Any]:
@@ -20,9 +11,6 @@ def compute_interest_centroid(conn, user_id: str, days: int = 30) -> Optional[An
 
     Returns None when the user has no clicks in the window, or when none of
     the clicked articles have embeddings yet (e.g. before backfill runs).
-    The return value is whatever pgvector.psycopg gives us — typically a
-    numpy array when register_vector() has been called on the connection.
-    Indexing / len() work the same, and cosine_similarity accepts both.
     """
     row = conn.execute(
         """
@@ -54,15 +42,25 @@ def count_recent_clicks(conn, user_id: str, days: int = 30) -> int:
     return int(row[0]) if row else 0
 
 
-def cosine_similarity(a, b) -> float:
-    """Cosine similarity of two 1-D vectors (list/tuple/ndarray). Zero-safe."""
+def cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
+    """Cosine similarity of two 1-D vectors. Zero-safe (fails open to sim=0)."""
     dot = 0.0
     na = 0.0
     nb = 0.0
-    for x, y in zip(a, b):
+    for x, y in zip(a, b, strict=False):
         dot += x * y
         na += x * x
         nb += y * y
     if na == 0.0 or nb == 0.0:
         return 0.0
     return dot / (math.sqrt(na) * math.sqrt(nb))
+
+
+def blend_centroids(
+    goal: Sequence[float],
+    click: Sequence[float],
+    click_weight: float,
+) -> list[float]:
+    """Element-wise blend; ``click_weight`` in [0, 1] weights the click centroid."""
+    w = max(0.0, min(1.0, click_weight))
+    return [float(g) * (1.0 - w) + float(c) * w for g, c in zip(goal, click, strict=False)]

--- a/summarize_goal.py
+++ b/summarize_goal.py
@@ -1,0 +1,67 @@
+"""Goal-conditioned summarization output parsing (KAZ-202)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_GOAL_NOTE_MARKER = "---関連---"
+
+
+@dataclass(frozen=True)
+class SummaryResult:
+    """Faithful summary (stored in DB) plus optional goal-relevance note (email only)."""
+
+    summary: str
+    goal_note: str
+
+
+def build_summarize_prompt(
+    title: str,
+    content: str,
+    *,
+    voice_rule: str,
+    content_char_limit: int,
+    goal_context: str,
+) -> str:
+    goal_block = ""
+    if goal_context.strip():
+        goal_block = f"""
+読者の現在のプロジェクト焦点（要約の歪め禁止・注釈の根拠のみに使用）:
+{goal_context[:4000]}
+"""
+
+    return f"""{voice_rule}
+{goal_block}
+以下の記事/動画を日本語で要約してください。
+技術的な要点、実装のヒント、開発者にとっての示唆を優先してください。
+
+重要:
+- 「---要約---」ブロックは出典に忠実な3行要約のみ。推測・補完・謝罪は禁止。困難なら要約ブロックを空にする。
+- 「---関連---」ブロックは上記プロジェクト焦点との関連を1〜2行で述べる（本旨を変えない注釈）。焦点が空、または関連が薄い場合は関連ブロックを空にする。
+- 各行は1文で「・」で始める。
+
+タイトル: {title}
+
+本文:
+{content[:content_char_limit]}
+
+出力形式（この2ブロックのみ）:
+---要約---
+・(1行目)
+・(2行目)
+・(3行目)
+---関連---
+・(関連があれば1行目)
+・(関連があれば2行目)"""
+
+
+def parse_summarize_response(raw: str) -> SummaryResult:
+    """Split Claude output into faithful summary and goal-relevance note."""
+    text = raw.strip()
+    if _GOAL_NOTE_MARKER not in text:
+        return SummaryResult(summary=text, goal_note="")
+
+    summary_part, note_part = text.split(_GOAL_NOTE_MARKER, 1)
+    summary = summary_part.replace("---要約---", "").strip()
+    goal_note = note_part.strip()
+    return SummaryResult(summary=summary, goal_note=goal_note)

--- a/tests/test_goal_loader.py
+++ b/tests/test_goal_loader.py
@@ -1,0 +1,56 @@
+"""Tests for goals.loader active-project conventions (KAZ-202)."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from goals import loader as goals_loader
+
+
+def test_load_goal_focus_extracts_active_sections(tmp_path: Path, monkeypatch) -> None:
+    vault = tmp_path / "vault"
+    project = vault / "10_projects" / "hibi"
+    project.mkdir(parents=True)
+    note = project / "status.md"
+    note.write_text(
+        "---\nstatus: active\n---\n"
+        "## Goal\nBuild the digest pipeline.\n\n"
+        "## Notes\nPrivate diary.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv(goals_loader.OVERRIDE_ENV, raising=False)
+    monkeypatch.delenv(goals_loader.OPTIONAL_ENV, raising=False)
+    monkeypatch.setenv(goals_loader.VAULT_ROOT_ENV, str(vault))
+
+    focus = goals_loader.load_goal_focus()
+    assert "hibi" in focus.project_slugs
+    assert "Build the digest pipeline" in focus.text
+    assert "Private diary" not in focus.text
+
+
+def test_abandoned_paths_skipped(tmp_path: Path, monkeypatch) -> None:
+    vault = tmp_path / "vault"
+    archived = vault / "10_projects" / "old" / "archive" / "x.md"
+    archived.parent.mkdir(parents=True)
+    archived.write_text("---\nstatus: active\n---\n## Goal\nhidden\n", encoding="utf-8")
+    monkeypatch.setenv(goals_loader.VAULT_ROOT_ENV, str(vault))
+    monkeypatch.delenv(goals_loader.OVERRIDE_ENV, raising=False)
+
+    focus = goals_loader.load_goal_focus()
+    assert focus.text == ""
+    assert focus.project_slugs == ()
+
+
+def test_override_env(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv(goals_loader.OVERRIDE_ENV, "Demo goal focus")
+    focus = goals_loader.load_goal_focus()
+    assert focus.text == "Demo goal focus"
+    assert focus.project_slugs == ("override",)
+
+
+def test_missing_vault_optional_returns_empty(monkeypatch) -> None:
+    monkeypatch.delenv(goals_loader.VAULT_ROOT_ENV, raising=False)
+    monkeypatch.setenv(goals_loader.OPTIONAL_ENV, "1")
+    focus = goals_loader.load_goal_focus()
+    assert focus.text == ""

--- a/tests/test_ranking_goal.py
+++ b/tests/test_ranking_goal.py
@@ -1,0 +1,42 @@
+"""Tests for goal/click centroid ranking helpers (KAZ-202)."""
+
+from daily_news_ranking import build_digest_plan, resolve_ranking_centroid
+from ranking import blend_centroids, cosine_similarity
+
+
+def test_resolve_ranking_centroid_prefers_goal_on_cold_start() -> None:
+    goal = [1.0, 0.0]
+    click = [0.0, 1.0]
+    out = resolve_ranking_centroid(
+        click,
+        goal,
+        click_count=0,
+        cold_start_clicks=5,
+        full_weight_clicks=30,
+    )
+    assert out == goal
+
+
+def test_blend_centroids_at_full_click_weight() -> None:
+    goal = [1.0, 0.0]
+    click = [0.0, 1.0]
+    blended = blend_centroids(goal, click, 1.0)
+    assert blended == [0.0, 1.0]
+
+
+def test_cosine_similarity_zero_safe() -> None:
+    assert cosine_similarity([], [1.0]) == 0.0
+
+
+def test_build_digest_plan_includes_challenge_slot() -> None:
+    ranked = [
+        {"content_id": "a", "sim": 0.9, "title": "high"},
+        {"content_id": "b", "sim": 0.1, "title": "low"},
+        {"content_id": "c", "sim": 0.5, "title": "mid"},
+    ]
+    plan = build_digest_plan(ranked, max_stories=2, challenge_min=1, challenge_max=1)
+    assert len(plan) == 2
+    slots = {p["digest_slot"] for p in plan}
+    assert slots == {"goal", "challenge"}
+    challenge = next(p for p in plan if p["digest_slot"] == "challenge")
+    assert challenge["content_id"] == "b"

--- a/tests/test_summarize_goal.py
+++ b/tests/test_summarize_goal.py
@@ -1,0 +1,23 @@
+"""Tests for goal-conditioned summarize parsing (KAZ-202)."""
+
+from summarize_goal import parse_summarize_response
+
+
+def test_parse_summarize_response_splits_blocks() -> None:
+    raw = """---要約---
+・一行目の事実。
+・二行目の事実。
+・三行目の事実。
+---関連---
+・プロジェクト焦点への関連注記。"""
+    parsed = parse_summarize_response(raw)
+    assert "一行目" in parsed.summary
+    assert "関連注記" in parsed.goal_note
+    assert "---要約---" not in parsed.summary
+
+
+def test_parse_legacy_three_line_format() -> None:
+    raw = "・のみの従来形式。\n・二行目。\n・三行目。"
+    parsed = parse_summarize_response(raw)
+    assert parsed.summary == raw
+    assert parsed.goal_note == ""

--- a/tests/test_voice.py
+++ b/tests/test_voice.py
@@ -125,7 +125,7 @@ def test_summarize_logs_warning_on_voice_violation(
         result = daily_news.summarize(fake, title="t", content="c" * 600)
 
     # 配信は通す (= 戻り値はそのまま返される)
-    assert result == dirty_summary
+    assert result.summary == dirty_summary
 
     # warning が出ている & 検出語が含まれている
     warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
@@ -146,7 +146,7 @@ def test_summarize_no_warning_for_clean_output(
     with caplog.at_level(logging.WARNING, logger=daily_news.log.name):
         result = daily_news.summarize(fake, title="t", content="c" * 600)
 
-    assert result == clean
+    assert result.summary == clean
     assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
 
 
@@ -164,5 +164,5 @@ def test_summarize_skips_check_on_empty_output(
     with caplog.at_level(logging.WARNING, logger=daily_news.log.name):
         result = daily_news.summarize(fake, title="t", content="c" * 600)
 
-    assert result == ""
+    assert result.summary == ""
     assert [r for r in caplog.records if r.levelno == logging.WARNING] == []


### PR DESCRIPTION
## Summary

- Load minimal goal focus text from active Obsidian notes under `10_projects/` (`goals/loader.py`) and embed it as a **goal centroid** for ranking when click history is sparse (no more pure-random cold start when goals exist).
- Blend goal and click centroids as clicks accumulate; keep cosine + jitter scoring with fails-open `sim=0`.
- Split Claude output into faithful `---要約---` (saved to DB) and `---関連---` (shown as the email `learning` line); goal context is prompt-only and capped for privacy.
- Reserve 1–2 **Challenge** digest slots (lowest goal similarity) to reduce confirmation bias.
- CI: set `HIBI_GOALS_OPTIONAL=1` in Daily News workflow when vault is not mounted.

## Active-project convention

In `{OBSIDIAN_VAULT_ROOT}/10_projects/<project>/`, mark notes with frontmatter `status: active` or `hibi-active: true`. Only Goal / Focus / 進捗 / 決定 sections are sent to the API. Use `HIBI_GOAL_CONTEXT_OVERRIDE` for sanitized demo profiles.

## Test plan

- [x] `pytest` (270 passed)
- [ ] After merge: set `OBSIDIAN_VAULT_ROOT` on homelab runner (or keep optional empty ranking)
- [ ] One manual `workflow_dispatch` with vault mounted to verify goal logging + challenge slot in email

Closes KAZ-202


Made with [Cursor](https://cursor.com)