### PR TITLE
fix(privacy): stop goal context leaking into English paste block (KAZ-209)

### DIFF
--- a/english_practice.py
+++ b/english_practice.py
@@ -44,17 +44,18 @@ def build_paste_request(
     *,
     article_title: str,
     article_summary: str | None,
-    goal_snippet: str,
 ) -> str:
-    """Deterministic Claude paste block (naturalness > grammar, speak-first)."""
+    """Deterministic Claude paste block (naturalness > grammar, speak-first).
+
+    Intentionally excludes Obsidian goal / conditioning text (KAZ-209). The
+    visible email paste block must not leak decisions/strategy/status; goal
+    context is for internal prompt_line generation only.
+    """
     summary_text = (article_summary or "").strip()
     if not summary_text:
         summary_text = "(No summary — react to the title and your own take.)"
     else:
         summary_text = summary_text[:PASTE_SUMMARY_LIMIT]
-
-    goal_text = goal_snippet.strip() or "(No project focus loaded today.)"
-    goal_text = goal_text[:GOAL_SNIPPET_LIMIT]
 
     return (
         "Please help me write a short response in natural English.\n"
@@ -67,10 +68,7 @@ def build_paste_request(
         "---\n"
         f"Article title: {article_title}\n\n"
         "Digest context (may be Japanese):\n"
-        f"{summary_text}\n\n"
-        "---\n"
-        "My current project focus (for relevance only):\n"
-        f"{goal_text}\n"
+        f"{summary_text}\n"
     )
 
 
@@ -136,7 +134,6 @@ Return ONLY JSON:
         prompt_line,
         article_title=title,
         article_summary=summary,
-        goal_snippet=goal_snippet,
     )
     return EnglishPractice(
         prompt_line=prompt_line,

--- a/tests/test_english_practice.py
+++ b/tests/test_english_practice.py
@@ -20,12 +20,51 @@ def test_build_paste_request_includes_naturalness_instruction() -> None:
         "In English: react to the story. （まず声に出してから書く。）",
         article_title="Test Article",
         article_summary="要約本文。",
-        goal_snippet="Project: hibi",
     )
     assert "natural English" in paste
     assert "not grammar nitpicking" in paste
     assert "spoke my thoughts aloud" in paste
     assert "Test Article" in paste
+
+
+def test_build_paste_request_excludes_goal_context() -> None:
+    paste = ep.build_paste_request(
+        "In English: react. （まず声に出してから書く。）",
+        article_title="Test Article",
+        article_summary="要約本文。",
+    )
+    assert "My current project focus" not in paste
+    assert "Gemini / GPT-4o-mini" not in paste
+
+
+def test_generate_english_practice_paste_omits_internal_goal_text(
+    monkeypatch,
+) -> None:
+    class FakeBlock:
+        def __init__(self, text: str) -> None:
+            self.text = text
+
+    class FakeResponse:
+        def __init__(self, text: str) -> None:
+            self.content = [FakeBlock(text)]
+
+    class FakeMessages:
+        def create(self, **_kwargs):
+            return FakeResponse("{}")
+
+    class FakeClient:
+        messages = FakeMessages()
+
+    secret = "INTERNAL: China API vendor lock-in decision must not leak"
+    anchor = {"title": "Story", "summary": "・要点。"}
+    result = ep.generate_english_practice(
+        FakeClient(),
+        anchor,
+        goal_focus_text=secret,
+        project_slugs=("monogatari",),
+    )
+    assert secret not in result.paste_request
+    assert "My current project focus" not in result.paste_request
 
 
 def test_generate_english_practice_uses_claude_json(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- Removes `My current project focus … {goal_text}` from `build_paste_request` so decisions/strategy/status never print in the digest email.
- Keeps `goal_focus_text` in `generate_english_practice` for Claude `prompt_line` generation only (internal API path).

## Test plan

- [x] `pytest tests/test_english_practice.py` — paste omits goal block even when goal_focus_text is non-empty
- [x] `pytest tests/ --ignore=tests/idea_mining` (153 passed)
- [ ] Next daily digest: English paste section has no internal Monogatari decision text

Closes KAZ-209


Made with [Cursor](https://cursor.com)