### PR TITLE
feat(ci): Obsidian vault in daily-news Actions for goal conditioning (KAZ-206)

### DIFF
--- a/.github/workflows/daily-news.yml
+++ b/.github/workflows/daily-news.yml
@@ -20,12 +20,32 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Goal conditioning (KAZ-202 / KAZ-204 / KAZ-206): sparse clone of the private
+      # Obsidian vault. Requires OBSIDIAN_VAULT_PAT (read-only) in repo secrets.
+      # See docs/obsidian-vault-ci.md.
+      - name: Checkout Obsidian vault (sparse)
+        uses: actions/checkout@v4
+        with:
+          repository: kazuki-0418/Obsidan-workspace
+          token: ${{ secrets.OBSIDIAN_VAULT_PAT }}
+          path: obsidian-vault
+          sparse-checkout: |
+            10_projects/monogatari
+            10_projects/roamlore
+            30_raw/hibi
+          sparse-checkout-cone-mode: true
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
           cache: "pip"
 
       - run: pip install -r requirements.txt
+
+      - name: Verify vault goal-conditioning paths
+        run: python scripts/verify_vault_goal_paths.py
+        env:
+          OBSIDIAN_VAULT_ROOT: ${{ github.workspace }}/obsidian-vault
 
       - run: python daily_news.py
         env:
@@ -48,8 +68,8 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           HIBI_RELEASE: ${{ github.sha }}
           HIBI_ENV: production
-          # Goal-conditioned ranking (KAZ-202): skip vault when unset in CI.
-          HIBI_GOALS_OPTIONAL: "1"
+          # Obsidian vault for goal / subject conditioning (KAZ-206).
+          OBSIDIAN_VAULT_ROOT: ${{ github.workspace }}/obsidian-vault
 
       # Dump editions from Neon → JSON files Astro reads at build time.
       # Idempotent overwrite; no-op if no editions changed.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ pip install -r requirements.txt
 | `GMAIL_REFRESH_TOKEN` | Gmail 送信用 refresh token |
 | `RECIPIENT_EMAIL` | 配信先メールアドレス |
 | `DATABASE_URL` | Neon PostgreSQL の pooled connection string |
+| `OPENAI_API_KEY` | Goal / subject embedding ranking（任意だが本番推奨） |
+| `OBSIDIAN_VAULT_PAT` | **Actions のみ** — private vault `Obsidan-workspace` の read-only PAT（[docs/obsidian-vault-ci.md](docs/obsidian-vault-ci.md)） |
 
 > **Gmail OAuth2 の取得:** Google Cloud Console で Gmail API を有効化し、OAuth2 認証フローで refresh_token を取得。
 
@@ -57,8 +59,8 @@ python daily_news.py
 
 ### 4. GitHub Actions による自動化
 
-1. リポジトリの **Settings → Secrets and variables → Actions** に上記6変数を登録
-2. `.github/workflows/daily_news.yml` が毎朝 UTC 13:00 に自動実行
+1. リポジトリの **Settings → Secrets and variables → Actions** に上記変数を登録（`OBSIDIAN_VAULT_PAT` 含む）
+2. `.github/workflows/daily-news.yml` が毎朝 UTC 13:17 に自動実行
 3. **Actions タブ → Daily News → Run workflow** で手動実行も可能
 
 ## Neon PostgreSQL セットアップ

--- a/architecture/skills/hibi-domain.md
+++ b/architecture/skills/hibi-domain.md
@@ -17,6 +17,7 @@ Hibi の現行ドメイン事実を固定するスキル。
 - cold start: `clicks_in_30d < 5` では Obsidian active project の **goal centroid** でランキング（KAZ-202）。goal も無いときのみ純ランダム
 - digest v2 (KAZ-204): allowlist は `monogatari` / `roamlore` のみ（`hibi` 自身は対象外）。conditioning は各 `10_projects/<slug>/` の `decisions.md` + `strategy.md` + `status.md` を `goals.loader.read_active_note` で読む（`status: active` / `hibi-active: true` 必須、見出し完全一致セクションのみ、ファイル mtime 降順 + 8000字 cap）。**プロジェクト別 centroid**（クリック blend なし）。類似度 `< 0.28` は novelty レーン。有用記事は `30_raw/hibi/capture/`、digest 満杯時の novelty は `30_raw/hibi/inbox/`（1 件/日）。centroid は vault `.hibi/goal_centroid_cache.json` または `HIBI_GOAL_CACHE_DIR`
 - `goals.loader`（KAZ-202 fallback）も同一 allowlist + frontmatter + 見出し規約。6000字 cap 前にノート mtime 降順
