### PR TITLE
fix(sources): Substack RSS feeds use pipeline User-Agent (KAZ-207)

### DIFF
--- a/fetchers/rss.py
+++ b/fetchers/rss.py
@@ -47,9 +47,19 @@ def _iso_from_struct_time(t: struct_time | None) -> str:
     return datetime.fromtimestamp(mktime(t), tz=timezone.utc).isoformat()
 
 
+def parse_feed(feed_url: str):
+    """Parse an RSS/Atom feed with the pipeline User-Agent (KAZ-207).
+
+    Substack and Cloudflare often return 403 + HTML to the default
+    ``Python-urllib/*`` agent feedparser would use, which surfaces as
+    ``not well-formed (invalid token)`` XML parse errors.
+    """
+    return feedparser.parse(feed_url, agent=USER_AGENT)
+
+
 def fetch_recent_items(source: dict, max_results: int) -> list[dict]:
     """Return the latest entries for an RSS source."""
-    feed = feedparser.parse(source["feed_url"])
+    feed = parse_feed(source["feed_url"])
     if feed.bozo and not feed.entries:
         reason = getattr(feed, "bozo_exception", "unknown")
         print(f"  ⚠️  Failed to parse feed {source['feed_url']}: {reason}")

--- a/scripts/verify_feeds.py
+++ b/scripts/verify_feeds.py
@@ -9,9 +9,15 @@
 """
 
 import sys
+from pathlib import Path
 
-import feedparser
 import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from fetchers.rss import parse_feed
 
 
 def verify_feeds(yaml_path: str) -> int:
@@ -30,7 +36,7 @@ def verify_feeds(yaml_path: str) -> int:
             failures += 1
             continue
 
-        feed = feedparser.parse(feed_url)
+        feed = parse_feed(feed_url)
         entry_count = len(feed.entries) if feed.entries else 0
         if feed.bozo and not feed.entries:
             exc = getattr(feed, "bozo_exception", "parse error")

--- a/sources/rss.py
+++ b/sources/rss.py
@@ -1,8 +1,8 @@
-import feedparser
+from fetchers.rss import parse_feed
 
 
 def fetch(feed_url: str, top_n: int, source_name: str) -> list[dict]:
-    feed = feedparser.parse(feed_url)
+    feed = parse_feed(feed_url)
     articles = []
     for entry in feed.entries[:top_n]:
         articles.append({

--- a/tests/test_rss_fetcher.py
+++ b/tests/test_rss_fetcher.py
@@ -48,3 +48,23 @@ def test_trafilatura_config_sets_user_agent() -> None:
     rss._cached_trafilatura_config = None
     config = rss._trafilatura_config()
     assert config.get("DEFAULT", "USER_AGENT") == rss.USER_AGENT
+
+
+def test_parse_feed_uses_pipeline_user_agent() -> None:
+    mock_feed = MagicMock()
+    mock_feed.bozo = False
+    mock_feed.entries = []
+    with patch.object(rss.feedparser, "parse", return_value=mock_feed) as mock_parse:
+        rss.parse_feed("https://example.com/feed")
+    mock_parse.assert_called_once_with(
+        "https://example.com/feed",
+        agent=rss.USER_AGENT,
+    )
+
+
+def test_fetch_recent_items_uses_parse_feed() -> None:
+    source = {"name": "Test", "feed_url": "https://example.com/feed"}
+    with patch.object(rss, "parse_feed") as mock_parse:
+        mock_parse.return_value = MagicMock(bozo=False, entries=[])
+        rss.fetch_recent_items(source, 3)
+    mock_parse.assert_called_once_with("https://example.com/feed")


### PR DESCRIPTION
## Summary

- Root cause: Cloudflare/Substack returns **403 + HTML** to the default `Python-urllib/*` agent feedparser uses, which shows up as `not well-formed (invalid token)` in Actions.
- Adds `fetchers.rss.parse_feed()` that passes the existing `USER_AGENT` to `feedparser.parse(..., agent=...)`.
- Wires `daily_news` RSS fetch, `scripts/verify_feeds.py`, and legacy `sources/rss.py` through the same helper.

Feed URLs in `sources.yaml` are unchanged (`*.substack.com/feed`); no source removal needed.

## Test plan

- [x] `pytest tests/ --ignore=tests/idea_mining` (151 passed)
- [x] `python scripts/verify_feeds.py sources.yaml` — Marketing Examples (1 entry), April Dunford (20 entries)
- [ ] Next daily-news run: no parse warnings for these two feeds; `fetched_count > 0` when new posts exist

Closes KAZ-207


Made with [Cursor](https://cursor.com)