### PR TITLE
feat(email): English output practice block (KAZ-203)

### DIFF
--- a/architecture/skills/hibi-domain.md
+++ b/architecture/skills/hibi-domain.md
@@ -29,6 +29,7 @@ Hibi の現行ドメイン事実を固定するスキル。
 - Stage B のフィルタ条件は `published_at >= now() - 14 days` AND `is_sent = false`
 - Stage B は ranking で上位 N 件を抽出。N の現行値は 5（旧 10 から変更済み）
 - Stage C: RSS は本文 + 要約 + Neon 保存（robots disallow / 本文未取得時は link-only）。YouTube はメタデータのみ（リンク行、要約なし）。要約は `---要約---`（DB）と `---関連---`（メール `learning` 行）を分離。challenge 枠 1–2 件常設
+- 英語産出 v0 (KAZ-203): digest に 1 区画だけ英語プロンプト + Claude 貼り付け依頼文（返信ループ・自動採点は非スコープ）
 - 各 Stage は前段の出力に対してのみ動作する。Stage C が Stage A の生メタデータを直接読まない
 - workflow timeout は 10 分以内。Stage B の N を増やすときは Stage C のランタイムを試算する
 

--- a/daily_news.py
+++ b/daily_news.py
@@ -36,6 +36,11 @@ from daily_news_ranking import (
 )
 from fetchers import rss as rss_fetcher
 from fetchers import youtube as youtube_fetcher
+from english_practice import (
+    EnglishPractice,
+    generate_english_practice,
+    pick_english_anchor,
+)
 from goals import load_goal_focus
 from mailer import build_html as build_hibi_html
 from observability import init_sentry_from_env
@@ -656,6 +661,7 @@ def main():
 
     # Stage C: 試行プールを順に処理。MAX_VIDEOS_PER_RUN 本揃ったら break
     processed_by_source: dict[str, list[dict]] = {}
+    delivered_items: list[dict] = []
     summarized_count = 0
     skipped_count = 0
 
@@ -729,17 +735,18 @@ def main():
             edition_id=edition_issue_no,
         )
 
-        processed_by_source.setdefault(item["source_name"], []).append(
-            {
-                "title": item["title"],
-                "summary": summary,
-                "goal_note": goal_note,
-                "url": item["url"],
-                "article_id": article_id,
-                "display_category": display_category,
-                "source_type": item.get("source_type"),
-            }
-        )
+        row = {
+            "title": item["title"],
+            "summary": summary,
+            "goal_note": goal_note,
+            "url": item["url"],
+            "article_id": article_id,
+            "display_category": display_category,
+            "source_type": item.get("source_type"),
+            "digest_slot": slot,
+        }
+        processed_by_source.setdefault(item["source_name"], []).append(row)
+        delivered_items.append(row)
 
         if summarized_count >= MAX_VIDEOS_PER_RUN:
             break
@@ -780,13 +787,34 @@ def main():
         # DB 書き込み失敗はメール配信を止めない (best effort)。
         log.warning("update_edition_meta failed: %s", exc)
 