+- 本番 Actions は `Obsidan-workspace` を sparse-checkout し `OBSIDIAN_VAULT_ROOT` を渡す（`OBSIDIAN_VAULT_PAT` secret）。`HIBI_GOALS_OPTIONAL=1` は本番 daily-news では使わない（[docs/obsidian-vault-ci.md](../../docs/obsidian-vault-ci.md)）
 - score 式: `sim × 0.7 × weight + rand() × (1 − 0.4 × weight)`、weight = `min(1, clicks_in_30d / 30)`
 - 現行の事実は以下のダイアグラムから確認する:
   - `architecture/diagrams/pipeline-flow.mmd`

--- a/docs/obsidian-vault-ci.md
+++ b/docs/obsidian-vault-ci.md
@@ -1,0 +1,69 @@
+# Obsidian vault in GitHub Actions (KAZ-206)
+
+Daily news goal-conditioning (`KAZ-202` / `KAZ-204`) reads growth-subject notes from a
+**separate private vault repo**, not from the Hibi git tree.
+
+## Vault repository
+
+- GitHub: `kazuki-0418/Obsidan-workspace` (historical repo name spelling)
+- Local clone path is arbitrary; Actions uses `${{ github.workspace }}/obsidian-vault`
+
+## Sparse checkout (privacy)
+
+`daily-news.yml` checks out only:
+
+```text
+10_projects/monogatari/
+10_projects/roamlore/
+30_raw/hibi/          # capture + novelty inbox writes (ephemeral on the runner)
+```
+
+Other vault paths (personal notes, unrelated projects) are **not** fetched in CI.
+
+## Required GitHub secret
+
+| Secret | Purpose |
+|--------|---------|
+| `OBSIDIAN_VAULT_PAT` | Fine-grained PAT (or classic PAT) with **read** access to `Obsidan-workspace` |
+
+Create under **Settings → Secrets and variables → Actions → New repository secret**.
+
+Fine-grained PAT example:
+
+- Repository access: `Obsidan-workspace` only
+- Permissions: Contents → Read-only
+
+Do **not** set `HIBI_GOALS_OPTIONAL=1` on the production daily-news job. That flag is
+for unit tests only and forces empty goal context.
+
+## Workflow env
+
+After checkout, the pipeline sets:
+
+```text
+OBSIDIAN_VAULT_ROOT=${{ github.workspace }}/obsidian-vault
+```
+
+## Verify after checkout
+
+`scripts/verify_vault_goal_paths.py` runs in Actions and logs which conditioning files
+exist. Missing files are OK when a project is not set up yet, but goal context stays
+empty for that slug.
+
+## Local development
+
+```bash
+git clone git@github.com:kazuki-0418/Obsidan-workspace.git ~/Obsidian-workspace
+export OBSIDIAN_VAULT_ROOT=~/Obsidian-workspace
+python scripts/verify_vault_goal_paths.py
+python daily_news.py
+```
+
+## Capture / inbox writes in CI
+
+`daily_news.py` may write under `30_raw/hibi/capture/` and `30_raw/hibi/inbox/` on the
+runner. Those files are **not** pushed back to the vault repo automatically (v0). Persist
+captures locally or via a future vault commit workflow.
+
+Centroid cache (`.hibi/goal_centroid_cache.json`) is also ephemeral in CI unless
+`HIBI_GOAL_CACHE_DIR` is pointed at durable storage.

