### PR TITLE
feat(ranking): per-project goal digest v2 (KAZ-204)

### DIFF
--- a/architecture/skills/hibi-domain.md
+++ b/architecture/skills/hibi-domain.md
@@ -15,6 +15,8 @@ Hibi の現行ドメイン事実を固定するスキル。
 - ranking 反映は **次回バッチ実行時**。クリックは即座に centroid を更新しない
 - embedding 対象は `title + summary`。本文ではない
 - cold start: `clicks_in_30d < 5` では Obsidian active project の **goal centroid** でランキング（KAZ-202）。goal も無いときのみ純ランダム
+- digest v2 (KAZ-204): allowlist は `monogatari` / `roamlore` のみ（`hibi` 自身は対象外）。conditioning は各 `10_projects/<slug>/` の `decisions.md` + `strategy.md` + `status.md` を `goals.loader.read_active_note` で読む（`status: active` / `hibi-active: true` 必須、見出し完全一致セクションのみ、ファイル mtime 降順 + 8000字 cap）。**プロジェクト別 centroid**（クリック blend なし）。類似度 `< 0.28` は novelty レーン。有用記事は `30_raw/hibi/capture/`、digest 満杯時の novelty は `30_raw/hibi/inbox/`（1 件/日）。centroid は vault `.hibi/goal_centroid_cache.json` または `HIBI_GOAL_CACHE_DIR`
+- `goals.loader`（KAZ-202 fallback）も同一 allowlist + frontmatter + 見出し規約。6000字 cap 前にノート mtime 降順
 - score 式: `sim × 0.7 × weight + rand() × (1 − 0.4 × weight)`、weight = `min(1, clicks_in_30d / 30)`
 - 現行の事実は以下のダイアグラムから確認する:
   - `architecture/diagrams/pipeline-flow.mmd`
@@ -28,7 +30,7 @@ Hibi の現行ドメイン事実を固定するスキル。
 - Stage A は **メタデータのみ** 取得する。transcript / 本文取得を Stage A に混ぜない
 - Stage B のフィルタ条件は `published_at >= now() - 14 days` AND `is_sent = false`
 - Stage B は ranking で上位 N 件を抽出。N の現行値は 5（旧 10 から変更済み）
-- Stage C: RSS は本文 + 要約 + Neon 保存（robots disallow / 本文未取得時は link-only）。YouTube はメタデータのみ（リンク行、要約なし）。要約は `---要約---`（DB）と `---関連---`（メール `learning` 行）を分離。challenge 枠 1–2 件常設
+- Stage C: RSS は本文 + 要約 + Neon 保存（robots disallow / 本文未取得時は link-only）。YouTube はメタデータのみ（リンク行、要約なし）。要約は `---要約---`（DB）と `---関連---`（メール `learning` 行）を分離。challenge 枠 1–2 件常設。v2 時は `---関連---` を `→ {Monogatari|RoamLore}:` で始める適用注記。メール並びは digest plan 順（v2）または `sources.yaml` 順（v1 fallback）
 - 英語産出 v0 (KAZ-203): digest に 1 区画だけ英語プロンプト + Claude 貼り付け依頼文（返信ループ・自動採点は非スコープ）
 - 各 Stage は前段の出力に対してのみ動作する。Stage C が Stage A の生メタデータを直接読まない
 - workflow timeout は 10 分以内。Stage B の N を増やすときは Stage C のランタイムを試算する

--- a/daily_news.py
+++ b/daily_news.py
@@ -31,8 +31,10 @@ from db import (
 )
 from daily_news_ranking import (
     build_digest_plan,
+    build_digest_plan_v2,
     resolve_ranking_centroid,
     score_candidates,
+    score_candidates_multi_project,
 )
 from fetchers import rss as rss_fetcher
 from fetchers import youtube as youtube_fetcher
@@ -41,7 +43,13 @@ from english_practice import (
     generate_english_practice,
     pick_english_anchor,
 )
-from goals import load_goal_focus
+from goals import (
+    embed_subject_centroids,
+    load_goal_focus,
+    load_subject_catalog,
+    write_novelty_inbox_item,
+    write_raw_capture,
+)
 from mailer import build_html as build_hibi_html
 from observability import init_sentry_from_env
 from ranking import compute_interest_centroid, count_recent_clicks
@@ -211,14 +219,17 @@ def summarize(
     title: str,
     content: str,
     goal_context: str = "",
+    *,
+    target_project_label: str = "",
 ) -> SummaryResult:
-    """Return faithful summary + optional goal-relevance note (KAZ-202)."""
+    """Return faithful summary + optional goal-relevance note (KAZ-202 / KAZ-204)."""
     prompt = build_summarize_prompt(
         title,
         content,
         voice_rule=_VOICE_RULE,
         content_char_limit=CONTENT_CHAR_LIMIT,
         goal_context=goal_context[:GOAL_CONTEXT_PROMPT_LIMIT],
+        target_project_label=target_project_label,
     )
 
     response = client.messages.create(
@@ -448,6 +459,24 @@ def _redirect_url(article_id: str | None, original_url: str) -> str:
 # ============================================================
 # Build HTML email (Hibi design-system; see `mailer.build_html`)
 # ============================================================
+def _delivered_to_articles(delivered_items: list[dict]) -> list[dict]:
+    """Flatten digest plan order into mailer articles (KAZ-204)."""
+    articles: list[dict] = []
+    for item in delivered_items:
+        articles.append(
+            {
+                "title": item["title"],
+                "url": _redirect_url(item.get("article_id"), item["url"]),
+                "summary": item["summary"],
+                "source": item.get("source_name", ""),
+                "category": item.get("display_category") or item.get("category"),
+                "source_type": item.get("source_type"),
+                "learning": item.get("goal_note") or "",
+            }
+        )
+    return articles
+
+
 def _sections_to_articles(sections: list[dict]) -> list[dict]:
     """Flatten `sections` (grouped by source) into the flat `articles` shape
     `mailer.build_html` expects, applying the click-tracking redirect to
@@ -550,6 +579,46 @@ def rank_candidates(
     return candidates
 
 
+def rank_candidates_subject_v2(
+    candidates: list[dict],
+    openai_client,
+    project_centroids: dict[str, list[float]],
+) -> list[dict]:
+    """Rank by per-project centroids only (KAZ-204; no goal/click blend)."""
+    if not project_centroids:
+        random.shuffle(candidates)
+        return candidates
+
+    texts = [
+        f"{c.get('title', '')}\n\n{(c.get('description') or '')[:RANKING_DESC_CHAR_LIMIT]}"
+        for c in candidates
+    ]
+    vectors = embed_batch(openai_client, texts)
+    score_candidates_multi_project(
+        candidates,
+        vectors,
+        project_centroids,
+        ranking_weight=1.0,
+        sim_base=SIM_BASE,
+        jitter_base=JITTER_BASE,
+    )
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    print(
+        f"\n📊 Ranked {len(candidates)} candidates "
+        f"(signal=subject-v2, projects={', '.join(project_centroids.keys())})"
+    )
+    for i, c in enumerate(candidates[:RANKING_TOP_LOG], 1):
+        title = (c.get("title") or "")[:60]
+        proj = c.get("target_project") or "—"
+        sim = c.get("project_sim", c.get("sim", 0.0))
+        print(
+            f"  [rank {i:2d}] project={proj} sim={sim:.2f}  "
+            f"{c.get('source_name', '?')} / {title}"
+        )
+    return candidates
+
+
 # ============================================================
 # Gmail send
 # ============================================================
@@ -634,18 +703,57 @@ def main():
     else:
         print("🎯 Goal context: (empty — optional vault or no active projects)")
 
-    goal_centroid = embed_goal_centroid(openai_client, goal_focus.text)
+    subject_catalog = load_subject_catalog()
+    project_centroids = embed_subject_centroids(
+        openai_client,
+        subject_catalog,
+        embed_batch=embed_batch,
+        embedding_model=EMBEDDING_MODEL,
+    )
+    use_subject_v2 = bool(project_centroids)
 
-    # Stage B: goal + click centroid ranking, then digest plan with challenge slots.
-    ranked = rank_candidates(
-        candidates, DEFAULT_USER_ID, openai_client, goal_centroid=goal_centroid
-    )
-    digest_plan = build_digest_plan(
-        ranked[:MAX_ATTEMPTS],
-        MAX_VIDEOS_PER_RUN,
-        challenge_min=CHALLENGE_SLOTS_MIN,
-        challenge_max=CHALLENGE_SLOTS_MAX,
-    )
+    if use_subject_v2:
+        for project in subject_catalog.projects:
+            if project.slug in project_centroids:
+                print(
+                    f"🎯 Subject centroid: {project.display_name} "
+                    f"({project.file_count} conditioning file(s))"
+                )
+            elif not project.conditioning_text.strip():
+                print(
+                    f"🎯 Subject centroid: {project.display_name} "
+                    "(empty conditioning — skipped)"
+                )
+        ranked = rank_candidates_subject_v2(
+            candidates, openai_client, project_centroids
+        )
+        digest_plan, inbox_overflow = build_digest_plan_v2(
+            ranked[:MAX_ATTEMPTS],
+            max_stories=MAX_VIDEOS_PER_RUN,
+            challenge_min=CHALLENGE_SLOTS_MIN,
+            challenge_max=CHALLENGE_SLOTS_MAX,
+        )
+        for overflow in inbox_overflow:
+            path = write_novelty_inbox_item(
+                title=overflow["title"],
+                url=overflow["url"],
+                reason="below project similarity threshold; digest full",
+            )
+            if path:
+                print(f"📥 Novelty inbox: {path.name}")
+    else:
+        goal_centroid = embed_goal_centroid(openai_client, goal_focus.text)
+        ranked = rank_candidates(
+            candidates, DEFAULT_USER_ID, openai_client, goal_centroid=goal_centroid
+        )
+        digest_plan = build_digest_plan(
+            ranked[:MAX_ATTEMPTS],
+            MAX_VIDEOS_PER_RUN,
+            challenge_min=CHALLENGE_SLOTS_MIN,
+            challenge_max=CHALLENGE_SLOTS_MAX,
+        )
+        inbox_overflow = []
+
     plan_ids = {c["content_id"] for c in digest_plan}
     attempt_pool = digest_plan + [
         c for c in ranked[:MAX_ATTEMPTS] if c["content_id"] not in plan_ids
@@ -688,11 +796,19 @@ def main():
                     f"{char_count} chars)"
                 )
         else:
+            target_slug = item.get("target_project") or ""
+            if use_subject_v2 and target_slug:
+                goal_ctx = subject_catalog.conditioning_for(target_slug)
+                project_label = subject_catalog.display_name(target_slug)
+            else:
+                goal_ctx = goal_focus.text
+                project_label = ""
             parsed = summarize(
                 claude,
                 item["title"],
                 content or "",
-                goal_context=goal_focus.text,
+                goal_context=goal_ctx,
+                target_project_label=project_label,
             )
             summary = parsed.summary
             goal_note = parsed.goal_note
@@ -709,12 +825,16 @@ def main():
             label = "link-only"
         elif slot == "challenge":
             label = "challenge"
+        elif slot == "novelty":
+            label = "novelty"
+        elif slot == "project":
+            label = "project"
         else:
             label = "summarized"
         print(f"  ✅ {label} ({summarized_count}/{MAX_VIDEOS_PER_RUN})")
 
-        display_category = item.get("category")
-        if slot == "challenge":
+        display_category = item.get("display_category") or item.get("category")
+        if slot == "challenge" and not item.get("display_category"):
             display_category = "Challenge"
 
         embedding = embed_article(
@@ -743,10 +863,22 @@ def main():
             "article_id": article_id,
             "display_category": display_category,
             "source_type": item.get("source_type"),
+            "source_name": item["source_name"],
             "digest_slot": slot,
+            "target_project": item.get("target_project"),
         }
         processed_by_source.setdefault(item["source_name"], []).append(row)
         delivered_items.append(row)
+
+        capture_path = write_raw_capture(
+            title=item["title"],
+            url=item["url"],
+            target_project=item.get("target_project"),
+            summary=summary,
+            goal_note=goal_note or None,
+        )
+        if capture_path:
+            print(f"  📎 Capture: {capture_path.name}")
 
         if summarized_count >= MAX_VIDEOS_PER_RUN:
             break
@@ -758,19 +890,20 @@ def main():
             "Likely cause: content blocking or low candidate pool."
         )
 
-    # sources.yaml の順序で section を組み立てる
-    sections = [
-        {"source_name": s["name"], "items": processed_by_source[s["name"]]}
-        for s in sources
-        if s["name"] in processed_by_source
-    ]
-
-    if not sections:
+    if not delivered_items:
         print("\n⚠️  No content to send today.")
         return
 
     date_str = datetime.now(timezone.utc).strftime("%Y.%m.%d")
-    articles = _sections_to_articles(sections)
+    if use_subject_v2:
+        articles = _delivered_to_articles(delivered_items)
+    else:
+        sections = [
+            {"source_name": s["name"], "items": processed_by_source[s["name"]]}
+            for s in sources
+            if s["name"] in processed_by_source
+        ]
+        articles = _sections_to_articles(sections)
 
     # Stage D: edition meta (standfirst + daily_title) を Claude で生成し、
     # editions テーブルに書き戻す (Issue #53)。Claude 失敗時はフォールバック値

--- a/daily_news_ranking.py
+++ b/daily_news_ranking.py
@@ -1,11 +1,14 @@
-"""Goal-conditioned ranking and digest slot planning (KAZ-202)."""
+"""Goal-conditioned ranking and digest slot planning (KAZ-202 / KAZ-204)."""
 
 from __future__ import annotations
 
 import random
 from typing import Any, Sequence
 
+from goals.subjects import DISPLAY_NAMES, SUBJECT_ALLOWLIST
 from ranking import blend_centroids, cosine_similarity
+
+NOVELTY_SIM_THRESHOLD = 0.28
 
 
 def resolve_ranking_centroid(
@@ -80,3 +83,128 @@ def build_digest_plan(
     for pick in challenge_picks:
         plan.append({**pick, "digest_slot": "challenge"})
     return plan
+
+
+def score_candidates_multi_project(
+    candidates: list[dict],
+    vectors: list[list[float] | None],
+    project_centroids: dict[str, list[float]],
+    *,
+    ranking_weight: float,
+    sim_base: float,
+    jitter_base: float,
+) -> None:
+    """Assign ``target_project``, ``project_sim``, and ranking ``score`` per candidate."""
+    weight = max(0.0, min(1.0, ranking_weight))
+    for candidate, vec in zip(candidates, vectors, strict=False):
+        if vec is None or not project_centroids:
+            candidate["project_sim"] = 0.0
+            candidate["target_project"] = None
+            candidate["digest_lane"] = "novelty"
+            candidate["sim"] = 0.0
+            candidate["score"] = random.random()
+            continue
+
+        best_slug: str | None = None
+        best_sim = 0.0
+        for slug, centroid in project_centroids.items():
+            sim = cosine_similarity(vec, centroid)
+            if sim > best_sim:
+                best_sim = sim
+                best_slug = slug
+
+        candidate["project_sim"] = best_sim
+        candidate["target_project"] = best_slug
+        if best_sim < NOVELTY_SIM_THRESHOLD:
+            candidate["digest_lane"] = "novelty"
+            candidate["sim"] = best_sim
+        else:
+            candidate["digest_lane"] = "project"
+            candidate["sim"] = best_sim
+
+        candidate["score"] = candidate["sim"] * sim_base * weight + random.random() * (
+            1.0 - (sim_base - jitter_base) * weight
+        )
+
+
+def build_digest_plan_v2(
+    ranked: list[dict],
+    *,
+    subject_slugs: tuple[str, ...] = SUBJECT_ALLOWLIST,
+    max_stories: int,
+    challenge_min: int = 1,
+    challenge_max: int = 1,
+    novelty_max: int = 1,
+) -> tuple[list[dict], list[dict]]:
+    """Per-project top story first, then novelty/challenge/fill. Returns plan + inbox overflow."""
+    if not ranked or max_stories <= 0:
+        return [], []
+
+    picked_ids: set[str] = set()
+    plan: list[dict] = []
+    inbox_overflow: list[dict] = []
+
+    for slug in subject_slugs:
+        if len(plan) >= max_stories:
+            break
+        label = DISPLAY_NAMES.get(slug, slug)
+        best: dict | None = None
+        for candidate in ranked:
+            if candidate["content_id"] in picked_ids:
+                continue
+            if candidate.get("target_project") != slug:
+                continue
+            if best is None or float(candidate.get("project_sim", 0)) > float(
+                best.get("project_sim", 0)
+            ):
+                best = candidate
+        if best is None:
+            continue
+        plan.append(
+            {
+                **best,
+                "digest_slot": "project",
+                "display_category": f"→ {label}",
+            }
+        )
+        picked_ids.add(best["content_id"])
+
+    novelty_pool = [
+        c
+        for c in ranked
+        if c.get("digest_lane") == "novelty" and c["content_id"] not in picked_ids
+    ]
+    novelty_pool.sort(key=lambda c: float(c.get("score", 0)), reverse=True)
+    if novelty_pool:
+        pick = novelty_pool[0]
+        if len(plan) < max_stories:
+            plan.append(
+                {**pick, "digest_slot": "novelty", "display_category": "Idea"}
+            )
+            picked_ids.add(pick["content_id"])
+        elif novelty_max > 0:
+            inbox_overflow.append(pick)
+
+    n_challenge = 0
+    if len(plan) < max_stories and challenge_min > 0:
+        n_challenge = min(challenge_max, challenge_min, max_stories - len(plan))
+
+    by_sim_asc = sorted(
+        [c for c in ranked if c["content_id"] not in picked_ids],
+        key=lambda c: float(c.get("project_sim", c.get("sim", 0))),
+    )
+    for pick in by_sim_asc[:n_challenge]:
+        if len(plan) >= max_stories:
+            break
+        plan.append({**pick, "digest_slot": "challenge", "display_category": "Challenge"})
+        picked_ids.add(pick["content_id"])
+
+    for candidate in ranked:
+        if len(plan) >= max_stories:
+            break
+        if candidate["content_id"] in picked_ids:
+            continue
+        plan.append({**candidate, "digest_slot": "fill"})
+        picked_ids.add(candidate["content_id"])
+
+    return plan, inbox_overflow

--- a/goals/__init__.py
+++ b/goals/__init__.py
@@ -1,5 +1,26 @@
-"""Obsidian active-project goal context for Hibi ranking and summarization."""
+"""Obsidian goal context for Hibi ranking and summarization."""
 
-from goals.loader import GoalFocus, load_goal_focus
+from goals.centroids import embed_subject_centroids
+from goals.loader import (
+    CONDITIONING_FILES,
+    GoalFocus,
+    SUBJECT_ALLOWLIST,
+    load_goal_focus,
+    read_active_note,
+)
+from goals.subjects import SubjectCatalog, SubjectProject, load_subject_catalog
+from goals.vault_io import write_novelty_inbox_item, write_raw_capture
 
-__all__ = ["GoalFocus", "load_goal_focus"]
+__all__ = [
+    "CONDITIONING_FILES",
+    "GoalFocus",
+    "SUBJECT_ALLOWLIST",
+    "SubjectCatalog",
+    "SubjectProject",
+    "embed_subject_centroids",
+    "load_goal_focus",
+    "load_subject_catalog",
+    "read_active_note",
+    "write_novelty_inbox_item",
+    "write_raw_capture",
+]

--- a/goals/centroids.py
+++ b/goals/centroids.py
@@ -1,0 +1,97 @@
+"""Per-project embedding centroids with on-disk cache (KAZ-204)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Final
+
+from goals.subjects import SubjectCatalog, SubjectProject
+
+CACHE_DIR_ENV: Final[str] = "HIBI_GOAL_CACHE_DIR"
+CACHE_FILENAME: Final[str] = "goal_centroid_cache.json"
+
+
+def _fingerprint(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:24]
+
+
+def _cache_path() -> Path | None:
+    explicit = os.environ.get(CACHE_DIR_ENV)
+    if explicit:
+        return Path(explicit) / CACHE_FILENAME
+    vault = os.environ.get("OBSIDIAN_VAULT_ROOT")
+    if vault:
+        return Path(vault) / ".hibi" / CACHE_FILENAME
+    return None
+
+
+def _read_cache() -> dict[str, dict[str, object]]:
+    path = _cache_path()
+    if path is None or not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+    if isinstance(data, dict):
+        return data
+    return {}
+
+
+def _write_cache(data: dict[str, dict[str, object]]) -> None:
+    path = _cache_path()
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def embed_subject_centroids(
+    openai_client,
+    catalog: SubjectCatalog,
+    *,
+    embed_batch,
+    embedding_model: str,
+) -> dict[str, list[float]]:
+    """Return per-slug centroids; reuse cache when conditioning fingerprint matches."""
+    if openai_client is None or not catalog.projects:
+        return {}
+
+    cache = _read_cache()
+    out: dict[str, list[float]] = {}
+    to_embed: list[SubjectProject] = []
+    texts: list[str] = []
+
+    for project in catalog.projects:
+        if not project.conditioning_text.strip():
+            continue
+        fp = _fingerprint(project.conditioning_text)
+        entry = cache.get(project.slug)
+        if (
+            isinstance(entry, dict)
+            and entry.get("fingerprint") == fp
+            and isinstance(entry.get("embedding"), list)
+        ):
+            out[project.slug] = [float(x) for x in entry["embedding"]]
+            continue
+        to_embed.append(project)
+        texts.append(project.conditioning_text)
+
+    if to_embed:
+        vectors = embed_batch(openai_client, texts)
+        for project, vec in zip(to_embed, vectors, strict=False):
+            if vec is None:
+                continue
+            fp = _fingerprint(project.conditioning_text)
+            out[project.slug] = vec
+            cache[project.slug] = {
+                "fingerprint": fp,
+                "embedding": vec,
+                "model": embedding_model,
+            }
+
+    _write_cache(cache)
+    return out

--- a/goals/loader.py
+++ b/goals/loader.py
@@ -1,17 +1,15 @@
-"""Load minimal goal focus text from Obsidian ``10_projects/`` active notes.
+"""Load goal focus / conditioning text from Obsidian ``10_projects/`` notes.
 
-Active-project convention (KAZ-202):
-- Vault root: ``OBSIDIAN_VAULT_ROOT`` (same as idea-mining).
-- Scan ``10_projects/<project>/`` — one directory depth under ``10_projects/``.
-- A project is **active** when any ``*.md`` in that folder has YAML frontmatter
-  with ``hibi-active: true`` or ``status: active`` (case-insensitive).
-- Abandoned paths are skipped: ``archive``, ``done``, ``abandoned``, ``.trash``.
-- Only these sections are extracted (heading match, case-insensitive):
-  Goal / ゴール / Focus / 焦点 / 進捗 / 決定 / Progress / Decision.
-- Concatenated focus text is capped at ``GOAL_FOCUS_CHAR_LIMIT`` for API privacy.
+Conventions (KAZ-202 / KAZ-204):
+- Vault root: ``OBSIDIAN_VAULT_ROOT``.
+- Subject allowlist (growth targets): ``monogatari``, ``roamlore`` — not ``hibi``.
+- A note is **active** only with YAML frontmatter ``hibi-active: true`` or
+  ``status: active`` (case-insensitive). Notes without frontmatter are skipped.
+- Section extraction uses **exact** ``##`` heading match (case-insensitive).
+- Notes are merged newest-first (mtime desc) before the char cap.
+- Abandoned path segments are skipped: ``archive``, ``done``, ``abandoned``, ``.trash``.
 
-Tests may set ``HIBI_GOALS_OPTIONAL=1`` (empty focus, no error) or
-``HIBI_GOAL_CONTEXT_OVERRIDE`` (synthetic profile for demos).
+Tests may set ``HIBI_GOALS_OPTIONAL=1`` or ``HIBI_GOAL_CONTEXT_OVERRIDE``.
 """
 from __future__ import annotations
 
@@ -26,6 +24,14 @@ OPTIONAL_ENV: Final[str] = "HIBI_GOALS_OPTIONAL"
 OVERRIDE_ENV: Final[str] = "HIBI_GOAL_CONTEXT_OVERRIDE"
 PROJECTS_SUBPATH: Final[str] = "10_projects"
 GOAL_FOCUS_CHAR_LIMIT: Final[int] = 6000
+
+SUBJECT_ALLOWLIST: Final[tuple[str, ...]] = ("monogatari", "roamlore")
+CONDITIONING_FILES: Final[tuple[str, ...]] = (
+    "decisions.md",
+    "strategy.md",
+    "status.md",
+)
+
 _EXCLUDED_PATH_PARTS: Final[frozenset[str]] = frozenset(
     {"archive", "done", "abandoned", ".trash", "_templates"}
 )
@@ -41,6 +47,15 @@ _SECTION_NAMES: Final[frozenset[str]] = frozenset(
         "決定",
         "progress",
         "decision",
+        "戦略",
+        "strategy",
+        "vision",
+        "ビジョン",
+        "positioning",
+        "ポジショニング",
+        "現状",
+        "現在のフェーズ",
+        "status",
     }
 )
 _FRONTMATTER_RE = re.compile(r"\A---\s*\r?\n(.*?)\r?\n---\s*\r?\n", re.DOTALL)
@@ -92,7 +107,8 @@ def _extract_focus_sections(body: str) -> str:
     return "\n\n".join(parts)
 
 
-def _note_focus(path: Path) -> str:
+def read_active_note(path: Path) -> str:
+    """Return extracted focus text for an active note, or empty if inactive."""
     raw = path.read_text(encoding="utf-8")
     body = raw
     fm_match = _FRONTMATTER_RE.match(raw)
@@ -101,7 +117,6 @@ def _note_focus(path: Path) -> str:
             return ""
         body = raw[fm_match.end() :]
     elif not _optional_enabled():
-        # Without frontmatter, non-optional runs ignore the file (not marked active).
         return ""
 
     return _extract_focus_sections(body)
@@ -111,8 +126,21 @@ def _path_excluded(path: Path) -> bool:
     return any(part in _EXCLUDED_PATH_PARTS for part in path.parts)
 
 
+def _notes_newest_first(project_dir: Path) -> list[str]:
+    """Collect active note excerpts sorted by mtime descending."""
+    dated: list[tuple[float, str]] = []
+    for md_path in project_dir.rglob("*.md"):
+        if _path_excluded(md_path):
+            continue
+        focus = read_active_note(md_path)
+        if focus:
+            dated.append((md_path.stat().st_mtime, focus))
+    dated.sort(key=lambda row: row[0], reverse=True)
+    return [text for _, text in dated]
+
+
 def load_goal_focus() -> GoalFocus:
-    """Load capped goal focus text from active project notes under ``10_projects/``."""
+    """Load capped goal focus from allowlisted active project notes."""
     override = os.environ.get(OVERRIDE_ENV, "").strip()
     if override:
         return GoalFocus(text=override[:GOAL_FOCUS_CHAR_LIMIT], project_slugs=("override",))
@@ -135,17 +163,11 @@ def load_goal_focus() -> GoalFocus:
 
     chunks: list[str] = []
     slugs: list[str] = []
-    for project_dir in sorted(projects_root.iterdir()):
-        if not project_dir.is_dir() or project_dir.name.startswith("."):
+    for slug in SUBJECT_ALLOWLIST:
+        project_dir = projects_root / slug
+        if not project_dir.is_dir():
             continue
-        slug = project_dir.name
-        project_parts: list[str] = []
-        for md_path in sorted(project_dir.rglob("*.md")):
-            if _path_excluded(md_path):
-                continue
-            focus = _note_focus(md_path)
-            if focus:
-                project_parts.append(focus)
+        project_parts = _notes_newest_first(project_dir)
         if not project_parts:
             continue
         slugs.append(slug)

--- a/goals/subjects.py
+++ b/goals/subjects.py
@@ -1,0 +1,135 @@
+"""Subject-project conditioning for digest v2 (KAZ-204).
+
+Growth targets are explicit allowlisted folders under ``10_projects/`` —
+not ``hibi`` itself. Conditioning uses ``decisions.md``, ``strategy.md``,
+``status.md`` via ``goals.loader.read_active_note`` (frontmatter + section
+extraction + file mtime ordering). ``daily-log`` is excluded by filename.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Final
+
+from goals.loader import (
+    CONDITIONING_FILES,
+    OPTIONAL_ENV,
+    OVERRIDE_ENV,
+    PROJECTS_SUBPATH,
+    SUBJECT_ALLOWLIST,
+    VAULT_ROOT_ENV,
+    read_active_note,
+)
+
+CONDITIONING_CHAR_LIMIT: Final[int] = 8000
+DISPLAY_NAMES: Final[dict[str, str]] = {
+    "monogatari": "Monogatari",
+    "roamlore": "RoamLore",
+}
+
+
+@dataclass(frozen=True)
+class SubjectProject:
+    slug: str
+    display_name: str
+    conditioning_text: str
+    file_count: int
+
+
+@dataclass(frozen=True)
+class SubjectCatalog:
+    projects: tuple[SubjectProject, ...]
+
+    @property
+    def slugs(self) -> tuple[str, ...]:
+        return tuple(p.slug for p in self.projects)
+
+    def conditioning_for(self, slug: str) -> str:
+        for project in self.projects:
+            if project.slug == slug:
+                return project.conditioning_text
+        return ""
+
+    def display_name(self, slug: str) -> str:
+        return DISPLAY_NAMES.get(slug, slug)
+
+
+def _optional_enabled() -> bool:
+    return os.environ.get(OPTIONAL_ENV) == "1"
+
+
+def _recency_weight(mtime: float, now: float) -> float:
+    """Linear decay: 1.0 today, ~0.5 at 7 days, floor 0.1."""
+    age_days = max(0.0, (now - mtime) / 86400.0)
+    return max(0.1, 1.0 - age_days / 14.0)
+
+
+def _load_conditioning(project_dir: Path) -> tuple[str, int]:
+    now = datetime.now(timezone.utc).timestamp()
+    weighted: list[tuple[float, str, str]] = []
+    used = 0
+    for filename in CONDITIONING_FILES:
+        path = project_dir / filename
+        if not path.is_file():
+            continue
+        used += 1
+        body = read_active_note(path)
+        if not body:
+            continue
+        weight = _recency_weight(path.stat().st_mtime, now)
+        weighted.append((weight, filename, body))
+    weighted.sort(key=lambda row: row[0], reverse=True)
+
+    parts: list[str] = []
+    for _weight, filename, body in weighted:
+        parts.append(f"## {filename}\n{body}")
+    text = "\n\n".join(parts)[:CONDITIONING_CHAR_LIMIT]
+    return text, used
+
+
+def load_subject_catalog() -> SubjectCatalog:
+    """Load allowlisted subject projects and their conditioning corpora."""
+    override = os.environ.get(OVERRIDE_ENV, "").strip()
+    if override:
+        demo = SubjectProject(
+            slug="monogatari",
+            display_name="Monogatari",
+            conditioning_text=override[:CONDITIONING_CHAR_LIMIT],
+            file_count=1,
+        )
+        return SubjectCatalog(projects=(demo,))
+
+    optional = _optional_enabled()
+    vault_root = os.environ.get(VAULT_ROOT_ENV)
+    if not vault_root:
+        if optional:
+            return SubjectCatalog(projects=())
+        raise RuntimeError(
+            f"{VAULT_ROOT_ENV} is not set; cannot load subject projects. "
+            f"Set {OPTIONAL_ENV}=1 to bypass (tests/CI only)."
+        )
+
+    projects_root = Path(vault_root) / PROJECTS_SUBPATH
+    if not projects_root.is_dir():
+        if optional:
+            return SubjectCatalog(projects=())
+        raise RuntimeError(f"Projects directory missing: {projects_root}")
+
+    loaded: list[SubjectProject] = []
+    for slug in SUBJECT_ALLOWLIST:
+        project_dir = projects_root / slug
+        if not project_dir.is_dir():
+            continue
+        text, file_count = _load_conditioning(project_dir)
+        loaded.append(
+            SubjectProject(
+                slug=slug,
+                display_name=DISPLAY_NAMES.get(slug, slug),
+                conditioning_text=text,
+                file_count=file_count,
+            )
+        )
+    return SubjectCatalog(projects=tuple(loaded))

--- a/goals/vault_io.py
+++ b/goals/vault_io.py
@@ -1,0 +1,101 @@
+"""Vault-side capture + idea-mining inbox writes (KAZ-204)."""
+
+from __future__ import annotations
+
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Final
+
+from goals.loader import OPTIONAL_ENV, VAULT_ROOT_ENV
+
+CAPTURE_SUBPATH: Final[str] = "30_raw/hibi/capture"
+INBOX_SUBPATH: Final[str] = "30_raw/hibi/inbox"
+NOVELTY_INBOX_MAX_PER_DAY: Final[int] = 1
+
+
+def _vault_root() -> Path | None:
+    root = os.environ.get(VAULT_ROOT_ENV)
+    if root:
+        return Path(root)
+    if os.environ.get(OPTIONAL_ENV) == "1":
+        return None
+    return None
+
+
+def _slugify(text: str, max_len: int = 48) -> str:
+    cleaned = re.sub(r"[^a-zA-Z0-9]+", "-", text).strip("-").lower()
+    return (cleaned or "item")[:max_len]
+
+
+def write_raw_capture(
+    *,
+    title: str,
+    url: str,
+    target_project: str | None,
+    summary: str | None,
+    goal_note: str | None,
+) -> Path | None:
+    """Write a raw capture stub under ``30_raw/hibi/capture/`` (not decisions.md)."""
+    root = _vault_root()
+    if root is None:
+        return None
+
+    day = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    out_dir = root / CAPTURE_SUBPATH
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / f"{day}-{_slugify(title)}.md"
+    lines = [
+        "---",
+        "source: hibi-digest",
+        f"project: {target_project or 'unassigned'}",
+        f"captured_at: {datetime.now(timezone.utc).isoformat()}",
+        "---",
+        "",
+        f"# {title}",
+        "",
+        f"URL: {url}",
+        "",
+    ]
+    if summary:
+        lines.extend(["## Digest summary", summary, ""])
+    if goal_note:
+        lines.extend(["## Application note", goal_note, ""])
+    lines.append("## Notes\n\n(manual follow-up)")
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def write_novelty_inbox_item(
+    *,
+    title: str,
+    url: str,
+    reason: str,
+) -> Path | None:
+    """Route low-centroid-match articles to the idea-mining Obsidian inbox (max 1/day)."""
+    root = _vault_root()
+    if root is None:
+        return None
+
+    day = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    out_dir = root / INBOX_SUBPATH
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    existing = list(out_dir.glob(f"{day}-*.md"))
+    if len(existing) >= NOVELTY_INBOX_MAX_PER_DAY:
+        return None
+
+    path = out_dir / f"{day}-{_slugify(title)}.md"
+    body = (
+        "---\n"
+        "source: hibi-novelty\n"
+        f"date: {day}\n"
+        "---\n\n"
+        f"# {title}\n\n"
+        f"URL: {url}\n\n"
+        f"Routed because: {reason}\n\n"
+        "Review in idea-mining workflow; do not merge into decisions.md automatically.\n"
+    )
+    path.write_text(body, encoding="utf-8")
+    return path

--- a/scripts/hibi_ingest.py
+++ b/scripts/hibi_ingest.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""List or summarize raw Hibi captures under the Obsidian vault (KAZ-204 v0).
+
+Usage:
+    python scripts/hibi_ingest.py
+
+Reads ``30_raw/hibi/capture/`` and ``30_raw/hibi/inbox/`` without mutating
+``decisions.md`` (centroid self-pollution guard).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from goals.vault_io import CAPTURE_SUBPATH, INBOX_SUBPATH
+
+load_dotenv()
+
+
+def _list_dir(root: Path, subpath: str) -> list[Path]:
+    folder = root / subpath
+    if not folder.is_dir():
+        return []
+    return sorted(folder.glob("*.md"))
+
+
+def main() -> int:
+    vault = os.environ.get("OBSIDIAN_VAULT_ROOT")
+    if not vault:
+        print("OBSIDIAN_VAULT_ROOT is not set.")
+        return 1
+
+    root = Path(vault)
+    captures = _list_dir(root, CAPTURE_SUBPATH)
+    inbox = _list_dir(root, INBOX_SUBPATH)
+
+    print(f"Vault: {root}")
+    print(f"\nCapture ({CAPTURE_SUBPATH}): {len(captures)} file(s)")
+    for path in captures[-10:]:
+        print(f"  - {path.name}")
+
+    print(f"\nNovelty inbox ({INBOX_SUBPATH}): {len(inbox)} file(s)")
+    for path in inbox[-10:]:
+        print(f"  - {path.name}")
+
+    print("\nEdit captures manually; do not auto-append to decisions.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/summarize_goal.py
+++ b/summarize_goal.py
@@ -22,13 +22,20 @@ def build_summarize_prompt(
     voice_rule: str,
     content_char_limit: int,
     goal_context: str,
+    target_project_label: str = "",
 ) -> str:
     goal_block = ""
     if goal_context.strip():
         goal_block = f"""
-読者の現在のプロジェクト焦点（要約の歪め禁止・注釈の根拠のみに使用）:
+対象プロジェクトの conditioning（要約の歪め禁止・適用注記の根拠のみ）:
 {goal_context[:4000]}
 """
+    project_hint = ""
+    if target_project_label:
+        project_hint = (
+            f"- 「---関連---」ブロックは必ず「→ {target_project_label}:」で始める。"
+            "そのプロジェクトへの適用を1〜2行で述べる（事実要約は変更しない）。\n"
+        )
 
     return f"""{voice_rule}
 {goal_block}
@@ -37,7 +44,7 @@ def build_summarize_prompt(
 
 重要:
 - 「---要約---」ブロックは出典に忠実な3行要約のみ。推測・補完・謝罪は禁止。困難なら要約ブロックを空にする。
-- 「---関連---」ブロックは上記プロジェクト焦点との関連を1〜2行で述べる（本旨を変えない注釈）。焦点が空、または関連が薄い場合は関連ブロックを空にする。
+{project_hint}- 「---関連---」ブロックが不要な場合は空にする。
 - 各行は1文で「・」で始める。
 
 タイトル: {title}

--- a/tests/test_goal_digest_v2.py
+++ b/tests/test_goal_digest_v2.py
@@ -1,0 +1,232 @@
+"""Tests for goal-conditioned digest v2 (KAZ-204)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from daily_news_ranking import (
+    NOVELTY_SIM_THRESHOLD,
+    build_digest_plan_v2,
+    score_candidates_multi_project,
+)
+from goals.centroids import embed_subject_centroids
+from goals.subjects import load_subject_catalog
+from goals.vault_io import write_novelty_inbox_item, write_raw_capture
+from summarize_goal import build_summarize_prompt
+
+
+def test_score_candidates_multi_project_assigns_best_slug() -> None:
+    candidates = [
+        {"content_id": "a", "title": "A", "description": ""},
+        {"content_id": "b", "title": "B", "description": ""},
+    ]
+    vectors = [[1.0, 0.0], [0.0, 1.0]]
+    centroids = {"monogatari": [1.0, 0.0], "roamlore": [0.0, 1.0]}
+    score_candidates_multi_project(
+        candidates,
+        vectors,
+        centroids,
+        ranking_weight=1.0,
+        sim_base=0.7,
+        jitter_base=0.4,
+    )
+    assert candidates[0]["target_project"] == "monogatari"
+    assert candidates[1]["target_project"] == "roamlore"
+    assert candidates[0]["digest_lane"] == "project"
+    assert candidates[1]["digest_lane"] == "project"
+
+
+def test_build_digest_plan_v2_per_project_and_novelty() -> None:
+    ranked = [
+        {
+            "content_id": "m1",
+            "target_project": "monogatari",
+            "project_sim": 0.9,
+            "score": 1.0,
+            "title": "mono high",
+        },
+        {
+            "content_id": "r1",
+            "target_project": "roamlore",
+            "project_sim": 0.8,
+            "score": 0.9,
+            "title": "roam",
+        },
+        {
+            "content_id": "n1",
+            "digest_lane": "novelty",
+            "project_sim": 0.1,
+            "score": 0.5,
+            "title": "novel",
+        },
+    ]
+    plan, overflow = build_digest_plan_v2(ranked, max_stories=3, novelty_max=1)
+    assert len(plan) == 3
+    assert plan[0]["content_id"] == "m1"
+    assert plan[0]["display_category"] == "→ Monogatari"
+    assert plan[1]["content_id"] == "r1"
+    assert plan[1]["display_category"] == "→ RoamLore"
+    novelty = next(p for p in plan if p["digest_slot"] == "novelty")
+    assert novelty["content_id"] == "n1"
+    assert overflow == []
+
+
+def test_build_digest_plan_v2_overflow_when_digest_full() -> None:
+    ranked = [
+        {
+            "content_id": "m1",
+            "target_project": "monogatari",
+            "project_sim": 0.9,
+            "score": 1.0,
+            "title": "mono",
+        },
+        {
+            "content_id": "n1",
+            "digest_lane": "novelty",
+            "project_sim": 0.1,
+            "score": 0.5,
+            "title": "novel",
+        },
+    ]
+    plan, overflow = build_digest_plan_v2(ranked, max_stories=1, novelty_max=1)
+    assert len(plan) == 1
+    assert len(overflow) == 1
+    assert overflow[0]["content_id"] == "n1"
+
+
+def test_load_subject_catalog_from_fixture(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("OBSIDIAN_VAULT_ROOT", str(tmp_path))
+    monkeypatch.delenv("HIBI_GOALS_OPTIONAL", raising=False)
+    proj = tmp_path / "10_projects" / "monogatari"
+    proj.mkdir(parents=True)
+    (proj / "decisions.md").write_text(
+        "---\nstatus: active\n---\n## 決定\nShip v2 ranking.\n",
+        encoding="utf-8",
+    )
+
+    catalog = load_subject_catalog()
+    assert len(catalog.projects) == 1
+    assert catalog.projects[0].slug == "monogatari"
+    assert "Ship v2" in catalog.projects[0].conditioning_text
+
+
+def test_subject_catalog_skips_inactive_conditioning(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("OBSIDIAN_VAULT_ROOT", str(tmp_path))
+    monkeypatch.delenv("HIBI_GOALS_OPTIONAL", raising=False)
+    proj = tmp_path / "10_projects" / "monogatari"
+    proj.mkdir(parents=True)
+    (proj / "decisions.md").write_text(
+        "## 決定\nNo frontmatter.\n",
+        encoding="utf-8",
+    )
+    (proj / "strategy.md").write_text(
+        "---\nstatus: active\n---\n## 戦略\nActive strategy.\n",
+        encoding="utf-8",
+    )
+
+    catalog = load_subject_catalog()
+    text = catalog.projects[0].conditioning_text
+    assert "Active strategy" in text
+    assert "No frontmatter" not in text
+
+
+def test_embed_subject_centroids_empty_catalog() -> None:
+    from goals.subjects import SubjectCatalog
+
+    class FakeClient:
+        pass
+
+    def fake_embed(_client, texts: list[str]) -> list[list[float]]:
+        return [[float(i)] * 3 for i, _ in enumerate(texts)]
+
+    assert (
+        embed_subject_centroids(
+            FakeClient(),
+            SubjectCatalog(projects=()),
+            embed_batch=fake_embed,
+            embedding_model="test",
+        )
+        == {}
+    )
+
+
+def test_centroid_cache_hit(tmp_path: Path, monkeypatch) -> None:
+    from goals.subjects import SubjectCatalog, SubjectProject
+
+    class FakeClient:
+        pass
+
+    calls: list[int] = []
+
+    def fake_embed(_client, texts: list[str]) -> list[list[float]]:
+        calls.append(len(texts))
+        return [[1.0, 0.0, 0.0] for _ in texts]
+
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("HIBI_GOAL_CACHE_DIR", str(cache_dir))
+    project = SubjectProject(
+        slug="monogatari",
+        display_name="Monogatari",
+        conditioning_text="focus text",
+        file_count=1,
+    )
+    catalog = SubjectCatalog(projects=(project,))
+
+    embed_subject_centroids(
+        FakeClient(),
+        catalog,
+        embed_batch=fake_embed,
+        embedding_model="text-embedding-3-small",
+    )
+    embed_subject_centroids(
+        FakeClient(),
+        catalog,
+        embed_batch=fake_embed,
+        embedding_model="text-embedding-3-small",
+    )
+    assert calls == [1]
+    cache_file = cache_dir / "goal_centroid_cache.json"
+    assert cache_file.is_file()
+    data = json.loads(cache_file.read_text(encoding="utf-8"))
+    assert "monogatari" in data
+
+
+def test_vault_io_capture_and_inbox(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("OBSIDIAN_VAULT_ROOT", str(tmp_path))
+
+    cap = write_raw_capture(
+        title="Test Article",
+        url="https://example.com/a",
+        target_project="monogatari",
+        summary="Summary line.",
+        goal_note="→ Monogatari: note",
+    )
+    assert cap is not None
+    assert "monogatari" in cap.read_text(encoding="utf-8")
+
+    inbox1 = write_novelty_inbox_item(
+        title="Novel idea",
+        url="https://example.com/n",
+        reason="low similarity",
+    )
+    assert inbox1 is not None
+    inbox2 = write_novelty_inbox_item(
+        title="Second novel",
+        url="https://example.com/n2",
+        reason="also low",
+    )
+    assert inbox2 is None
+
+
+def test_summarize_prompt_includes_project_arrow() -> None:
+    prompt = build_summarize_prompt(
+        "Title",
+        "Body",
+        voice_rule="rule",
+        content_char_limit=1000,
+        goal_context="conditioning",
+        target_project_label="Monogatari",
+    )
+    assert "→ Monogatari:" in prompt
+    assert NOVELTY_SIM_THRESHOLD == 0.28

--- a/tests/test_goal_loader.py
+++ b/tests/test_goal_loader.py
@@ -1,16 +1,15 @@
-"""Tests for goals.loader active-project conventions (KAZ-202)."""
+"""Tests for goals.loader active-project conventions (KAZ-202 / KAZ-204)."""
 
 import os
+import time
 from pathlib import Path
-
-import pytest
 
 from goals import loader as goals_loader
 
 
 def test_load_goal_focus_extracts_active_sections(tmp_path: Path, monkeypatch) -> None:
     vault = tmp_path / "vault"
-    project = vault / "10_projects" / "hibi"
+    project = vault / "10_projects" / "monogatari"
     project.mkdir(parents=True)
     note = project / "status.md"
     note.write_text(
@@ -24,14 +23,91 @@ def test_load_goal_focus_extracts_active_sections(tmp_path: Path, monkeypatch) -
     monkeypatch.setenv(goals_loader.VAULT_ROOT_ENV, str(vault))
 
     focus = goals_loader.load_goal_focus()
-    assert "hibi" in focus.project_slugs
+    assert focus.project_slugs == ("monogatari",)
     assert "Build the digest pipeline" in focus.text
     assert "Private diary" not in focus.text
 
 
+def test_allowlist_excludes_non_subject_projects(tmp_path: Path, monkeypatch) -> None:
+    vault = tmp_path / "vault"
+    hibi = vault / "10_projects" / "hibi"
+    hibi.mkdir(parents=True)
+    (hibi / "status.md").write_text(
+        "---\nstatus: active\n---\n## Goal\nHibi internal.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(goals_loader.VAULT_ROOT_ENV, str(vault))
+    monkeypatch.delenv(goals_loader.OVERRIDE_ENV, raising=False)
+
+    focus = goals_loader.load_goal_focus()
+    assert focus.text == ""
+    assert focus.project_slugs == ()
+
+
+def test_strategy_heading_extracted(tmp_path: Path, monkeypatch) -> None:
+    vault = tmp_path / "vault"
+    project = vault / "10_projects" / "roamlore"
+    project.mkdir(parents=True)
+    (project / "strategy.md").write_text(
+        "---\nhibi-active: true\n---\n"
+        "## 戦略\nLaunch in Q3.\n\n"
+        "## Notes\nDiary noise.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(goals_loader.VAULT_ROOT_ENV, str(vault))
+    monkeypatch.delenv(goals_loader.OVERRIDE_ENV, raising=False)
+
+    focus = goals_loader.load_goal_focus()
+    assert "Launch in Q3" in focus.text
+    assert "Diary noise" not in focus.text
+
+
+def test_recency_prefers_newer_note_before_cap(tmp_path: Path, monkeypatch) -> None:
+    vault = tmp_path / "vault"
+    project = vault / "10_projects" / "monogatari"
+    project.mkdir(parents=True)
+    old = project / "decisions.md"
+    new = project / "status.md"
+    old.write_text(
+        "---\nstatus: active\n---\n## 決定\nOLD_DECISION_TEXT.\n",
+        encoding="utf-8",
+    )
+    new.write_text(
+        "---\nstatus: active\n---\n## 現状\nNEW_STATUS_TEXT.\n",
+        encoding="utf-8",
+    )
+    now = time.time()
+    os.utime(old, (now - 86400 * 10, now - 86400 * 10))
+    os.utime(new, (now, now))
+
+    monkeypatch.setenv(goals_loader.VAULT_ROOT_ENV, str(vault))
+    monkeypatch.delenv(goals_loader.OVERRIDE_ENV, raising=False)
+
+    focus = goals_loader.load_goal_focus()
+    assert focus.text.index("NEW_STATUS_TEXT") < focus.text.index("OLD_DECISION_TEXT")
+
+
+def test_read_active_note_skips_without_frontmatter(tmp_path: Path, monkeypatch) -> None:
+    note = tmp_path / "strategy.md"
+    note.write_text("## 戦略\nNo frontmatter.\n", encoding="utf-8")
+    monkeypatch.delenv(goals_loader.OPTIONAL_ENV, raising=False)
+
+    assert goals_loader.read_active_note(note) == ""
+
+
+def test_read_active_note_optional_allows_no_frontmatter(
+    tmp_path: Path, monkeypatch
+) -> None:
+    note = tmp_path / "strategy.md"
+    note.write_text("## strategy\nBody.\n", encoding="utf-8")
+    monkeypatch.setenv(goals_loader.OPTIONAL_ENV, "1")
+
+    assert "Body" in goals_loader.read_active_note(note)
+
+
 def test_abandoned_paths_skipped(tmp_path: Path, monkeypatch) -> None:
     vault = tmp_path / "vault"
-    archived = vault / "10_projects" / "old" / "archive" / "x.md"
+    archived = vault / "10_projects" / "monogatari" / "archive" / "x.md"
     archived.parent.mkdir(parents=True)
     archived.write_text("---\nstatus: active\n---\n## Goal\nhidden\n", encoding="utf-8")
     monkeypatch.setenv(goals_loader.VAULT_ROOT_ENV, str(vault))

--- a/tests/test_ranking_goal.py
+++ b/tests/test_ranking_goal.py
@@ -1,6 +1,11 @@
 """Tests for goal/click centroid ranking helpers (KAZ-202)."""
 
-from daily_news_ranking import build_digest_plan, resolve_ranking_centroid
+from daily_news_ranking import (
+    NOVELTY_SIM_THRESHOLD,
+    build_digest_plan,
+    build_digest_plan_v2,
+    resolve_ranking_centroid,
+)
 from ranking import blend_centroids, cosine_similarity
 
 
@@ -40,3 +45,20 @@ def test_build_digest_plan_includes_challenge_slot() -> None:
     assert slots == {"goal", "challenge"}
     challenge = next(p for p in plan if p["digest_slot"] == "challenge")
     assert challenge["content_id"] == "b"
+
+
+def test_novelty_threshold_constant() -> None:
+    assert NOVELTY_SIM_THRESHOLD == 0.28
+
+
+def test_build_digest_plan_v2_reserves_project_slots() -> None:
+    ranked = [
+        {
+            "content_id": "m",
+            "target_project": "monogatari",
+            "project_sim": 0.6,
+            "score": 1.0,
+        },
+    ]
+    plan, _ = build_digest_plan_v2(ranked, max_stories=2)
+    assert plan[0]["digest_slot"] == "project"


### PR DESCRIPTION
## Summary

- Adds digest v2 for growth subjects `monogatari` and `roamlore`: per-project embedding centroids (cached), multi-project ranking, digest plan with `→ Monogatari` / `→ RoamLore` labels, novelty lane, and per-project summarize conditioning.
- Aligns `goals.loader` with KAZ-204 AC: subject allowlist, extended section headings (`## 戦略`, `## 現状`, etc.), frontmatter gate (`status: active` / `hibi-active: true`), mtime-newest-first before cap; `subjects.py` reads conditioning files via `read_active_note`.
- Writes useful items to `30_raw/hibi/capture/` and overflow novelty to `30_raw/hibi/inbox/` (max 1/day); adds `scripts/hibi_ingest.py` v0 lister. Falls back to KAZ-202 ranking when no subject centroids are available.

## Test plan

- [x] `pytest tests/ --ignore=tests/idea_mining` (144 passed)
- [ ] Cron / manual run with `OBSIDIAN_VAULT_ROOT` set: confirm subject centroids log for Monogatari (and RoamLore when conditioning is non-empty)
- [ ] Verify Monogatari `strategy.md` / `status.md` have active frontmatter and single-heading sections per vault convention
- [ ] Spot-check email order follows digest plan (v2) and `---関連---` lines start with `→ Monogatari:` / `→ RoamLore:`

Closes KAZ-204


Made with [Cursor](https://cursor.com)