-    # スキップ件数を footer で透明性表示する (#12 Phase 1)。
-    # 字幕不足 / Claude による短文 reject の合計。詳細区別は今回はしない。
+    english_practice_block: EnglishPractice | None = None
+    anchor = pick_english_anchor(delivered_items)
+    if anchor is not None:
+        try:
+            english_practice_block = generate_english_practice(
+                claude,
+                anchor,
+                goal_focus.text,
+                goal_focus.project_slugs,
+            )
+            print(f"🗣️  English practice: {english_practice_block.prompt_line[:80]}...")
+        except Exception as exc:
+            log.warning("english practice generation failed: %s", exc)
+
+    english_for_email: dict | None = None
+    if english_practice_block is not None:
+        english_for_email = {
+            "prompt_line": english_practice_block.prompt_line,
+            "paste_request": english_practice_block.paste_request,
+            "article_title": english_practice_block.article_title,
+        }
+
     html = build_hibi_html(
         articles,
         date_str,
         skipped_count=skipped_count,
         standfirst=standfirst,
+        english_practice=english_for_email,
     )
     send_email(
         subject=format_subject(date_str, count=len(articles)),

--- a/english_practice.py
+++ b/english_practice.py
@@ -1,0 +1,145 @@
+"""English output practice block for the daily digest (KAZ-203).
+
+One prompt per edition: tied to a goal-ranked or challenge article, with a
+copy-paste Claude request that stresses naturalness over grammar nitpicks.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+
+from anthropic import Anthropic
+
+log = logging.getLogger(__name__)
+
+GOAL_SNIPPET_LIMIT = 800
+PASTE_SUMMARY_LIMIT = 400
+CLAUDE_MODEL = "claude-haiku-4-5-20251001"
+
+
+@dataclass(frozen=True)
+class EnglishPractice:
+    """Single daily English output exercise."""
+
+    prompt_line: str
+    paste_request: str
+    article_title: str
+
+
+def pick_english_anchor(delivered: list[dict]) -> dict | None:
+    """Pick one digest article for the English prompt (goal first, then challenge)."""
+    if not delivered:
+        return None
+    for slot in ("goal", "challenge"):
+        for item in delivered:
+            if item.get("digest_slot") == slot:
+                return item
+    return delivered[0]
+
+
+def build_paste_request(
+    prompt_line: str,
+    *,
+    article_title: str,
+    article_summary: str | None,
+    goal_snippet: str,
+) -> str:
+    """Deterministic Claude paste block (naturalness > grammar, speak-first)."""
+    summary_text = (article_summary or "").strip()
+    if not summary_text:
+        summary_text = "(No summary — react to the title and your own take.)"
+    else:
+        summary_text = summary_text[:PASTE_SUMMARY_LIMIT]
+
+    goal_text = goal_snippet.strip() or "(No project focus loaded today.)"
+    goal_text = goal_text[:GOAL_SNIPPET_LIMIT]
+
+    return (
+        "Please help me write a short response in natural English.\n"
+        "- At least one sentence (2–3 is fine).\n"
+        "- Prioritize natural, fluent expression — not grammar nitpicking.\n"
+        "- I already spoke my thoughts aloud first; this is the written step.\n\n"
+        "---\n"
+        "Today's exercise prompt:\n"
+        f"{prompt_line}\n\n"
+        "---\n"
+        f"Article title: {article_title}\n\n"
+        "Digest context (may be Japanese):\n"
+        f"{summary_text}\n\n"
+        "---\n"
+        "My current project focus (for relevance only):\n"
+        f"{goal_text}\n"
+    )
+
+
+def _fallback_prompt_line(article_title: str, project_slugs: tuple[str, ...]) -> str:
+    projects = ", ".join(project_slugs) if project_slugs else "your active projects"
+    short_title = article_title[:80]
+    return (
+        f"In English (2–3 sentences): how does «{short_title}» apply to {projects}? "
+        "Speak out loud first, then write at least one sentence. "
+        "（まず声に出してから書く。）"
+    )
+
+
+def generate_english_practice(
+    client: Anthropic,
+    anchor: dict,
+    goal_focus_text: str,
+    project_slugs: tuple[str, ...],
+) -> EnglishPractice:
+    """Generate today's English output prompt via Claude, with template fallback."""
+    title = anchor.get("title", "")
+    summary = anchor.get("summary")
+    goal_snippet = goal_focus_text[:GOAL_SNIPPET_LIMIT]
+
+    prompt = f"""You create ONE short English-output exercise for a Japanese reader who wants to practice switching into English (not translation drills).
+
+Article title: {title}
+Digest summary (may be empty): {(summary or "")[:PASTE_SUMMARY_LIMIT]}
+Project focus (trimmed): {goal_snippet or "(none)"}
+Active projects: {", ".join(project_slugs) if project_slugs else "(unspecified)"}
+
+Rules for prompt_line:
+- One line the reader sees in their morning email.
+- Include an English task (2–3 sentences worth of output expected).
+- Tie the task to the article AND the reader's project focus (no blank page).
+- End with exactly this Japanese phrase: （まず声に出してから書く。）
+- No emoji, no exclamation marks, no marketing tone.
+
+Return ONLY JSON:
+{{"prompt_line": "..."}}"""
+
+    prompt_line = ""
+    try:
+        response = client.messages.create(
+            model=CLAUDE_MODEL,
+            max_tokens=200,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        raw = response.content[0].text.strip()
+        if raw.startswith("{"):
+            parsed = json.loads(raw)
+            if isinstance(parsed.get("prompt_line"), str):
+                prompt_line = parsed["prompt_line"].strip()
+    except (json.JSONDecodeError, KeyError, TypeError, IndexError) as exc:
+        log.warning("english practice JSON parse failed: %s", exc)
+    except Exception as exc:
+        log.warning("english practice generation failed: %s", exc)
+
+    if not prompt_line or "声に出して" not in prompt_line:
+        prompt_line = _fallback_prompt_line(title, project_slugs)
+
+    paste_request = build_paste_request(
+        prompt_line,
+        article_title=title,
+        article_summary=summary,
+        goal_snippet=goal_snippet,
+    )
+    return EnglishPractice(
+        prompt_line=prompt_line,
+        paste_request=paste_request,
+        article_title=title,
+    )

--- a/mailer.py
+++ b/mailer.py
@@ -59,6 +59,50 @@ SOURCE_KIND_STYLE = (
     "text-align:right;"
 )
 
+EN_SECTION_STYLE = (
+    "padding:28px 48px;border-top:1px solid #1A1A1A;border-bottom:1px solid #E8E6E1;"
+    "background:#FAFAF7;"
+)
+EN_LABEL_STYLE = (
+    f"font-family:{FONT_EN};font-size:10px;letter-spacing:0.25em;"
+    "text-transform:uppercase;color:#9B9894;margin-bottom:12px;"
+)
+EN_PROMPT_STYLE = (
+    f"font-family:{FONT_EN};font-size:15px;line-height:1.7;color:#1A1A1A;"
+    "margin:0 0 16px;"
+)
+EN_PASTE_STYLE = (
+    f"font-family:{FONT_EN};font-size:12px;line-height:1.6;color:#5C5A57;"
+    "margin:0;white-space:pre-wrap;"
+)
+EN_PASTE_BOX_STYLE = (
+    "margin-top:8px;padding:14px 16px;border:1px solid #E8E6E1;background:#FFFFFF;"
+)
+
+
+def _english_practice_html(practice: dict | None) -> str:
+    """Render the single English output exercise block (KAZ-203)."""
+    if not practice:
+        return ""
+
+    prompt_line = html.escape(practice.get("prompt_line", ""))
+    paste_request = html.escape(practice.get("paste_request", ""))
+    article_title = html.escape(practice.get("article_title", ""))
+
+    return (
+        f'<section class="hb-english" style="{EN_SECTION_STYLE}">'
+        f'<div style="{EN_LABEL_STYLE}">English output · 1 prompt</div>'
+        f'<p style="{EN_PROMPT_STYLE}">{prompt_line}</p>'
+        f'<div style="{EN_LABEL_STYLE}">Paste into Claude</div>'
+        f'<p style="font-family:{FONT_EN};font-size:11px;color:#9B9894;margin:0 0 8px;">'
+        f"Re: {article_title}"
+        "</p>"
+        f'<div style="{EN_PASTE_BOX_STYLE}">'
+        f'<pre style="{EN_PASTE_STYLE}">{paste_request}</pre>'
+        "</div>"
+        "</section>"
+    )
+
 
 def _story_html(index: int, article: dict, is_last: bool) -> str:
     """Render a single Story row matching design-system/ui_kits/email.
@@ -165,6 +209,7 @@ def build_html(
     date: str,
     skipped_count: int = 0,
     standfirst: str = "",
+    english_practice: dict | None = None,
 ) -> str:
     """Build the daily email HTML from enriched article dicts.
 
@@ -181,6 +226,10 @@ def build_html(
     な朝の読みもの。" placeholder. Empty string (default) keeps the legacy
     static standfirst so callers that do not opt-in stay byte-compatible
     behavior-wise.
+
+    ``english_practice`` is an optional dict with ``prompt_line``,
+    ``paste_request``, and ``article_title`` (KAZ-203). Rendered as one
+    section after stories, before sources.
     """
     with open(TEMPLATE_PATH, encoding="utf-8") as f:
         template = Template(f.read())
@@ -225,10 +274,13 @@ def build_html(
             f"</em>静かな朝の読みもの。"
         )
 
+    english_practice_html = _english_practice_html(english_practice)
+
     return template.safe_substitute(
         date=date,
         article_count=len(articles),
         articles_html=articles_html,
+        english_practice_html=english_practice_html,
         sources_html=sources_html,
         source_count=source_count,
         skipped_html=skipped_html,

--- a/templates/email.html
+++ b/templates/email.html
@@ -57,6 +57,8 @@
 
   $articles_html
 
+  $english_practice_html
+
   <section class="hb-srcs" style="padding:32px 48px;border-top:1px solid #1A1A1A;background:#FAFAF7;">
     <div style="font-family:'Inter',system-ui,-apple-system,sans-serif;font-size:10px;letter-spacing:0.25em;text-transform:uppercase;color:#9B9894;margin-bottom:14px;">Sources scanned this morning</div>
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;">

--- a/tests/test_english_practice.py
+++ b/tests/test_english_practice.py
@@ -1,0 +1,64 @@
+"""Tests for English output practice (KAZ-203)."""
+
+import json
+
+import english_practice as ep
+
+
+def test_pick_english_anchor_prefers_goal_slot() -> None:
+    delivered = [
+        {"digest_slot": "challenge", "title": "c"},
+        {"digest_slot": "goal", "title": "g"},
+    ]
+    anchor = ep.pick_english_anchor(delivered)
+    assert anchor is not None
+    assert anchor["title"] == "g"
+
+
+def test_build_paste_request_includes_naturalness_instruction() -> None:
+    paste = ep.build_paste_request(
+        "In English: react to the story. （まず声に出してから書く。）",
+        article_title="Test Article",
+        article_summary="要約本文。",
+        goal_snippet="Project: hibi",
+    )
+    assert "natural English" in paste
+    assert "not grammar nitpicking" in paste
+    assert "spoke my thoughts aloud" in paste
+    assert "Test Article" in paste
+
+
+def test_generate_english_practice_uses_claude_json(monkeypatch) -> None:
+    class FakeBlock:
+        def __init__(self, text: str) -> None:
+            self.text = text
+
+    class FakeResponse:
+        def __init__(self, text: str) -> None:
+            self.content = [FakeBlock(text)]
+
+    class FakeMessages:
+        def create(self, **_kwargs):
+            payload = json.dumps(
+                {
+                    "prompt_line": (
+                        "In English (2–3 sentences): tie this to Monogatari. "
+                        "（まず声に出してから書く。）"
+                    )
+                }
+            )
+            return FakeResponse(payload)
+
+    class FakeClient:
+        messages = FakeMessages()
+
+    anchor = {"title": "React 19 ships", "summary": "・要点。"}
+    result = ep.generate_english_practice(
+        FakeClient(),
+        anchor,
+        goal_focus_text="Goal: ship Monogatari",
+        project_slugs=("monogatari",),
+    )
+    assert "Monogatari" in result.prompt_line
+    assert "Paste into Claude" not in result.paste_request
+    assert "natural English" in result.paste_request

--- a/tests/test_english_practice_mailer.py
+++ b/tests/test_english_practice_mailer.py
@@ -1,0 +1,31 @@
+"""Mailer rendering for English practice section (KAZ-203)."""
+
+import mailer
+
+
+def test_build_html_renders_english_practice_section() -> None:
+    practice = {
+        "prompt_line": (
+            "In English (2 sentences): apply this to your job search. "
+            "（まず声に出してから書く。）"
+        ),
+        "paste_request": "Please help me write natural English.\nNot grammar nitpicking.",
+        "article_title": "Sample Story",
+    }
+    html = mailer.build_html(
+        [{"title": "T", "url": "https://example.com", "summary": "s", "source": "S"}],
+        "2026.06.03",
+        english_practice=practice,
+    )
+    assert "English output" in html
+    assert "Paste into Claude" in html
+    assert "grammar nitpicking" in html
+    assert "まず声に出して" in html
+
+
+def test_build_html_omits_english_section_when_none() -> None:
+    html = mailer.build_html(
+        [{"title": "T", "url": "https://example.com", "summary": "s", "source": "S"}],
+        "2026.06.03",
+    )
+    assert "English output" not in html


### PR DESCRIPTION
## Summary

- Add one **English output** section to the morning digest (after stories, before sources).
- Anchor article: prefer `digest_slot=goal`, else `challenge` (KAZ-202 slots).
- Claude generates a single prompt line tied to the article + Obsidian goal focus; a deterministic **Paste into Claude** block includes naturalness-over-grammar instructions and speak-then-write.
- Zero extra infra: reuses the existing Anthropic client; no reply loop or auto-feedback (v0 habit validation only).

## Test plan

- [x] `pytest` (275 passed)
- [ ] One `workflow_dispatch` — confirm English section appears in Gmail
- [ ] 1–2 weeks: track whether the prompt gets used before opening issue (a) reply loop

Closes KAZ-203


Made with [Cursor](https://cursor.com)