--- a/scripts/verify_vault_goal_paths.py
+++ b/scripts/verify_vault_goal_paths.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Verify Obsidian vault paths needed for Hibi goal conditioning (KAZ-206).
+
+Exits 0 when ``OBSIDIAN_VAULT_ROOT`` exists; prints OK/MISS for allowlisted
+``10_projects/<slug>/`` conditioning files. Used in daily-news Actions after
+sparse vault checkout.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from goals.loader import CONDITIONING_FILES, SUBJECT_ALLOWLIST, VAULT_ROOT_ENV
+
+
+def main() -> int:
+    root = os.environ.get(VAULT_ROOT_ENV)
+    if not root:
+        print(f"{VAULT_ROOT_ENV} is not set.")
+        return 1
+
+    vault = Path(root)
+    if not vault.is_dir():
+        print(f"Vault root missing: {vault}")
+        return 1
+
+    print(f"Vault root: {vault}")
+    any_file = False
+    for slug in SUBJECT_ALLOWLIST:
+        project_dir = vault / "10_projects" / slug
+        if not project_dir.is_dir():
+            print(f"MISS directory {project_dir}")
+            continue
+        for filename in CONDITIONING_FILES:
+            path = project_dir / filename
+            if path.is_file():
+                any_file = True
+                print(f"OK   {path}")
+            else:
+                print(f"MISS {path}")
+
+    if not any_file:
+        print(
+            "WARN: no conditioning files found; goal context may be empty "
+            "(check frontmatter status: active on decisions/strategy/status)."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_verify_vault_goal_paths.py
+++ b/tests/test_verify_vault_goal_paths.py
@@ -1,0 +1,37 @@
+"""Tests for scripts/verify_vault_goal_paths.py (KAZ-206)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_verify_vault_goal_paths_ok(tmp_path: Path, monkeypatch) -> None:
+    vault = tmp_path / "vault"
+    mono = vault / "10_projects" / "monogatari"
+    mono.mkdir(parents=True)
+    (mono / "decisions.md").write_text("x", encoding="utf-8")
+    monkeypatch.setenv("OBSIDIAN_VAULT_ROOT", str(vault))
+
+    proc = subprocess.run(
+        [sys.executable, "scripts/verify_vault_goal_paths.py"],
+        cwd=Path(__file__).resolve().parents[1],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    assert "OK" in proc.stdout
+
+
+def test_verify_vault_goal_paths_missing_root(monkeypatch) -> None:
+    monkeypatch.delenv("OBSIDIAN_VAULT_ROOT", raising=False)
+    proc = subprocess.run(
+        [sys.executable, "scripts/verify_vault_goal_paths.py"],
+        cwd=Path(__file__).resolve().parents[1],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 1


### PR DESCRIPTION
## Summary

- Checks out private vault `kazuki-0418/Obsidan-workspace` in `daily-news.yml` with **sparse-checkout** (`10_projects/monogatari`, `10_projects/roamlore`, `30_raw/hibi` only).
- Sets `OBSIDIAN_VAULT_ROOT` for `daily_news.py` and removes production `HIBI_GOALS_OPTIONAL=1` (was forcing empty goal context).
- Adds `scripts/verify_vault_goal_paths.py` preflight step and [docs/obsidian-vault-ci.md](docs/obsidian-vault-ci.md) for the new `OBSIDIAN_VAULT_PAT` secret.

## Deploy note (required before merge helps prod)

Add GitHub Actions secret **`OBSIDIAN_VAULT_PAT`** (read-only access to `Obsidan-workspace`). Without it, the vault checkout step fails.

## Test plan

- [x] `pytest tests/ --ignore=tests/idea_mining` (149 passed)
- [ ] After secret is set: `workflow_dispatch` daily-news → log shows non-empty goal context / subject centroids
- [ ] Confirm ranking signal is not click-only on cold-start days when vault files are active

Closes KAZ-206


Made with [Cursor](https://cursor.com)