### PR TITLE
fix(email): link-only digest rows no longer crash mailer (KAZ-205)

### DIFF
--- a/daily_news.py
+++ b/daily_news.py
@@ -866,6 +866,7 @@ def main():
             "source_name": item["source_name"],
             "digest_slot": slot,
             "target_project": item.get("target_project"),
+            "link_only": link_only,
         }
         processed_by_source.setdefault(item["source_name"], []).append(row)
         delivered_items.append(row)

--- a/mailer.py
+++ b/mailer.py
@@ -78,6 +78,17 @@ EN_PASTE_STYLE = (
 EN_PASTE_BOX_STYLE = (
     "margin-top:8px;padding:14px 16px;border:1px solid #E8E6E1;background:#FFFFFF;"
 )
+LINK_ONLY_LABEL = "新着動画"
+LINK_LEAD_STYLE = (
+    f"font-family:{FONT_JP};font-size:14px;line-height:1.6;color:#5C5A57;margin:0 0 14px;"
+)
+
+
+def _is_link_only_article(article: dict) -> bool:
+    """True when digest has no summary body (KAZ-200 YouTube / KAZ-201 RSS)."""
+    if article.get("link_only"):
+        return True
+    return article.get("summary") is None
 
 
 def _english_practice_html(practice: dict | None) -> str:
@@ -112,31 +123,46 @@ def _story_html(index: int, article: dict, is_last: bool) -> str:
     containing `&`, `<`, `>`, or a stray `"` can't corrupt the rendered Gmail
     body or break the anchor `href`. URLs go through `quote=True` so quotes
     inside an href are neutralized.
+
+    Link-only articles (``summary is None``) render without summary blocks
+    (KAZ-205).
     """
-    title = html.escape(article.get("title", ""))
-    url = html.escape(article.get("url", "#"), quote=True)
-    summary = html.escape(article.get("summary", ""))
-    learning = html.escape(article.get("learning", ""))
-    practical = html.escape(article.get("practical_application", ""))
-    category = html.escape(article.get("category") or "News")
+    title = html.escape(article.get("title") or "")
+    url = html.escape(article.get("url") or "#", quote=True)
     source_name = html.escape(article.get("source") or article.get("source_name") or "")
     source_type = html.escape(article.get("source_type") or "")
 
-    # Meta line: CATEGORY · SOURCE_TYPE (caps), no emoji, no pill backgrounds.
+    if _is_link_only_article(article):
+        category = html.escape(LINK_ONLY_LABEL)
+    else:
+        category = html.escape(article.get("category") or "News")
+
     meta_parts: list[str] = [f'<span style="{META_CAT_STYLE}">{category}</span>']
     if source_type:
         meta_parts.append(f'<span style="{META_SEP_STYLE}">·</span>')
         meta_parts.append(f"<span>{source_type}</span>")
     meta_html = "".join(meta_parts)
 
-    body_parts: list[str] = []
-    if summary:
-        body_parts.append(f'<p class="hb-story-p" style="{P_STYLE}">{summary}</p>')
-    if learning:
-        body_parts.append(f'<p class="hb-story-p" style="{P_STYLE}">{learning}</p>')
-    if practical:
-        body_parts.append(f'<p class="hb-story-p" style="{P_STYLE}">{practical}</p>')
-    body_html = "".join(body_parts)
+    if _is_link_only_article(article):
+        src_label = source_name or "Source"
+        body_html = (
+            f'<p class="hb-story-link-lead" style="{LINK_LEAD_STYLE}">'
+            f'要約なし。<a href="{url}" style="{SRC_LINK_STYLE}">{src_label}</a>'
+            "で視聴・閲覧できる。"
+            "</p>"
+        )
+    else:
+        summary = html.escape(article.get("summary") or "")
+        learning = html.escape(article.get("learning") or "")
+        practical = html.escape(article.get("practical_application") or "")
+        body_parts: list[str] = []
+        if summary:
+            body_parts.append(f'<p class="hb-story-p" style="{P_STYLE}">{summary}</p>')
+        if learning:
+            body_parts.append(f'<p class="hb-story-p" style="{P_STYLE}">{learning}</p>')
+        if practical:
+            body_parts.append(f'<p class="hb-story-p" style="{P_STYLE}">{practical}</p>')
+        body_html = "".join(body_parts)
 
     src_label = source_name or "Source"
     src_html = (

--- a/tests/test_mailer_link_only.py
+++ b/tests/test_mailer_link_only.py
@@ -1,0 +1,61 @@
+"""Regression tests for link-only digest rows in mailer (KAZ-205)."""
+
+import mailer
+
+
+def test_build_html_accepts_summary_none() -> None:
+    articles = [
+        {
+            "title": "Marc Lou — new upload",
+            "url": "https://www.youtube.com/watch?v=example",
+            "summary": None,
+            "source": "Marc Lou",
+            "source_type": "youtube",
+        },
+        {
+            "title": "Regular story",
+            "url": "https://example.com/post",
+            "summary": "・通常の要約行。",
+            "source": "Example Blog",
+            "source_type": "rss",
+        },
+    ]
+    html = mailer.build_html(articles, "2026.06.04")
+    assert "Marc Lou" in html
+    assert "新着動画" in html
+    assert "要約なし" in html
+    assert "・通常の要約行。" in html
+
+
+def test_link_only_story_omits_empty_summary_paragraph() -> None:
+    html = mailer.build_html(
+        [
+            {
+                "title": "Link only item",
+                "url": "https://youtube.example/v",
+                "summary": None,
+                "source": "Channel",
+                "source_type": "youtube",
+            }
+        ],
+        "2026.06.04",
+    )
+    assert 'class="hb-story-p"' not in html
+    assert "hb-story-link-lead" in html
+    assert "Link only item" in html
+
+
+def test_is_link_only_via_flag() -> None:
+    html = mailer.build_html(
+        [
+            {
+                "title": "Flagged",
+                "url": "https://example.com",
+                "summary": "",
+                "link_only": True,
+                "source": "S",
+            }
+        ],
+        "2026.06.04",
+    )
+    assert "新着動画" in html


### PR DESCRIPTION
## Summary

- Fixes production crash when link-only articles (YouTube metadata / RSS body unavailable) pass `summary: None` into `mailer.build_html` — `html.escape(None)` raised `AttributeError` (issue_no=39).
- Link-only stories render with a **新着動画** meta label, a short link lead line, and no empty summary blocks.
- Pipeline rows now include `link_only: true` for explicit mailer detection.

## Test plan

- [x] `pytest tests/ --ignore=tests/idea_mining` (147 passed)
- [x] `tests/test_mailer_link_only.py` — `summary=None` mixed edition builds
- [ ] Merge and verify next daily-news Actions run delivers with link-only YouTube items in the pool

Closes KAZ-205


Made with [Cursor](https://cursor.com)