### PR TITLE
docs: Cloud Agent development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,82 @@
+# AGENTS.md
+
+Cloud-agent operating notes for the Hibi (日々) monorepo. See `CLAUDE.md` for product context and coding rules.
+
+## Cursor Cloud specific instructions
+
+### Runtime versions
+
+- **Python 3.12** for the daily pipeline (`requirements.txt`) and manager tests.
+- **`uv`** for the FastAPI service under `service/` (`service/pyproject.toml`, `service/uv.lock`).
+- **Node ≥ 20.18.0** for the Astro site (`web/.nvmrc` pins `20.18.0`).
+
+### One-time VM prerequisites
+
+Ubuntu images may ship without `python3.12-venv`. If `python3 -m venv .venv` fails, install it once:
+
+```bash
+sudo apt-get install -y python3.12-venv
+```
+
+Install `uv` if it is not on `PATH` (the Astral installer may fail in some networks; `pip install uv` works):
+
+```bash
+pip install uv
+```
+
+### Dependency refresh (automatic)
+
+The VM update script recreates/refreshes:
+
+- Root venv: `pip install -r requirements.txt pytest`
+- Service env: `cd service && uv sync`
+- Web deps: `cd web && npm install`
+
+### Verify / lint / test
+
+| Area | Command | Notes |
+|------|---------|-------|
+| Pipeline unit tests | `source .venv/bin/activate && pytest tests/ -q` | **Scope `tests/` only** — bare `pytest` also collects `scripts/test_neon_connection.py`, which exits if `DATABASE_URL` is unset. |
+| Service unit tests | `cd service && uv run pytest -q` | Mocks DB via `service/tests/conftest.py`; no Neon needed. |
+| Web typecheck | `cd web && npm run check` | `@astrojs/check` |
+| Web build | `cd web && npm run build` | Static output in `web/dist/` |
+
+There is no repo-wide Python linter (ruff/mypy). Web linting is `npm run check`.
+
+`manager/tests/` has some failing runner tests on current `main` (6 failures observed during env setup); pipeline and service suites are the primary CI gates for product code.
+
+### Run locally (no secrets)
+
+**Web archive (recommended hello-world):**
+
+```bash
+cd web && npm run dev -- --host 0.0.0.0 --port 4321
+```
+
+Uses committed JSON in `web/src/content/editions/` — no database or API keys.
+
+**FastAPI click API:**
+
+```bash
+cd service
+export CLICK_SIGNING_SECRET=dev-secret-0123456789abcdef
+export DATABASE_URL=postgresql://test/test
+export PUBLIC_BASE_URL=http://localhost:8000
+export IP_SALT=dev-ip-salt-0123456789
+export APP_ENV=development
+uv run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+`/health` returns `{"status":"ok"}` even with a dummy `DATABASE_URL` (pool warnings are expected). `/docs` is available when `APP_ENV=development`.
+
+Use **tmux** for long-running dev servers in Cloud Agent VMs.
+
+### Full pipeline / E2E (secrets required)
+
+`daily_news.py` needs Neon (`DATABASE_URL`), Anthropic, YouTube, and Gmail OAuth vars from `.env.example`. Do not run against production Neon without explicit approval.
+
+### Gotchas
+
+- Root `.venv` and `service/.venv` are separate; activate the right one per task.
+- `pytest` is not listed in `requirements.txt` but is required for local/CI-style verification (installed by the update script).
+- `docker-compose.yml` is homelab/prod-oriented (GHCR image + Cloudflare tunnel), not a local dev stack.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud-specific instructions for setting up and running the Hibi monorepo locally.

## What's documented

- Runtime versions (Python 3.12, uv, Node ≥ 20.18.0)
- One-time VM prerequisites (`python3.12-venv`, `uv` install fallback)
- Test/lint/build commands per subsystem
- Local dev server startup for web archive and FastAPI API
- Gotchas (separate venvs, `pytest tests/` scope, no repo-wide Python linter)

## VM update script (proposed)

```
test -d .venv || python3 -m venv .venv
.venv/bin/pip install -q -r requirements.txt pytest
pip install -q uv
cd service && uv sync
cd web && npm install
```

## Verification performed

| Check | Result |
|-------|--------|
| `pytest tests/ -q` | 300 passed |
| `cd service && uv run pytest -q` | 41 passed |
| `cd web && npm run check` | 0 errors |
| `cd web && npm run build` | 42 pages built |
| Web dev server | http://localhost:4321 — archive + edition pages |
| API `/health` | `{"status":"ok","version":"0.1.0"}` |

<video src="/opt/cursor/artifacts/hibi-web-archive-demo.mp4" />
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6eeeaf52-5b48-4a09-94d9-a3aa108cde5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6eeeaf52-5b48-4a09-94d9-a3aa108cde5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

